### PR TITLE
Bugfix for AionBlockchainImpl.getTransactionInfo(hash) + java-api: added filter to batch request

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -273,7 +273,11 @@ public class AionBlockchainImpl implements IAionBlockchain {
             // pick up the receipt from the block on the main chain
             for (AionTxInfo info : infos) {
                 AionBlock block = getBlockStore().getBlockByHash(info.getBlockHash());
+                if (block == null) continue;
+
                 AionBlock mainBlock = getBlockStore().getChainBlockByNumber(block.getNumber());
+                if (mainBlock == null) continue;
+
                 if (FastByteComparisons.equal(info.getBlockHash(), mainBlock.getHash())) {
                     txInfo = info;
                     break;

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -1237,9 +1237,15 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
             try {
                 req = Message.req_getBlockDetailsByNumber.parseFrom(data);
-                List<Long> blkNum = req.getBlkNumbersList().parallelStream()
-                        .collect(Collectors.toSet()).parallelStream()
-                        .sorted().collect(Collectors.toList());
+                long latestBlkNum = this.getBestBlock().getNumber();
+
+                List<Long> blkNum = req.getBlkNumbersList()
+                        .parallelStream()
+                        .filter(n -> n <= latestBlkNum)
+                        .collect(Collectors.toSet())
+                            .parallelStream()
+                            .sorted()
+                            .collect(Collectors.toList());
 
                 if (blkNum.size() > 1000) {
                     blkNum = blkNum.subList(0, 1000);


### PR DESCRIPTION
1. fix minor bug in java api + 
2. workaround for transactionStore.get(txHash) referencing blockhashes which have been removed from blocks DB