### PR TITLE
Parallelize transaction validation; Optimize syncing

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -796,12 +796,12 @@ public class AionBlockchainImpl implements IAionBlockchain {
 
                 Map<Address, BigInteger> nonceCache = new HashMap<>();
 
-                for (AionTransaction tx : txs) {
-                    if (!TXValidator.isValid(tx)) {
-                        LOG.error("tx sig does not match with the tx raw data, tx[{}]", tx.toString());
-                        return false;
-                    }
+                if (txs.parallelStream().anyMatch(tx -> !TXValidator.isValid(tx))) {
+                    LOG.error("Some transactions in the block are invalid");
+                    return false;
+                }
 
+                for (AionTransaction tx : txs) {
                     Address txSender = tx.getFrom();
 
                     BigInteger expectedNonce = nonceCache.get(txSender);

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -245,8 +245,10 @@ public final class SyncMgr {
             }
 
             // break if not consisting
-            if(prev != null && current.getNumber() != (prev.getNumber() + 1))
-                break;
+            if(prev != null && (current.getNumber() != (prev.getNumber() + 1) || !Arrays.equals(current.getParentHash(), prev.getHash()))) {
+                log.debug("<inconsistent-block-headers>");
+                return;
+            }
 
             // add if not cached
             if(!importedBlockHashes.containsKey(ByteArrayWrapper.wrap(current.getHash())))
@@ -270,7 +272,7 @@ public final class SyncMgr {
     public void validateAndAddBlocks(int _nodeIdHashcode, String _displayId, final List<byte[]> _bodies) {
 
         if (importedBlocks.size() > blocksQueueMax) {
-            log.debug("Imported blocks queue is full. Stop validating income bodies");
+            log.debug("Imported blocks queue is full. Stop validating incoming bodies");
             return;
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -205,6 +205,11 @@ public final class SyncMgr {
     }
 
     private void getHeaders(BigInteger _selfTd){
+        if (importedBlocks.size() > blocksQueueMax) {
+            log.debug("Imported blocks queue is full. Stop requesting headers");
+            return;
+        }
+
         workers.submit(new TaskGetHeaders(p2pMgr, Math.max(1, this.chain.getBestBlock().getNumber() + 1 - syncBackwardMax), this.syncImportMax, _selfTd, log));
     }
 
@@ -265,7 +270,7 @@ public final class SyncMgr {
     public void validateAndAddBlocks(int _nodeIdHashcode, String _displayId, final List<byte[]> _bodies) {
 
         if (importedBlocks.size() > blocksQueueMax) {
-            log.debug("imported blocks queue is full!");
+            log.debug("Imported blocks queue is full. Stop validating income bodies");
             return;
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetBodies.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetBodies.java
@@ -92,27 +92,22 @@ final class TaskGetBodies implements Runnable {
 
             int idHash = hw.getNodeIdHash();
             List<A0BlockHeader> headers = hw.getHeaders();
-            HeadersWrapper hwPrevious = headersSent.get(idHash);
+            if (headers.isEmpty()) {
+                continue;
+            }
 
-            // already sent, check timeout and add it back if
-            // not timeout yet
+            HeadersWrapper hwPrevious = headersSent.get(idHash);
             if (hwPrevious == null || (System.currentTimeMillis() - hwPrevious.getTimestamp()) > SENT_HEADERS_TIMEOUT) {
                 this.headersSent.put(idHash, hw);
-                List<byte[]> headerHashes = new ArrayList<>();
-                for (A0BlockHeader h : headers) {
-                    headerHashes.add(h.getHash());
+
+                if (log.isDebugEnabled()) {
+                    log.debug("<get-bodies from-num={} to-num={} node={}>",
+                            headers.get(0).getNumber(),
+                            headers.get(headers.size() - 1).getNumber(),
+                            hw.getDisplayId());
                 }
 
-                if (!headerHashes.isEmpty()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("<get-bodies from-num={} to-num={} node={}>",
-                                headers.get(0).getNumber(),
-                                headers.get(headers.size() - 1).getNumber(),
-                                hw.getDisplayId());
-                    }
-
-                    this.p2p.send(idHash, new ReqBlocksBodies(headers.stream().map(k -> k.getHash()).collect(Collectors.toList())));
-                }
+                this.p2p.send(idHash, new ReqBlocksBodies(headers.stream().map(k -> k.getHash()).collect(Collectors.toList())));
             }
         }
     }

--- a/modDbImpl/src/org/aion/db/impl/AbstractDB.java
+++ b/modDbImpl/src/org/aion/db/impl/AbstractDB.java
@@ -60,7 +60,7 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
 
     protected final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-    protected static final int DEFAULT_CACHE_SIZE_BYTES = 512 * 1024 * 1024; // 512mb
+    protected static final int DEFAULT_CACHE_SIZE_BYTES = 128 * 1024 * 1024; // 128mb
     protected static final int DEFAULT_WRITE_BUFFER_SIZE_BYTES = 16 * 1024 * 1024; // 16mb
 
     protected final String name;

--- a/modDbImpl/src/org/aion/db/impl/AbstractDB.java
+++ b/modDbImpl/src/org/aion/db/impl/AbstractDB.java
@@ -60,8 +60,8 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
 
     protected final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-    protected static final int DEFAULT_CACHE_SIZE_BYTES = 128 * 1024 * 1024; // 128mb
-    protected static final int DEFAULT_WRITE_BUFFER_SIZE_BYTES = 10 * 1024 * 1024; // 10mb
+    protected static final int DEFAULT_CACHE_SIZE_BYTES = 512 * 1024 * 1024; // 512mb
+    protected static final int DEFAULT_WRITE_BUFFER_SIZE_BYTES = 16 * 1024 * 1024; // 16mb
 
     protected final String name;
     protected String path = null;


### PR DESCRIPTION
* Parallelize transaction validation
* Stop requesting headers when the imported blocks queue is full
* Increase default database cache size
* Add block parent hash check
