### PR TITLE
Don't wait for aion blockchain in p2p-write

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -230,7 +230,9 @@ public final class SyncMgr {
 //        );
 
         // filter imported block headers
-        _headers = _headers.stream().filter((k) -> !importedBlockHashes.containsKey(k.getHash())).collect(Collectors.toList());
+        _headers = _headers.stream()
+                .filter((k) -> !importedBlockHashes.containsKey(ByteArrayWrapper.wrap(k.getHash())))
+                .collect(Collectors.toList());
 
         _headers.sort((h1, h2) -> (int) (h1.getNumber() - h2.getNumber()));
         importedHeaders.add(new HeadersWrapper(_nodeIdHashcode, _displayId, _headers));

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqStatusHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqStatusHandler.java
@@ -69,11 +69,8 @@ public final class ReqStatusHandler extends Handler {
     @Override
     public void receive(int _nodeIdHashcode, String _displayId, byte[] _msg) {
         this.log.debug("<req-status from-node={}>", _displayId);
-        ResStatus res = null;
-        synchronized (this.chain) {
-            res = new ResStatus(this.chain.getBestBlock().getNumber(), this.chain.getTotalDifficulty().toByteArray(),
+        ResStatus res = new ResStatus(this.chain.getBestBlock().getNumber(), this.chain.getTotalDifficulty().toByteArray(),
                     this.chain.getBestBlockHash(), this.genesisHash);
-        }
         this.mgr.send(_nodeIdHashcode, res);
     }
 }


### PR DESCRIPTION
The sync module doesn't require the three fields to be atomic, so there is no need to lock the aionblockchainimpl any more.