### PR TITLE
Database clean-up

### DIFF
--- a/modAion/src/org/aion/zero/db/AionRepositoryCache.java
+++ b/modAion/src/org/aion/zero/db/AionRepositoryCache.java
@@ -122,22 +122,33 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
 
     @Override
     public boolean isClosed() {
-        throw new RuntimeException("Not supported");
+        // delegate to the tracked repository
+        return repository.isClosed();
     }
 
     @Override
     public void close() {
-        throw new RuntimeException("Not supported");
+        throw new UnsupportedOperationException(
+                "The tracking cache cannot be closed. \'Close\' should be called on the tracked repository.");
+    }
+
+    @Override
+    public void compact() {
+        throw new UnsupportedOperationException(
+                "The tracking cache cannot be compacted. \'Compact\' should be called on the tracked repository.");
     }
 
     @Override
     public byte[] getRoot() {
-        throw new RuntimeException("Not supported");
+        throw new UnsupportedOperationException(
+                "The tracking cache cannot return the root. \'Get root\' should be called on the tracked repository.");
+
     }
 
     @Override
     public void syncToRoot(byte[] root) {
-        throw new RuntimeException("Not supported");
+        throw new UnsupportedOperationException(
+                "The tracking cache cannot sync to root. \'Sync to root\' should be called on the tracked repository.");
     }
 
     @Override

--- a/modAionBase/src/org/aion/base/db/IDatabase.java
+++ b/modAionBase/src/org/aion/base/db/IDatabase.java
@@ -186,4 +186,5 @@ public interface IDatabase {
      */
     long approximateSize();
 
+    void compact();
 }

--- a/modAionBase/src/org/aion/base/db/IDatabase.java
+++ b/modAionBase/src/org/aion/base/db/IDatabase.java
@@ -97,6 +97,11 @@ public interface IDatabase {
      */
     boolean commit();
 
+    /**
+     * Reduce the size of the database when possible.
+     */
+    void compact();
+
     // Get information about the database state
     // ------------------------------------------------------------------------
 
@@ -185,6 +190,4 @@ public interface IDatabase {
      *             if the data store is closed
      */
     long approximateSize();
-
-    void compact();
 }

--- a/modAionBase/src/org/aion/base/db/IRepository.java
+++ b/modAionBase/src/org/aion/base/db/IRepository.java
@@ -61,9 +61,9 @@ public interface IRepository<AS, DW, BSB> extends IRepositoryQuery<AS, DW> {
      * Performs batch updates on the data.
      *
      * @param accountStates
-     *            cached account states
+     *         cached account states
      * @param contractDetails
-     *            cached contract details
+     *         cached contract details
      */
     void updateBatch(Map<Address, AS> accountStates, Map<Address, IContractDetails<DW>> contractDetails);
 
@@ -81,10 +81,14 @@ public interface IRepository<AS, DW, BSB> extends IRepositoryQuery<AS, DW> {
     boolean isClosed();
 
     /**
-     * Closes the connection to the database. TODO: what semantics do we use for
-     * tracker repositories?
+     * Closes the connection to the database.
      */
     void close();
+
+    /**
+     * Reduce the size of the database when possible.
+     */
+    void compact();
 
     // navigate through snapshots
     // --------------------------------------------------------------------------------------
@@ -93,7 +97,7 @@ public interface IRepository<AS, DW, BSB> extends IRepositoryQuery<AS, DW> {
      * Used to check for corruption in the database.
      *
      * @param root
-     *            a world state trie root
+     *         a world state trie root
      * @return {@code true} if the root is valid, {@code false} otherwise
      */
     boolean isValidRoot(byte[] root);
@@ -104,7 +108,7 @@ public interface IRepository<AS, DW, BSB> extends IRepositoryQuery<AS, DW> {
      * Return to one of the previous snapshots by moving the root.
      *
      * @param root
-     *            - new root
+     *         - new root
      */
     void syncToRoot(byte[] root);
 

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -512,41 +512,41 @@ public class AionRepositoryImpl extends AbstractRepository<AionBlock, A0BlockHea
             try {
                 if (detailsDS != null) {
                     detailsDS.close();
-                    LOGGEN.info("details source closed.");
+                    LOGGEN.info("Details data source closed.");
                     detailsDS = null;
                 }
             } catch (Exception e) {
-                LOGGEN.error("details source close exception", e);
+                LOGGEN.error("Exception occurred while closing the details data source.", e);
             }
 
             try {
                 if (stateDatabase != null) {
                     stateDatabase.close();
-                    LOGGEN.info("state DB closed.");
+                    LOGGEN.info("State database closed.");
                     stateDatabase = null;
                 }
             } catch (Exception e) {
-                LOGGEN.error("state DB close exception", e);
+                LOGGEN.error("Exception occurred while closing the state database.", e);
             }
 
             try {
                 if (transactionDatabase != null) {
                     transactionDatabase.close();
-                    LOGGEN.info("transaction DB closed.");
+                    LOGGEN.info("Transaction database closed.");
                     transactionDatabase = null;
                 }
             } catch (Exception e) {
-                LOGGEN.error("transaction DB close exception", e);
+                LOGGEN.error("Exception occurred while closing the transaction database.", e);
             }
 
             try {
                 if (blockStore != null) {
                     blockStore.close();
-                    LOGGEN.info("block store closed.");
+                    LOGGEN.info("Block store closed.");
                     blockStore = null;
                 }
             } catch (Exception e) {
-                LOGGEN.error("block store close exception", e);
+                LOGGEN.error("Exception occurred while closing the block store.", e);
             }
         } finally {
             rwLock.writeLock().unlock();

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -586,4 +586,14 @@ public class AionRepositoryImpl extends AbstractRepository<AionBlock, A0BlockHea
         return "AionRepositoryImpl{ identityHashCode=" + System.identityHashCode(this) + ", " + //
                 "databaseGroupSize=" + (databaseGroup == null ? 0 : databaseGroup.size()) + '}';
     }
+
+    public void compact() {
+        if (databaseGroup != null) {
+            for (IByteArrayKeyValueDatabase db : databaseGroup) {
+                db.compact();
+            }
+        } else {
+            LOG.warn("databaseGroup is null");
+        }
+    }
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -510,13 +510,13 @@ public class AionRepositoryImpl extends AbstractRepository<AionBlock, A0BlockHea
         try {
 
             try {
-                if (detailsDatabase != null) {
-                    detailsDatabase.close();
-                    LOGGEN.info("details DB closed.");
-                    detailsDatabase = null;
+                if (detailsDS != null) {
+                    detailsDS.close();
+                    LOGGEN.info("details source closed.");
+                    detailsDS = null;
                 }
             } catch (Exception e) {
-                LOGGEN.error("details DB close exception", e);
+                LOGGEN.error("details source close exception", e);
             }
 
             try {
@@ -542,11 +542,11 @@ public class AionRepositoryImpl extends AbstractRepository<AionBlock, A0BlockHea
             try {
                 if (blockStore != null) {
                     blockStore.close();
-                    LOGGEN.info("block DB closed.");
+                    LOGGEN.info("block store closed.");
                     blockStore = null;
                 }
             } catch (Exception e) {
-                LOGGEN.error("block DB close exception", e);
+                LOGGEN.error("block store close exception", e);
             }
         } finally {
             rwLock.writeLock().unlock();
@@ -587,13 +587,14 @@ public class AionRepositoryImpl extends AbstractRepository<AionBlock, A0BlockHea
                 "databaseGroupSize=" + (databaseGroup == null ? 0 : databaseGroup.size()) + '}';
     }
 
+    @Override
     public void compact() {
         if (databaseGroup != null) {
             for (IByteArrayKeyValueDatabase db : databaseGroup) {
                 db.compact();
             }
         } else {
-            LOG.warn("databaseGroup is null");
+            LOG.error("Database group is null.");
         }
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -93,6 +93,7 @@ public class RecoveryUtils {
         store.pruneAndCorrect();
         store.flush();
 
+        ((AionRepositoryImpl) blockchain.getRepository()).compact();
         blockchain.getRepository().close();
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -83,6 +83,7 @@ public class RecoveryUtils {
 
         IBlockStoreBase store = blockchain.getBlockStore();
 
+
         IBlock bestBlock = store.getBestBlock();
         if (bestBlock == null) {
             System.out.println("Empty database. Nothing to do.");
@@ -93,7 +94,9 @@ public class RecoveryUtils {
         store.pruneAndCorrect();
         store.flush();
 
-        ((AionRepositoryImpl) blockchain.getRepository()).compact();
+        // compact database after the changes were applied
+        blockchain.getRepository().compact();
+
         blockchain.getRepository().close();
     }
 

--- a/modDbImpl/src/org/aion/db/impl/AbstractDB.java
+++ b/modDbImpl/src/org/aion/db/impl/AbstractDB.java
@@ -97,6 +97,11 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
         throw new UnsupportedOperationException("Only automatic commits are supported by " + this.toString());
     }
 
+    @Override
+    public void compact() {
+        LOG.warn("Compact not supported by " + this.toString() + ".");
+    }
+
     /**
      * @inheritDoc
      */
@@ -196,8 +201,38 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
      */
     public abstract boolean commitCache(Map<ByteArrayWrapper, byte[]> cache);
 
+    // IKeyValueStore functionality ------------------------------------------------------------------------------------
+
+    /**
+     * @inheritDoc
+     */
     @Override
-    public void compact() {
-        LOG.info("Compact not supported by " + this.toString() + ".");
+    public Optional<byte[]> get(byte[] k) {
+        check(k);
+
+        // acquire read lock
+        lock.readLock().lock();
+
+        byte[] v;
+
+        try {
+            check();
+
+            v = getInternal(k);
+        } finally {
+            // releasing read lock
+            lock.readLock().unlock();
+        }
+
+        return Optional.ofNullable(v);
     }
+
+    /**
+     * Database specific get functionality, without locking required. Locking is applied in {@link #get(byte[])}.
+     *
+     * @param k
+     *         the key for which the method must return the associated value
+     * @return the value stored in the database for the give key.
+     */
+    protected abstract byte[] getInternal(byte[] k);
 }

--- a/modDbImpl/src/org/aion/db/impl/AbstractDB.java
+++ b/modDbImpl/src/org/aion/db/impl/AbstractDB.java
@@ -196,4 +196,8 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
      */
     public abstract boolean commitCache(Map<ByteArrayWrapper, byte[]> cache);
 
+    @Override
+    public void compact() {
+        LOG.info("Compact not supported by " + this.toString() + ".");
+    }
 }

--- a/modDbImpl/src/org/aion/db/impl/AbstractDatabaseWithCache.java
+++ b/modDbImpl/src/org/aion/db/impl/AbstractDatabaseWithCache.java
@@ -614,4 +614,8 @@ public abstract class AbstractDatabaseWithCache implements IByteArrayKeyValueDat
         // the dirty entries now match the storage
         dirtyEntries.clear();
     }
+
+    public void compact(){
+        database.compact();
+    }
 }

--- a/modDbImpl/src/org/aion/db/impl/AbstractDatabaseWithCache.java
+++ b/modDbImpl/src/org/aion/db/impl/AbstractDatabaseWithCache.java
@@ -233,6 +233,8 @@ public abstract class AbstractDatabaseWithCache implements IByteArrayKeyValueDat
         // acquire write lock
         lock.writeLock().lock();
 
+        LOG.info("Closing database " + this.toString());
+
         try {
             // close database
             database.close();
@@ -291,6 +293,22 @@ public abstract class AbstractDatabaseWithCache implements IByteArrayKeyValueDat
         }
 
         return success;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void compact() {
+        // acquire write lock
+        lock.writeLock().lock();
+
+        try {
+            database.compact();
+        } finally {
+            // releasing write lock
+            lock.writeLock().unlock();
+        }
     }
 
     /**
@@ -387,7 +405,8 @@ public abstract class AbstractDatabaseWithCache implements IByteArrayKeyValueDat
     }
 
     private String propertiesInfo() {
-        return "<autocommit=" + (enableAutoCommit ? "ON" : "OFF") + //
+        return "<name=" + getName().get() + //
+                ",autocommit=" + (enableAutoCommit ? "ON" : "OFF") + //
                 ",size" + (maxSize == 0 ? "=UNBOUND" : "<" + maxSize) + //
                 ",stats=" + (statsEnabled ? "ON" : "OFF") + ">";
     }
@@ -613,9 +632,5 @@ public abstract class AbstractDatabaseWithCache implements IByteArrayKeyValueDat
 
         // the dirty entries now match the storage
         dirtyEntries.clear();
-    }
-
-    public void compact(){
-        database.compact();
     }
 }

--- a/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
+++ b/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
@@ -191,6 +191,8 @@ public class H2MVMap extends AbstractDB {
             return;
         }
 
+        LOG.info("Closing database " + this.toString());
+
         try {
             // attempt to close the database
             store.close();

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -151,6 +151,8 @@ public class LevelDB extends AbstractDB {
             return;
         }
 
+        LOG.info("Closing database " + this.toString());
+
         try {
             // attempt to close the database
             db.close();

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -468,4 +468,18 @@ public class LevelDB extends AbstractDB {
         return success;
 
     }
+
+    @Override
+    public void compact() {
+        // acquire read lock
+        lock.writeLock().lock();
+
+        LOG.error("Compacting <" + this.name + ">.");
+        try {
+            db.compactRange(new byte[] { (byte) 0x00 }, new byte[] { (byte) 0xff });
+        } finally {
+            // release write lock
+            lock.writeLock().unlock();
+        }
+    }
 }

--- a/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
+++ b/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
@@ -54,7 +54,11 @@ public class MockDB extends AbstractDB {
         lock.writeLock().lock();
 
         // release resources if needed
-        if (kv != null) {kv.clear();}
+        if (kv != null) {
+            LOG.info("Closing database " + this.toString());
+
+            kv.clear();
+        }
 
         // set map to null
         kv = null;

--- a/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
+++ b/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
@@ -164,24 +164,8 @@ public class MockDB extends AbstractDB {
      * @inheritDoc
      */
     @Override
-    public Optional<byte[]> get(byte[] k) {
-        check(k);
-
-        // acquire read lock
-        lock.readLock().lock();
-
-        byte[] v;
-
-        try {
-            check();
-
-            v = kv.get(ByteArrayWrapper.wrap(k));
-        } finally {
-            // releasing read lock
-            lock.readLock().unlock();
-        }
-
-        return Optional.ofNullable(v);
+    public byte[] getInternal(byte[] k) {
+        return kv.get(ByteArrayWrapper.wrap(k));
     }
 
     /**

--- a/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
@@ -35,8 +35,6 @@
 package org.aion.db.impl;
 
 import org.aion.base.db.IByteArrayKeyValueDatabase;
-import org.aion.db.impl.DBVendor;
-import org.aion.db.impl.DatabaseFactory;
 import org.aion.db.impl.mockdb.MockDB;
 import org.aion.db.impl.mockdb.MockDBDriver;
 import org.junit.Test;
@@ -58,7 +56,7 @@ public class DatabaseFactoryTest {
     @Test
     public void testDriverReturnDatabase() {
         Properties props = new Properties();
-        props.setProperty("db_name", dbName);
+        props.setProperty("db_name", dbName + DatabaseTestUtils.getNext());
         props.setProperty("db_path", dbPath);
 
         // MOCKDB
@@ -89,7 +87,7 @@ public class DatabaseFactoryTest {
     @Test
     public void testDriverRandomClassReturnNull() {
         Properties props = new Properties();
-        props.setProperty("db_name", dbName);
+        props.setProperty("db_name", dbName + DatabaseTestUtils.getNext());
         props.setProperty("db_path", dbPath);
 
         // random class that is not an IDriver
@@ -102,7 +100,7 @@ public class DatabaseFactoryTest {
     @Test
     public void testDriverRandomStringReturnNull() {
         Properties props = new Properties();
-        props.setProperty("db_name", dbName);
+        props.setProperty("db_name", dbName + DatabaseTestUtils.getNext());
         props.setProperty("db_path", dbPath);
 
         // random string

--- a/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
@@ -90,65 +90,71 @@ public class DriverBaseTest {
                 // H2MVMap wo. db cache wo. compression
                 { "H2MVMap",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false } },
                 // H2MVMap w. db cache wo. compression
                 { "H2MVMap+dbCache",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, true, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, false } },
                 // H2MVMap wo. db cache w. compression
                 { "H2MVMap+compression",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, true } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, true } },
                 // H2MVMap w. db cache w. compression
                 { "H2MVMap+dbCache+compression",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, true, true } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, true } },
                 // LevelDB wo. db cache wo. compression
                 { "LevelDB",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false } },
                 // LevelDB w. db cache wo. compression
                 { "LevelDB+dbCache",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, true, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, false } },
                 // LevelDB wo. db cache w. compression
                 { "LevelDB+compression",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, true } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, true } },
                 // LevelDB w. db cache w. compression
                 { "LevelDB+dbCache+compression",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName, dbPath, true, true } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, true } },
                 // MockDB
                 { "MockDB", MockDB.class.getDeclaredConstructor(String.class), new Object[] { dbName } },
                 // H2MVMapWithCache w. autocommit
                 { "H2MVMapWithCache+autocommit",
                         H2MVMapWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, false, true, unboundHeapCache, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, true,
+                                unboundHeapCache, false } },
                 // H2MVMapWithCache wo. autocommit
                 { "H2MVMapWithCache",
                         H2MVMapWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, false, false, unboundHeapCache, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, false,
+                                unboundHeapCache, false } },
                 // LevelDBWithCache w. autocommit
                 { "LevelDBWithCache+autocommit",
                         LevelDBWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, false, true, unboundHeapCache, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, true,
+                                unboundHeapCache, false } },
                 // LevelDBWithCache wo. autocommit
                 { "LevelDBWithCache",
                         LevelDBWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName, dbPath, false, false, false, unboundHeapCache, false } },
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, false,
+                                unboundHeapCache, false } },
                 // MockDBWithCache w. autocommit
                 { "MockDBWithCache+autocommit",
                         MockDBWithCache.class.getDeclaredConstructor(String.class, boolean.class, String.class,
-                                boolean.class), new Object[] { dbName, true, unboundHeapCache, false } },
+                                boolean.class),
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), true, unboundHeapCache, false } },
                 // MockDBWithCache wo. autocommit
                 { "MockDBWithCache",
                         MockDBWithCache.class.getDeclaredConstructor(String.class, boolean.class, String.class,
-                                boolean.class), new Object[] { dbName, false, unboundHeapCache, false } } });
+                                boolean.class),
+                        new Object[] { dbName + DatabaseTestUtils.getNext(), false, unboundHeapCache, false } } });
     }
 
     private IByteArrayKeyValueDatabase db;

--- a/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
@@ -79,7 +79,7 @@ import static org.junit.Assert.assertTrue;
 public class DriverBaseTest {
 
     private static final File testDir = new File(System.getProperty("user.dir"), "tmp");
-    private static final String dbName = "TestDB";
+    private static final String dbNamePrefix = "TestDB";
     private static final String dbPath = testDir.getAbsolutePath();
     private static final String unboundHeapCache = "0";
     //    public static String boundHeapCache = "256";
@@ -90,77 +90,79 @@ public class DriverBaseTest {
                 // H2MVMap wo. db cache wo. compression
                 { "H2MVMap",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, false } },
                 // H2MVMap w. db cache wo. compression
                 { "H2MVMap+dbCache",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, false } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, true, false } },
                 // H2MVMap wo. db cache w. compression
                 { "H2MVMap+compression",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, true } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, true } },
                 // H2MVMap w. db cache w. compression
                 { "H2MVMap+dbCache+compression",
                         H2MVMap.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, true } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, true, true } },
                 // LevelDB wo. db cache wo. compression
                 { "LevelDB",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, false } },
                 // LevelDB w. db cache wo. compression
                 { "LevelDB+dbCache",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, false } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, true, false } },
                 // LevelDB wo. db cache w. compression
                 { "LevelDB+compression",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, true } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, true } },
                 // LevelDB w. db cache w. compression
                 { "LevelDB+dbCache+compression",
                         LevelDB.class.getDeclaredConstructor(String.class, String.class, boolean.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, true, true } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, true, true } },
                 // MockDB
-                { "MockDB", MockDB.class.getDeclaredConstructor(String.class), new Object[] { dbName } },
+                { "MockDB", MockDB.class.getDeclaredConstructor(String.class), new Object[] { dbNamePrefix } },
                 // H2MVMapWithCache w. autocommit
                 { "H2MVMapWithCache+autocommit",
                         H2MVMapWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, true,
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, false, true,
                                 unboundHeapCache, false } },
                 // H2MVMapWithCache wo. autocommit
                 { "H2MVMapWithCache",
                         H2MVMapWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, false,
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, false, false,
                                 unboundHeapCache, false } },
                 // LevelDBWithCache w. autocommit
                 { "LevelDBWithCache+autocommit",
                         LevelDBWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, true,
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, false, true,
                                 unboundHeapCache, false } },
                 // LevelDBWithCache wo. autocommit
                 { "LevelDBWithCache",
                         LevelDBWithCache.class.getDeclaredConstructor(String.class, String.class, boolean.class,
                                 boolean.class, boolean.class, String.class, boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), dbPath, false, false, false,
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), dbPath, false, false, false,
                                 unboundHeapCache, false } },
                 // MockDBWithCache w. autocommit
                 { "MockDBWithCache+autocommit",
                         MockDBWithCache.class.getDeclaredConstructor(String.class, boolean.class, String.class,
                                 boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), true, unboundHeapCache, false } },
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), true, unboundHeapCache, false } },
                 // MockDBWithCache wo. autocommit
                 { "MockDBWithCache",
                         MockDBWithCache.class.getDeclaredConstructor(String.class, boolean.class, String.class,
                                 boolean.class),
-                        new Object[] { dbName + DatabaseTestUtils.getNext(), false, unboundHeapCache, false } } });
+                        new Object[] { dbNamePrefix + DatabaseTestUtils.getNext(), false, unboundHeapCache,
+                                false } } });
     }
 
     private IByteArrayKeyValueDatabase db;
 
     private final Constructor<IByteArrayKeyValueDatabase> constructor;
     private final Object[] args;
+    private final String dbName;
 
     private static final byte[] k1 = "key1".getBytes();
     private static final byte[] v1 = "value1".getBytes();
@@ -185,6 +187,7 @@ public class DriverBaseTest {
 
         this.constructor = constructor;
         this.args = args;
+        this.dbName = (String) args[0];
         this.db = constructor.newInstance(args);
     }
 
@@ -208,7 +211,7 @@ public class DriverBaseTest {
 
         if (db.isPersistent()) {
             assertThat(db.isCreatedOnDisk()).isFalse();
-            assertThat(db.getPath().get()).isEqualTo(dbPath + "/" + dbName);
+            assertThat(db.getPath().get()).isEqualTo(new File(dbPath, dbName).getAbsolutePath());
         }
 
         assertThat(db.isLocked()).isFalse();
@@ -222,7 +225,7 @@ public class DriverBaseTest {
 
         if (db.isPersistent()) {
             assertThat(db.isCreatedOnDisk()).isTrue();
-            assertThat(db.getPath().get()).isEqualTo(dbPath + "/" + dbName);
+            assertThat(db.getPath().get()).isEqualTo(new File(dbPath, dbName).getAbsolutePath());
         }
 
         assertThat(db.isLocked()).isFalse();
@@ -237,7 +240,7 @@ public class DriverBaseTest {
 
         if (db.isPersistent()) {
             assertThat(db.isCreatedOnDisk()).isTrue();
-            assertThat(db.getPath().get()).isEqualTo(dbPath + "/" + dbName);
+            assertThat(db.getPath().get()).isEqualTo(new File(dbPath, dbName).getAbsolutePath());
         }
 
         assertThat(db.isLocked()).isFalse();
@@ -253,7 +256,7 @@ public class DriverBaseTest {
             assertThat(db.isCreatedOnDisk()).isTrue();
             assertThat(FileUtils.deleteRecursively(new File(db.getPath().get()))).isTrue();
             assertThat(db.isCreatedOnDisk()).isFalse();
-            assertThat(db.getPath().get()).isEqualTo(dbPath + "/" + dbName);
+            assertThat(db.getPath().get()).isEqualTo(new File(dbPath, dbName).getAbsolutePath());
         }
 
         assertThat(db.isLocked()).isFalse();


### PR DESCRIPTION
* critical bug fixed: storage database was not closed on repository closing call
* fixed tests that were failing due to overlapping storage folders
* added compact() functionality to databases and repository
* applying compact after recovery with -r
* some code and messages clean-up