### PR TITLE
Ctrl test fix

### DIFF
--- a/modP2p/test/org/aion/p2p/IMsgTest.java
+++ b/modP2p/test/org/aion/p2p/IMsgTest.java
@@ -9,7 +9,6 @@ public class IMsgTest {
 
     @Test
     public void testCTRL() {
-        
         /*
          * getValue 
          */
@@ -19,18 +18,11 @@ public class IMsgTest {
         }
 
         /*
-         * Out range
+         * Out of range
          */
         CTRL type = CTRL.getType(CTRL.MIN - 1);
-        assertNull(type);
+        assertEquals(CTRL.UNKNOWN, type);
         type = CTRL.getType(CTRL.MAX + 1);
-        assertNull(type);
-        
-        /*
-         * Unregistered
-         */
-        type = CTRL.getType(CTRL.MAX);
-        assertNull(type);
-        
+        assertEquals(CTRL.UNKNOWN, type);
     }
 }

--- a/modP2p/test/org/aion/p2p/IMsgTest.java
+++ b/modP2p/test/org/aion/p2p/IMsgTest.java
@@ -24,5 +24,11 @@ public class IMsgTest {
         assertEquals(CTRL.UNKNOWN, type);
         type = CTRL.getType(CTRL.MAX + 1);
         assertEquals(CTRL.UNKNOWN, type);
+
+        /*
+         * In range but unregistered
+         */
+        type = CTRL.getType(126);
+        assertEquals(CTRL.UNKNOWN, type);
     }
 }


### PR DESCRIPTION
the expected behaviour is to return UNKNOWN instead of null for out of range and unregistered values in ctrl enum