### PR TITLE
Prune side chain blocks and correct block info

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -112,8 +112,9 @@ public final class Cli {
                     break;
                 case "-r":
                     if (args.length < 2) {
-                        System.out.println("Please provide the block number you want to revert to as an argument.");
-                        return 1;
+                        System.out.println("Starting database clean-up.");
+                        RecoveryUtils.pruneAndCorrect();
+                        System.out.println("Finished database clean-up.");
                     } else {
                         switch (revertTo(args[1])) {
                         case SUCCESS:
@@ -141,6 +142,7 @@ public final class Cli {
             System.out.println("");
         } catch (Throwable e) {
             System.out.println("");
+            e.printStackTrace();
             return 1;
         }
 
@@ -164,6 +166,7 @@ public final class Cli {
         System.out.println();
         System.out.println("  -i                           show information");
         System.out.println();
+        System.out.println("  -r                           remove blocks on side chains and correct block info");
         System.out.println("  -r [block_number]            revert db up to specific block number");
         System.out.println();
         System.out.println("  -v                           show version");

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -72,6 +72,7 @@ public class RecoveryUtils {
         IBlock bestBlock = store.getBestBlock();
         if (bestBlock == null) {
             System.out.println("Empty database. Nothing to do.");
+            return;
         }
 
         // revert to block number and flush changes

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -56,6 +56,32 @@ public class RecoveryUtils {
     }
 
     /**
+     * Used by the CLI call.
+     */
+    public static void pruneAndCorrect() {
+        // ensure mining is disabled
+        CfgAion cfg = CfgAion.inst();
+        cfg.dbFromXML();
+        cfg.getConsensus().setMining(false);
+
+        // get the current blockchain
+        AionBlockchainImpl blockchain = AionBlockchainImpl.inst();
+
+        IBlockStoreBase store = blockchain.getBlockStore();
+
+        IBlock bestBlock = store.getBestBlock();
+        if (bestBlock == null) {
+            System.out.println("Empty database. Nothing to do.");
+        }
+
+        // revert to block number and flush changes
+        store.pruneAndCorrect();
+        store.flush();
+
+        blockchain.getRepository().close();
+    }
+
+    /**
      * Used my internal world state recovery method.
      */
     public static Status revertTo(AionBlockchainImpl blockchain, long nbBlock) {

--- a/modMcf/src/org/aion/mcf/db/IBlockStoreBase.java
+++ b/modMcf/src/org/aion/mcf/db/IBlockStoreBase.java
@@ -63,6 +63,8 @@ public interface IBlockStoreBase<BLK extends IBlock<?, ?>, BH extends AbstractBl
 
     void revert(long previousLevel);
 
+    void pruneAndCorrect();
+
     void load();
 
     void close();


### PR DESCRIPTION
Command line functionality for walking through the database to:
1. remove blocks that are on side chains; and
2. update the block information and recompute the total difficulty.

This functionality is useful in case the total difficulty is incorrect due to database corruption.