### PR TITLE
revise account unlock logic

### DIFF
--- a/modMcf/src/org/aion/mcf/account/AccountManager.java
+++ b/modMcf/src/org/aion/mcf/account/AccountManager.java
@@ -84,7 +84,12 @@ public class AccountManager {
 
     public boolean unlockAccount(Address _address, String _password, int _timeout) {
 
-        int timeout = _timeout <= 0 || _timeout > UNLOCK_MAX ? UNLOCK_DEFAULT : _timeout;
+        int timeout = UNLOCK_DEFAULT;
+        if (_timeout > UNLOCK_MAX) {
+            timeout = UNLOCK_MAX;
+        } else if (_timeout > 0) {
+            timeout = _timeout;
+        }
 
         ECKey key = Keystore.getKey(_address.toString(), _password);
 


### PR DESCRIPTION
change the account unlock logic. if user pass the unlock time more than 1 day. set to 86400, not the default setting - 60 sec