### PR TITLE
P2p updates

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
@@ -77,12 +77,8 @@ final class TaskShowStatus implements Runnable {
     public void run() {
         Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
         while (this.start.get()) {
-            AionBlock selfBest;
-            String selfTd;
-            synchronized (this.chain) {
-                selfBest = this.chain.getBestBlock();
-                selfTd = this.chain.getTotalDifficulty().toString(10);
-            }
+            AionBlock selfBest = this.chain.getBestBlock();
+            String selfTd = this.chain.getTotalDifficulty().toString(10);
 
             String status = "[sync-status avg-import=" + this.statics.getAvgBlocksPerSec() //
                     + "b/s" //

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -40,8 +40,8 @@
 	<db>
 		<path>database</path>
 		<vendor>leveldb</vendor>
-		<enable_heap_cache>true</enable_heap_cache>
-		<max_heap_cache_size>8096</max_heap_cache_size>
+		<enable_heap_cache>false</enable_heap_cache>
+		<max_heap_cache_size>1024</max_heap_cache_size>
 		<enable_db_cache>true</enable_db_cache>
 		<enable_db_compression>true</enable_db_compression>
 	</db>

--- a/modP2pImpl/src/org/aion/p2p/impl/ChannelBuffer.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/ChannelBuffer.java
@@ -54,7 +54,7 @@ class ChannelBuffer {
      */
     public AtomicBoolean onWrite = new AtomicBoolean(false);
 
-    public BlockingQueue<Msg> messages = new ArrayBlockingQueue<>(10);
+    public BlockingQueue<Msg> messages = new ArrayBlockingQueue<>(128);
 
     void refreshHeader(){
         headerBuf.clear();

--- a/modP2pImpl/src/org/aion/p2p/impl/P2pMgr.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/P2pMgr.java
@@ -40,6 +40,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -702,8 +703,15 @@ public final class  P2pMgr implements IP2pMgr {
             selector = Selector.open();
 
             scheduledWorkers = new ScheduledThreadPoolExecutor(1);
-            workers = Executors.newFixedThreadPool(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16));
-            // workers = Executors.newCachedThreadPool();
+            workers = Executors.newFixedThreadPool(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), new ThreadFactory() {
+
+                private AtomicInteger cnt = new AtomicInteger();
+
+                @Override
+                public Thread newThread(Runnable r) {
+                    return new Thread(r,"p2p-worker-" + cnt.incrementAndGet());
+                }
+            });
 
             tcpServer = ServerSocketChannel.open();
             tcpServer.configureBlocking(false);

--- a/modP2pImpl/src/org/aion/p2p/impl/TaskWrite.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/TaskWrite.java
@@ -27,11 +27,12 @@ package org.aion.p2p.impl;
 
 import org.aion.p2p.Header;
 import org.aion.p2p.Msg;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author chris
@@ -63,8 +64,8 @@ public class TaskWrite implements Runnable {
 
     @Override
     public void run() {
-        Thread.currentThread().setName("p2p-write");
-        Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
+        boolean closed = false;
+
         if (this.channelBuffer.onWrite.compareAndSet(false, true)) {
             /*
              * @warning header set len (body len) before header encode
@@ -87,16 +88,23 @@ public class TaskWrite implements Runnable {
                 while (buf.hasRemaining()) {
                     sc.write(buf);
                 }
-            } catch (IOException e) {
+            } catch (ClosedChannelException ex1) {
+                if (showLog) {
+                    System.out.println("<p2p closed-channel-exception node=" + this.nodeShortId + ">");
+                }
+                closed = true;
+            } catch (IOException ex2) {
                 if (showLog) {
                     System.out.println("<p2p write-msg-io-exception node=" + this.nodeShortId + ">");
                 }
             } finally {
                 this.channelBuffer.onWrite.set(false);
-                Msg msg = this.channelBuffer.messages.poll();
-                if (msg != null) {
-                    //System.out.println("write " + h.getCtrl() + "-" + h.getAction());
-                    workers.submit(new TaskWrite(workers, showLog, nodeShortId, sc, msg, channelBuffer));
+                if (!closed) {
+                    Msg msg = this.channelBuffer.messages.poll();
+                    if (msg != null) {
+                        //System.out.println("write " + h.getCtrl() + "-" + h.getAction());
+                        workers.submit(new TaskWrite(workers, showLog, nodeShortId, sc, msg, channelBuffer));
+                    }
                 }
             }
         } else {

--- a/modP2pImpl/src/org/aion/p2p/impl/TaskWrite.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/TaskWrite.java
@@ -105,15 +105,13 @@ public class TaskWrite implements Runnable {
                         //System.out.println("write " + h.getCtrl() + "-" + h.getAction());
                         workers.submit(new TaskWrite(workers, showLog, nodeShortId, sc, msg, channelBuffer));
                     }
+                } else {
+                    this.channelBuffer.messages.clear();
                 }
             }
         } else {
-            try {
-                this.channelBuffer.messages.put(msg);
-            } catch (InterruptedException e) {
-                if(showLog)
-                    e.printStackTrace();
-            }
+            // message may get dropped here when the message queue is full.
+            this.channelBuffer.messages.offer(msg);
         }
     }
 }

--- a/modP2pImpl/src/org/aion/p2p/impl/TaskWrite.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/TaskWrite.java
@@ -93,15 +93,10 @@ public class TaskWrite implements Runnable {
                 }
             } finally {
                 this.channelBuffer.onWrite.set(false);
-                try {
-                    Msg msg = this.channelBuffer.messages.poll(1, TimeUnit.MILLISECONDS);
-                    if (msg != null) {
-                        //System.out.println("write " + h.getCtrl() + "-" + h.getAction());
-                        workers.submit(new TaskWrite(workers, showLog, nodeShortId, sc, msg, channelBuffer));
-                    }
-                } catch (InterruptedException e) {
-                    if(showLog)
-                        e.printStackTrace();
+                Msg msg = this.channelBuffer.messages.poll();
+                if (msg != null) {
+                    //System.out.println("write " + h.getCtrl() + "-" + h.getAction());
+                    workers.submit(new TaskWrite(workers, showLog, nodeShortId, sc, msg, channelBuffer));
                 }
             }
         } else {


### PR DESCRIPTION
* Don't block p2p threads when the message queue is full
* Remove `synchronized` keyword in `TaskGetStatus`
* Disable heap cache by default