### PR TITLE
Adds logging parameter

### DIFF
--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -75,7 +75,7 @@ public class Aion {
 
 
         // If commit this out, the config setting will be ignore. all log module been set to "INFO" Level
-        AionLoggerFactory.init(cfg.getLog().getModules());
+        AionLoggerFactory.init(cfg.getLog().getModules(), cfg.getLog().getLogToFileEnabled());
         Logger LOG = AionLoggerFactory.getLogger(LogEnum.GEN.toString());
 
         System.out.println(                

--- a/modLogger/src/org/aion/log/AionLoggerFactory.java
+++ b/modLogger/src/org/aion/log/AionLoggerFactory.java
@@ -91,7 +91,7 @@ public class AionLoggerFactory {
         if (logFile) {
             // setup rolling policy
             TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<>();
-            policy.setFileNamePattern("aion.%d{yyyy-MM-dd-HH-mm}.gz");
+            policy.setFileNamePattern("aion.%d{yyyy-MM-dd-HH}.gz");
             policy.setContext(loggerContext);
             policy.setParent(rollingFileAppender);
             policy.start();

--- a/modLogger/src/org/aion/log/AionLoggerFactory.java
+++ b/modLogger/src/org/aion/log/AionLoggerFactory.java
@@ -91,7 +91,7 @@ public class AionLoggerFactory {
         if (logFile) {
             // setup rolling policy
             TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<>();
-            policy.setFileNamePattern("aion.%d{yyyy-MM-dd-HH-mm}.gzip");
+            policy.setFileNamePattern("aion.%d{yyyy-MM-dd-HH-mm}.gz");
             policy.setContext(loggerContext);
             policy.setParent(rollingFileAppender);
             policy.start();

--- a/modMcf/src/org/aion/mcf/config/CfgLog.java
+++ b/modMcf/src/org/aion/mcf/config/CfgLog.java
@@ -42,6 +42,7 @@ import javax.xml.stream.XMLStreamWriter;
 public class CfgLog {
 
     private Map<String, String> modules;
+    private boolean logFile = false;
 
     public CfgLog() {
         modules = new HashMap<>();
@@ -59,7 +60,14 @@ public class CfgLog {
             int eventType = sr.next();
             switch (eventType) {
             case XMLStreamReader.START_ELEMENT:
+
+                // add a special clause for file
                 String elementName = sr.getLocalName().toUpperCase();
+                if (elementName.equals("APPEND_FILE")) {
+                    logFile = Boolean.parseBoolean(Cfg.readValue(sr));
+                    break;
+                }
+
                 if (LogEnum.contains(elementName))
                     this.modules.put(elementName, Cfg.readValue(sr).toUpperCase());
                 break;
@@ -106,4 +114,7 @@ public class CfgLog {
         return this.modules;
     }
 
+    public boolean getLogToFileEnabled() {
+        return this.logFile;
+    }
 }


### PR DESCRIPTION
This pull request will:

* Add a ``RollingFileAppender`` that will log to a gzipped file on the hour.
* Add in changes to the configuration file to add a ``bool`` to turn feature on or off.

However, there is still much to be discussed, presently I'm using this as a stopgap solution to enabled logging on some nodes. Open questions are:

* Should we expose logback xml directly?
* If not, should users be able to configure output path, trigger frequency, compression etc.