### PR TITLE
Safe pub bestblock

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -105,6 +105,18 @@ public class AionBlockchainImpl implements IAionBlockchain {
     private TransactionStore<AionTransaction, AionTxReceipt, org.aion.zero.impl.types.AionTxInfo> transactionStore;
     private AionBlock bestBlock;
 
+    /**
+     * This version of the bestBlock is only used for external reference
+     * (ex. through {@link #getBestBlock()}), this is done because {@link #bestBlock}
+     * can slip into temporarily inconsistent states while forking, and we
+     * don't want to expose that information to external actors.
+     *
+     * However we would still like to publish a bestBlock without locking,
+     * therefore we introduce a volatile block that is only published when
+     * all forking/appending behaviour is completed.
+     */
+    private volatile AionBlock pubBestBlock;
+
     private BigInteger totalDifficulty = ZERO;
     private ChainStatistics chainStats;
 
@@ -242,14 +254,40 @@ public class AionBlockchainImpl implements IAionBlockchain {
         return (AionBlockStore) repository.getBlockStore();
     }
 
+    /**
+     * Referenced only by external
+     *
+     * Note: If you are making changes to this method and want to use
+     * it to track internal state, use {@link #bestBlock} instead
+     *
+     * @return {@code bestAionBlock}
+     * @see #pubBestBlock
+     */
     @Override
     public byte[] getBestBlockHash() {
-        return getBestBlock().getHash();
+        return this.pubBestBlock.getHash();
     }
 
+    /**
+     * Referenced only by external
+     *
+     * Note: If you are making changes to this method and want to use
+     * it to track internal state, opt for {@link #getSizeInternal()}
+     * instead.
+     *
+     * @return {@code positive long} representing the current size
+     * @see #pubBestBlock
+     */
     @Override
     public long getSize() {
-        return bestBlock.getNumber() + 1;
+        return this.pubBestBlock.getNumber() + 1;
+    }
+
+    /**
+     * @see #getSize()
+     */
+    private long getSizeInternal() {
+        return this.bestBlock.getNumber() + 1;
     }
 
     @Override
@@ -365,7 +403,14 @@ public class AionBlockchainImpl implements IAionBlockchain {
         stateStack.pop();
     }
 
-    private synchronized AionBlockSummary tryConnectAndFork(final AionBlock block) {
+    /**
+     * Not thread safe, currently only run in {@link #tryToConnect(AionBlock)},
+     * assumes that the environment is already locked
+     *
+     * @param block
+     * @return
+     */
+    private AionBlockSummary tryConnectAndFork(final AionBlock block) {
         State savedState = pushState(block.getParentHash());
         this.fork = true;
 
@@ -463,7 +508,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
                 this.evtMgr.newEvent(evtOnBlock);
 
                 IEvent evtTrace = new EventBlock(EventBlock.CALLBACK.ONTRACE0);
-                String str = String.format("Block chain size: [ %d ]", this.getSize());
+                String str = String.format("Block chain size: [ %d ]", this.getSizeInternal());
                 evtTrace.setFuncArgs(Collections.singletonList(str));
                 this.evtMgr.newEvent(evtTrace);
 
@@ -939,14 +984,6 @@ public class AionBlockchainImpl implements IAionBlockchain {
         return getParent(block.getHeader()) != null;
     }
 
-    // @Override
-    // public List<Chain> getAltChains() {
-    // return altChains;
-    // }
-    // @Override
-    // public List<NcBlock> getGarbage() {
-    // return garbage;
-    // }
     public TransactionStore<AionTransaction, AionTxReceipt, AionTxInfo> getTransactionStore() {
         return transactionStore;
     }
@@ -954,14 +991,13 @@ public class AionBlockchainImpl implements IAionBlockchain {
     @Override
     public synchronized void setBestBlock(AionBlock block) {
         bestBlock = block;
+        pubBestBlock = block;
         updateBestKnownBlock(block);
     }
 
-    // @Override
-    public synchronized AionBlock getBestBlock() {
-        // the method is synchronized since the bestBlock might be
-        // temporarily switched to the fork while importing non-best block
-        return bestBlock;
+    @Override
+    public AionBlock getBestBlock() {
+        return this.pubBestBlock;
     }
 
     @Override

--- a/modAionImpl/src/org/aion/zero/impl/pow/AionPoW.java
+++ b/modAionImpl/src/org/aion/zero/impl/pow/AionPoW.java
@@ -100,26 +100,24 @@ public class AionPoW {
             setupHandler();
             registerCallback();
 
-//            new Thread(() -> {
-//                while (!shutDown.get()) {
-//                    try {
-//                        Thread.sleep(100);
-//
-//                        long now = System.currentTimeMillis();
-//                        if (now - lastUpdate.get() > 3000 && newPendingTxReceived.compareAndSet(true, false)
-//                                || now - lastUpdate.get() > 10000) { // fallback, when
-//                                                               // we never
-//                                                               // received any
-//                                                               // events
-//                            createNewBlockTemplate();
-//                        }
-//                    } catch (InterruptedException e) {
-//                        break;
-//                    }
-//                }
-//            }, "pow").start();
+            new Thread(() -> {
+                while (!shutDown.get()) {
+                    try {
+                        Thread.sleep(100);
 
-            createNewBlockTemplate();
+                        long now = System.currentTimeMillis();
+                        if (now - lastUpdate.get() > 3000 && newPendingTxReceived.compareAndSet(true, false)
+                                || now - lastUpdate.get() > 10000) { // fallback, when
+                                                               // we never
+                                                               // received any
+                                                               // events
+                            createNewBlockTemplate();
+                        }
+                    } catch (InterruptedException e) {
+                        break;
+                    }
+                }
+            }, "pow").start();
         }
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/pow/AionPoW.java
+++ b/modAionImpl/src/org/aion/zero/impl/pow/AionPoW.java
@@ -100,24 +100,26 @@ public class AionPoW {
             setupHandler();
             registerCallback();
 
-            new Thread(() -> {
-                while (!shutDown.get()) {
-                    try {
-                        Thread.sleep(100);
+//            new Thread(() -> {
+//                while (!shutDown.get()) {
+//                    try {
+//                        Thread.sleep(100);
+//
+//                        long now = System.currentTimeMillis();
+//                        if (now - lastUpdate.get() > 3000 && newPendingTxReceived.compareAndSet(true, false)
+//                                || now - lastUpdate.get() > 10000) { // fallback, when
+//                                                               // we never
+//                                                               // received any
+//                                                               // events
+//                            createNewBlockTemplate();
+//                        }
+//                    } catch (InterruptedException e) {
+//                        break;
+//                    }
+//                }
+//            }, "pow").start();
 
-                        long now = System.currentTimeMillis();
-                        if (now - lastUpdate.get() > 3000 && newPendingTxReceived.compareAndSet(true, false)
-                                || now - lastUpdate.get() > 10000) { // fallback, when
-                                                               // we never
-                                                               // received any
-                                                               // events
-                            createNewBlockTemplate();
-                        }
-                    } catch (InterruptedException e) {
-                        break;
-                    }
-                }
-            }, "pow").start();
+            createNewBlockTemplate();
         }
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/types/AionBlock.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionBlock.java
@@ -54,7 +54,7 @@ public class AionBlock extends AbstractBlock<A0BlockHeader, AionTransaction> imp
 
     /* Private */
     private byte[] rlpEncoded;
-    private boolean parsed = false;
+    private volatile boolean parsed = false;
 
     private Trie txsState;
 
@@ -108,23 +108,25 @@ public class AionBlock extends AbstractBlock<A0BlockHeader, AionTransaction> imp
         this.parsed = true;
     }
 
-    public synchronized void parseRLP() {
-        if (parsed) {
+    public void parseRLP() {
+        if (this.parsed) {
             return;
         }
 
-        RLPList params = RLP.decode2(rlpEncoded);
-        RLPList block = (RLPList) params.get(0);
+        synchronized (this) {
+            RLPList params = RLP.decode2(rlpEncoded);
+            RLPList block = (RLPList) params.get(0);
 
-        // Parse Header
-        RLPList header = (RLPList) block.get(0);
-        this.header = new A0BlockHeader(header);
+            // Parse Header
+            RLPList header = (RLPList) block.get(0);
+            this.header = new A0BlockHeader(header);
 
-        // Parse Transactions
-        RLPList txTransactions = (RLPList) block.get(1);
-        this.parseTxs(this.header.getTxTrieRoot(), txTransactions);
+            // Parse Transactions
+            RLPList txTransactions = (RLPList) block.get(1);
+            this.parseTxs(this.header.getTxTrieRoot(), txTransactions);
 
-        this.parsed = true;
+            this.parsed = true;
+        }
     }
 
     public int size() {
@@ -192,8 +194,7 @@ public class AionBlock extends AbstractBlock<A0BlockHeader, AionTransaction> imp
     public BigInteger getCumulativeDifficulty() {
         // TODO: currently returning incorrect total difficulty
         parseRLP();
-        BigInteger calcDifficulty = new BigInteger(1, this.header.getDifficulty());
-        return calcDifficulty;
+        return new BigInteger(1, this.header.getDifficulty());
     }
 
     public long getTimestamp() {

--- a/modAionImpl/src/org/aion/zero/impl/types/AionBlock.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionBlock.java
@@ -114,6 +114,9 @@ public class AionBlock extends AbstractBlock<A0BlockHeader, AionTransaction> imp
         }
 
         synchronized (this) {
+            if (this.parsed)
+                return;
+            
             RLPList params = RLP.decode2(rlpEncoded);
             RLPList block = (RLPList) params.get(0);
 

--- a/modAionImpl/test/org/aion/zero/impl/BlockchainConcurrencyTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/BlockchainConcurrencyTest.java
@@ -1,0 +1,67 @@
+package org.aion.zero.impl;
+
+import org.aion.zero.impl.types.AionBlock;
+import org.aion.zero.types.AionTransaction;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class BlockchainConcurrencyTest {
+
+    @Test
+    public void testPublishBestBlockSafely() {
+        ExecutorService blockCreationService = Executors.newSingleThreadExecutor();
+        ExecutorService getBlockService = Executors.newSingleThreadExecutor();
+
+        StandaloneBlockchain.Bundle bundle = new StandaloneBlockchain.Builder()
+                .withDefaultAccounts()
+                .withValidatorConfiguration("simple")
+                .build();
+        StandaloneBlockchain bc = bundle.bc;
+
+        final int MAX_COUNT = 100000;
+        final CountDownLatch endLatch = new CountDownLatch(2);
+
+        // this will not definitively prove
+        try {
+            blockCreationService.submit(() -> {
+                int count = 0;
+
+                List<AionTransaction> txList = Collections.emptyList();
+                AionBlock block = bc.createNewBlock(bc.genesis, Collections.emptyList(), false);
+                while (!Thread.currentThread().isInterrupted() && count < MAX_COUNT) {
+                    block = bc.createNewBlock(block, txList, false);
+                    count++;
+                }
+                System.out.println("completed block creation");
+                endLatch.countDown();
+            });
+
+            getBlockService.submit(() -> {
+                int count = 0;
+                long prevNumber = bc.getBestBlock().getNumber();
+                while(!Thread.currentThread().isInterrupted() && count < MAX_COUNT) {
+                    // all three of these methods use {@link AionBlockchainImpl#pubBestBlock}
+                    assertThat(bc.getBestBlockHash()).isNotNull();
+                    bc.getSize();
+
+                    AionBlock block = bc.getBestBlock();
+                    assertThat(block).isNotNull();
+                    assertThat(block.getNumber()).isAtLeast(prevNumber);
+                    prevNumber = block.getNumber();
+                    count++;
+                }
+                endLatch.countDown();
+            });
+        } finally {
+            blockCreationService.shutdown();
+            getBlockService.shutdown();
+        }
+    }
+}

--- a/modAionImpl/test/org/aion/zero/impl/BlockchainForkingTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/BlockchainForkingTest.java
@@ -71,9 +71,18 @@ public class BlockchainForkingTest {
 
         StandaloneBlockchain bc = b.bc;
         AionBlock block = bc.createNewBlock(bc.getBestBlock(), Collections.emptyList(), true);
+        AionBlock sameBlock = new AionBlock(block.getEncoded());
 
         ImportResult firstRes = bc.tryToConnect(block);
-        ImportResult secondRes = bc.tryToConnect(block);
+
+        // check that the returned block is the first block
+        assertThat(bc.getBestBlock() == block).isTrue();
+
+        ImportResult secondRes = bc.tryToConnect(sameBlock);
+
+        // the second block should get rejected, so check that the reference still refers
+        // to the first block (we dont change the published reference)
+        assertThat(bc.getBestBlock() == block).isTrue();
 
         assertThat(firstRes).isEqualTo(ImportResult.IMPORTED_BEST);
         assertThat(secondRes).isEqualTo(ImportResult.EXIST);
@@ -128,11 +137,17 @@ public class BlockchainForkingTest {
         ImportResult result = bc.tryToConnect(standardBlock);
         assertThat(result).isEqualTo(ImportResult.IMPORTED_BEST);
 
+        // assert that the block we just inserted (best) is the instance that is returned
+        assertThat(bc.getBestBlock() == standardBlock).isTrue();
+
         System.out.println(new ByteArrayWrapper(bc.getRepository().getRoot()));
 
         ImportResult higherDifficultyResult = bc.tryToConnect(higherDifficultyBlock);
 
         assertThat(higherDifficultyResult).isEqualTo(ImportResult.IMPORTED_BEST);
         assertThat(bc.getBestBlockHash()).isEqualTo(higherDifficultyBlock.getHash());
+
+        // the object reference here is intentional
+        assertThat(bc.getBestBlock() == higherDifficultyBlock).isTrue();
     }
 }

--- a/modAionImpl/test/org/aion/zero/impl/sync/BlockPropagationTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/BlockPropagationTest.java
@@ -9,6 +9,7 @@ import org.aion.zero.impl.sync.handler.BlockPropagationHandler;
 import org.aion.zero.impl.types.AionBlock;
 import org.junit.Test;
 
+import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,8 +46,8 @@ public class BlockPropagationTest {
         }
 
         @Override
-        public byte[] getTotalDifficulty() {
-            return new byte[0];
+        public BigInteger getTotalDifficulty() {
+            return BigInteger.ZERO;
         }
 
         @Override
@@ -70,8 +71,7 @@ public class BlockPropagationTest {
         }
 
         @Override
-        public void updateStatus(long _bestBlockNumber, byte[] _bestBlockHash, byte[] _totalDifficulty) {
-
+        public void updateStatus(long _bestBlockNumber, byte[] _bestBlockHash, BigInteger totalDifficulty) {
         }
     }
 


### PR DESCRIPTION
This PR:
* Relaxes synchronized conditions on parseRLP(), currently each block is required to synchronized on parseRLP(), its now replaced with a double check.

* Relaxes synchronized condition on ``getBestBlock()``, this was previous synchronized due to the fact that ``this.bestBlock`` can temporarily turn into an inconsistent state (for example on a state ``push`` or ``pop`` or when forking). We've added a volatile variable this.pubBestBlock, that only gets updated when we are sure the new block is best (on ``storeBlock``)

Reasoning behind this change is that AionPow and SyncMgr both frequently retrieve bestBlock, when this is done frequently it can cause threading blocking (especially since ``tryToConnect`` blocks for quite a long period of time)