### PR TITLE
Synchronize LRUMap

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -109,7 +109,7 @@ public class AionPendingStateImpl
     // to filter out the transactions we have already processed
     // transactions could be sent by peers even if they were already included
     // into blocks
-    private final Map<ByteArrayWrapper, Object> receivedTxs = new LRUMap<>(100000);
+    private final Map<ByteArrayWrapper, Object> receivedTxs = Collections.synchronizedMap(new LRUMap<>(100000));
     private final Object dummyObject = new Object();
 
     private IRepositoryCache pendingState;

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -85,7 +85,7 @@ public final class SyncMgr {
     private ConcurrentHashMap<Integer, List<A0BlockHeader>> sentHeaders = new ConcurrentHashMap<>();
     private final BlockingQueue<AionBlock> importedBlocksQueue = new LinkedBlockingQueue<>();
 
-    private LRUMap<ByteArrayWrapper, Object> importedBlocksCache = new LRUMap<>(1024);
+    private Map<ByteArrayWrapper, Object> importedBlocksCache = Collections.synchronizedMap(new LRUMap<>(1024));
 
     /**
      * Threads


### PR DESCRIPTION
There are two more raw LRUMap in `TransactionStore.java` and `BlockPropagationHandler.java`. The original authors have synchronized all access to the map, so there is no need to synchronize again.

Resolves #65 