### PR TITLE
Index database keys from int to long

### DIFF
--- a/modAionBase/src/org/aion/base/db/Flushable.java
+++ b/modAionBase/src/org/aion/base/db/Flushable.java
@@ -36,6 +36,4 @@ package org.aion.base.db;
 
 public interface Flushable {
     void flush();
-
-    void flushDangerously();
 }

--- a/modAionBase/src/org/aion/base/util/ByteUtil.java
+++ b/modAionBase/src/org/aion/base/util/ByteUtil.java
@@ -314,7 +314,7 @@ public class ByteUtil {
     /**
      * Cast hex encoded value from byte[] to int
      *
-     * Limited to Integer.MAX_VALUE: 2^32-1 (4 bytes)
+     * Limited to Integer.MAX_VALUE: 2^31-1 (4 bytes)
      *
      * @param b
      *            array contains the values
@@ -328,9 +328,9 @@ public class ByteUtil {
     }
 
     /**
-     * Cast hex encoded value from byte[] to int
+     * Cast hex encoded value from byte[] to long
      *
-     * Limited to Integer.MAX_VALUE: 2^32-1 (4 bytes)
+     * Limited to Long.MAX_VALUE: 2^63-1 (8 bytes)
      *
      * @param b
      *            array contains the values

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -94,6 +94,9 @@ public final class Cli {
                     cfg.toXML(null);
                     System.out.println("\nNew config generated");
                     break;
+                case "-d":
+                    RecoveryUtils.indexToLong();
+                    break;
                 case "-i":
                     cfg.fromXML();
                     System.out.println("\nInformation");

--- a/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
@@ -65,6 +65,7 @@ public class AionBlockStore extends AbstractPowBlockstore<AionBlock, A0BlockHead
     private void init(IByteArrayKeyValueDatabase index, IByteArrayKeyValueDatabase blocks) {
 
         indexDS = index;
+        RecoveryUtils.indexToLong(indexDS);
         this.index = new DataSourceLongArray<>(new ObjectDataSource<>(index, BLOCK_INFO_SERIALIZER));
         this.blocksDS = blocks;
 
@@ -499,7 +500,7 @@ public class AionBlockStore extends AbstractPowBlockstore<AionBlock, A0BlockHead
         level = 1;
         while (level <= initialLevel) {
             parentTotalDifficulty = correctTotalDifficulty(level, parentTotalDifficulty);
-            LOG.error("Updated total difficulty on level " + level + " to " + parentTotalDifficulty + ".");
+            LOG.info("Updated total difficulty on level " + level + " to " + parentTotalDifficulty + ".");
             level++;
         }
     }
@@ -509,7 +510,7 @@ public class AionBlockStore extends AbstractPowBlockstore<AionBlock, A0BlockHead
         long level = block.getNumber();
         byte[] blockHash = block.getHash();
 
-        LOG.error("Pruning side chains on level " + level + ".");
+        LOG.info("Pruning side chains on level " + level + ".");
 
         List<BlockInfo> levelBlocks = getBlockInfoForLevel(level);
         BlockInfo blockInfo = getBlockInfoForHash(levelBlocks, blockHash);

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -24,19 +24,122 @@
 
 package org.aion.zero.impl.db;
 
+import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.type.IBlock;
+import org.aion.base.util.Hex;
+import org.aion.db.impl.DatabaseFactory;
 import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
 import org.aion.mcf.db.IBlockStoreBase;
+import org.aion.mcf.ds.DataSourceArray;
+import org.aion.mcf.ds.DataSourceLongArray;
+import org.aion.mcf.ds.ObjectDataSource;
 import org.aion.zero.impl.AionBlockchainImpl;
 import org.aion.zero.impl.config.CfgAion;
+import org.slf4j.Logger;
 
+import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import static org.aion.zero.impl.db.AionBlockStore.BLOCK_INFO_SERIALIZER;
 
 public class RecoveryUtils {
 
+    private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.GEN.name());
+
     public enum Status {
         SUCCESS, FAILURE, ILLEGAL_ARGUMENT
+    }
+
+    /**
+     * Used by the CLI call.
+     */
+    public static Status indexToLong() {
+        // ensure mining is disabled
+        CfgAion cfg = CfgAion.inst();
+        cfg.dbFromXML();
+        cfg.getConsensus().setMining(false);
+
+        Map<String, String> cfgLog = new HashMap<>();
+        cfgLog.put("DB", "ERROR");
+
+        AionLoggerFactory.init(cfgLog);
+
+        Properties info = new Properties();
+        info.setProperty("db_name", "index");
+        info.setProperty("db_type", cfg.getDb().getVendor());
+        info.setProperty("db_path", new File(cfg.getBasePath(), cfg.getDb().getPath()).getAbsolutePath());
+        info.setProperty("enable_auto_commit", String.valueOf(cfg.getDb().isAutoCommitEnabled()));
+        info.setProperty("enable_db_cache", String.valueOf(cfg.getDb().isDbCacheEnabled()));
+        info.setProperty("enable_db_compression", String.valueOf(cfg.getDb().isDbCompressionEnabled()));
+        info.setProperty("enable_heap_cache", String.valueOf(cfg.getDb().isHeapCacheEnabled()));
+        info.setProperty("max_heap_cache_size", cfg.getDb().getMaxHeapCacheSize());
+        info.setProperty("enable_heap_cache_stats", String.valueOf(cfg.getDb().isHeapCacheStatsEnabled()));
+
+        IByteArrayKeyValueDatabase indexDatabase = DatabaseFactory.connect(info);
+
+        // open the database connection
+        indexDatabase.open();
+
+        // check object status
+        if (indexDatabase == null) {
+            System.out.println(
+                    "Database <" + info.getProperty("db_type") + "> connection could not be established for <" + info
+                            .getProperty("db_name") + ">.");
+            return Status.FAILURE;
+        }
+
+        // check persistence status
+        if (!indexDatabase.isCreatedOnDisk()) {
+            System.out.println("Database <" + info.getProperty("db_type") + "> cannot be saved to disk for <" + info
+                    .getProperty("db_name") + ">.");
+            return Status.FAILURE;
+        }
+
+        indexToLong(indexDatabase);
+
+        // ok if we managed to get down to the expected block
+        return Status.SUCCESS;
+    }
+
+    /**
+     * Used by internal recovery method.
+     */
+    public static void indexToLong(IByteArrayKeyValueDatabase indexDatabase) {
+        byte[] oldSizeKey = Hex.decode("FFFFFFFFFFFFFFFF");
+
+        if (indexDatabase.get(oldSizeKey).isPresent()) {
+            LOG.info("Database using old version of block indexing. Updating ...");
+
+            DataSourceArray<List<AionBlockStore.BlockInfo>> oldIndex = new DataSourceArray<>(
+                    new ObjectDataSource<>(indexDatabase, BLOCK_INFO_SERIALIZER));
+            DataSourceLongArray<List<AionBlockStore.BlockInfo>> newIndex = new DataSourceLongArray<>(
+                    new ObjectDataSource<>(indexDatabase, BLOCK_INFO_SERIALIZER));
+
+            int size = oldIndex.size();
+
+            // converting data storage to use long
+            for (int i = 0; i < size; i++) {
+                newIndex.set((long) i, oldIndex.get(i));
+            }
+            newIndex.flush();
+
+            for (int i = size - 1; i >= 0; i--) {
+                oldIndex.remove(i);
+            }
+            oldIndex.flush();
+
+            // deleting old size key
+            indexDatabase.delete(oldSizeKey);
+
+            if (!indexDatabase.isAutoCommitEnabled()) {
+                indexDatabase.commit();
+            }
+            LOG.info("Update complete.");
+        }
     }
 
     /**
@@ -49,7 +152,8 @@ public class RecoveryUtils {
         cfg.getConsensus().setMining(false);
 
         Map<String, String> cfgLog = new HashMap<>();
-        cfgLog.put("DB", "ERROR");
+        cfgLog.put("DB", "INFO");
+        cfgLog.put("GEN", "INFO");
 
         AionLoggerFactory.init(cfgLog);
 
@@ -74,7 +178,8 @@ public class RecoveryUtils {
         cfg.getConsensus().setMining(false);
 
         Map<String, String> cfgLog = new HashMap<>();
-        cfgLog.put("DB", "ERROR");
+        cfgLog.put("DB", "INFO");
+        cfgLog.put("GEN", "INFO");
 
         AionLoggerFactory.init(cfgLog);
 
@@ -97,7 +202,7 @@ public class RecoveryUtils {
     }
 
     /**
-     * Used my internal world state recovery method.
+     * Used by internal world state recovery method.
      */
     public static Status revertTo(AionBlockchainImpl blockchain, long nbBlock) {
         IBlockStoreBase store = blockchain.getBlockStore();

--- a/modMcf/src/org/aion/mcf/ds/DataSourceLongArray.java
+++ b/modMcf/src/org/aion/mcf/ds/DataSourceLongArray.java
@@ -27,20 +27,18 @@ import org.aion.base.db.Flushable;
 import org.aion.base.util.ByteUtil;
 import org.aion.base.util.Hex;
 
-import java.util.AbstractList;
-
 /**
- * DataSource Array.
+ * DataSource LongArray.
  *
  * @param <V>
  */
-public class DataSourceArray<V> extends AbstractList<V> implements Flushable {
+public class DataSourceLongArray<V> implements Flushable {
 
     private ObjectDataSource<V> src;
-    private static final byte[] sizeKey = Hex.decode("FFFFFFFFFFFFFFFF");
-    private int size = -1;
+    private static final byte[] sizeKey = ByteUtil.longToBytes(-2L);
+    private long size = -1;
 
-    public DataSourceArray(ObjectDataSource<V> src) {
+    public DataSourceLongArray(ObjectDataSource<V> src) {
         this.src = src;
     }
 
@@ -49,52 +47,46 @@ public class DataSourceArray<V> extends AbstractList<V> implements Flushable {
         src.flush();
     }
 
-    @Override
-    public V set(int idx, V value) {
+    public V set(long idx, V value) {
         if (idx >= size()) {
             setSize(idx + 1);
         }
-        src.put(ByteUtil.intToBytes(idx), value);
+        src.put(ByteUtil.longToBytes(idx), value);
         return value;
     }
 
-    @Override
-    public void add(int index, V element) {
+    public void add(long index, V element) {
         set(index, element);
     }
 
-    @Override
-    public V remove(int index) {
-        src.delete(ByteUtil.intToBytes(index));
+    public void remove(long index) {
+        src.delete(ByteUtil.longToBytes(index));
         if (index < size()) {
             setSize(index);
         }
-        // TODO: remove returned type
-        return null;
     }
 
-    @Override
-    public V get(int idx) {
+    public V get(long idx) {
         if (idx < 0 || idx >= size()) {
             throw new IndexOutOfBoundsException(idx + " > " + size);
         }
-        return src.get(ByteUtil.intToBytes(idx));
+        return src.get(ByteUtil.longToBytes(idx));
     }
 
-    @Override
-    public int size() {
+    public long size() {
 
         if (size < 0) {
             // Read the value from the database directly and
             // convert to the size, and if it doesn't exist, 0.
-            size = src.getSrc().get(sizeKey).map(ByteUtil::byteArrayToInt).orElse(0);
+            size = src.getSrc().get(sizeKey).map(ByteUtil::byteArrayToLong).orElse(0L);
         }
 
         return size;
     }
 
-    private synchronized void setSize(int newSize) {
+    private synchronized void setSize(long newSize) {
         size = newSize;
-        src.getSrc().put(sizeKey, ByteUtil.intToBytes(newSize));
+        src.getSrc().put(sizeKey, ByteUtil.longToBytes(newSize));
     }
+
 }

--- a/modMcf/src/org/aion/mcf/ds/ObjectDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/ObjectDataSource.java
@@ -99,10 +99,4 @@ public class ObjectDataSource<V> implements Flushable {
     public void close() {
         src.close();
     }
-
-    @Override
-    public void flushDangerously() {
-        // TODO Auto-generated method stub
-
-    }
 }

--- a/modMcf/src/org/aion/mcf/trie/SecureTrie.java
+++ b/modMcf/src/org/aion/mcf/trie/SecureTrie.java
@@ -34,10 +34,10 @@
  ******************************************************************************/
 package org.aion.mcf.trie;
 
+import org.aion.base.db.IByteArrayKeyValueStore;
+
 import static org.aion.base.util.ByteUtil.EMPTY_BYTE_ARRAY;
 import static org.aion.crypto.HashUtil.h256;
-
-import org.aion.base.db.IByteArrayKeyValueStore;
 
 public class SecureTrie extends TrieImpl implements Trie {
 
@@ -62,13 +62,5 @@ public class SecureTrie extends TrieImpl implements Trie {
     @Override
     public void delete(byte[] key) {
         this.update(key, EMPTY_BYTE_ARRAY);
-    }
-
-    @Override
-    public SecureTrie clone() {
-        this.getCache();
-        this.getRoot();
-
-        return null;
     }
 }


### PR DESCRIPTION
* replaced `DataSourceArray.java` with `DataSourceLongArray.java` to avoid the type casting from long to int and back (which may cause problems in the future)
* added functionality for automatic conversion when using a database from an old kernel version
* minor cleanup: removed unused flushDangerously method and clone method