### PR TITLE
DB Config: new parameters

### DIFF
--- a/modAionBase/build.xml
+++ b/modAionBase/build.xml
@@ -13,6 +13,8 @@
     <path id="classpath.test">
         <pathelement location="${dir.lib}/junit_4/junit-4.12.jar"/>
         <pathelement location="${dir.lib}/hamcrest/hamcrest-core-1.3.jar"/>
+        <pathelement location="${dir.lib}/guava-19.0.jar"/>
+        <pathelement location="${dir.lib}/truth-0.36.jar"/>
         <pathelement location="${main.build.dir}"/>
     </path>
 

--- a/modAionBase/src/org/aion/base/db/IRepositoryConfig.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryConfig.java
@@ -71,4 +71,8 @@ public interface IRepositoryConfig {
      * @return
      */
     String getMaxHeapCacheSize();
+
+    int getMaxFdAllocSize();
+
+    int getBlockSize();
 }

--- a/modAionBase/src/org/aion/base/db/IRepositoryConfig.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryConfig.java
@@ -75,4 +75,8 @@ public interface IRepositoryConfig {
     int getMaxFdAllocSize();
 
     int getBlockSize();
+
+    int getWriteBufferSize();
+
+    int getCacheSize();
 }

--- a/modAionBase/src/org/aion/base/util/Utils.java
+++ b/modAionBase/src/org/aion/base/util/Utils.java
@@ -42,6 +42,8 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Utils {
@@ -237,5 +239,86 @@ public class Utils {
             }
             return ret.toString();
         }
+    }
+
+
+    private static final Pattern matchPattern = Pattern.compile("^([0-9]+)([a-zA-Z]+)$");
+    public static final long KILO_BYTE = 1024;
+    public static final long MEGA_BYTE = 1048576;
+    public static final long GIGA_BYTE = 1073741824;
+    /**
+     * <p>
+     * Matches file sizes based on fileSize string, in the format:
+     * [numericalValue][sizeDescriptor]
+     * </p>
+     *
+     * <p>
+     * Examples of acceptable formats:
+     *
+     * <li>
+     *   <ul>10b</ul>
+     *   <ul>10B</ul>
+     *   <ul>10K</ul>
+     *   <ul>10KB</ul>
+     *   <ul>10kB</ul>
+     *   <ul>10M</ul>
+     *   <ul>10mB</ul>
+     *   <ul>10MB</ul>
+     *   <ul>10G</ul>
+     *   <ul>10gB</ul>
+     *   <ul>10GB</ul>
+     * </li>
+     * </p>
+     *
+     * <p>
+     * Commas are <b>not</b> accepted by the parser, and are considered invalid.
+     *
+     * Note: Anything beyond {@code gigaByte (GB, G, gB)} is not considered valid, and will
+     * be treated as a parse exception.
+     *
+     * Note: this function assumes the binary representation of magnitudes,
+     * therefore 1kB (kiloByte) is not {@code 1000 bytes} but rather {@code 1024 bytes}.
+     * </p>
+     *
+     * @param fileSize file size string
+     * @return {@code Optional.of(fileSizeInt)} if we were able to successfully decode
+     * the filesize string, otherwise outputs {@code Optional.empty()} indicating that
+     * we were unable to decode the file size string, this usually refers to some
+     * sort of syntactic error made by the user.
+     */
+    public static Optional<Long> parseSize(String fileSize) {
+        Matcher m = matchPattern.matcher(fileSize);
+        // if anything does not match
+        if (!m.find()) {
+            return Optional.empty();
+        }
+
+        String numerical = m.group(1);
+        String sizeSuffix = m.group(2);
+
+        long size = Integer.parseInt(numerical);
+        switch (sizeSuffix) {
+            case "B":
+                break;
+            case "K":
+            case "kB":
+            case "KB":
+                // process kiloByte (1024 * byte) here
+                size = size * KILO_BYTE;
+                break;
+            case "M":
+            case "mB":
+            case "MB":
+                size = size * MEGA_BYTE;
+                break;
+            case "G":
+            case "gB":
+            case "GB":
+                size = size * GIGA_BYTE;
+                break;
+            default:
+                return Optional.empty();
+        }
+        return Optional.of(size);
     }
 }

--- a/modAionBase/test/org/aion/base/util/SizeParseTest.java
+++ b/modAionBase/test/org/aion/base/util/SizeParseTest.java
@@ -1,0 +1,63 @@
+package org.aion.base.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(Parameterized.class)
+public class SizeParseTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {new Bundle("10kB", true, 10L * 1024L)},
+                {new Bundle("10KB", true, 10L * 1024L)},
+                {new Bundle("10K", true, 10L * 1024L)},
+                {new Bundle("10mB", true, 10L * 1048576L)},
+                {new Bundle("10MB", true, 10L * 1048576L)},
+                {new Bundle("10M", true, 10L * 1048576L)},
+                {new Bundle("10gB", true, 10L * 1073741824L)},
+                {new Bundle("10GB", true, 10L * 1073741824L)},
+                {new Bundle("10G", true, 10L * 1073741824L)},
+
+                // fail cases
+                {new Bundle("10b", false, 0)},
+                {new Bundle("10k", false, 0)},
+                {new Bundle("10m", false, 0)},
+                {new Bundle("10g", false, 0)}
+        });
+    }
+
+    private static class Bundle {
+        public final String input;
+        public final boolean expectedResult;
+        public final long expectedSize;
+
+        public Bundle(String input, boolean expectedResult, long expectedSize) {
+            this.input = input;
+            this.expectedResult = expectedResult;
+            this.expectedSize = expectedSize;
+        }
+    }
+
+    private Bundle bundle;
+
+    public SizeParseTest(Bundle bundle) {
+        this.bundle = bundle;
+    }
+
+    @Test
+    public void test() {
+        Optional<Long> maybeSize = Utils.parseSize(bundle.input);
+        assertThat(maybeSize.isPresent()).isEqualTo(bundle.expectedResult);
+
+        maybeSize.ifPresent((p) ->
+            assertThat(p).isEqualTo(bundle.expectedSize));
+    }
+}

--- a/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
@@ -112,6 +112,16 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
             return false;
         }
 
+        @Override
+        public int getMaxFdAllocSize() {
+            return 1024;
+        }
+
+        // default levelDB setting, may want to change this later
+        @Override
+        public int getBlockSize() {
+            return 4096;
+        }
     };
 
     protected StandaloneBlockchain(final A0BCConfig config, final ChainConfiguration chainConfig) {
@@ -279,6 +289,15 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
                     return false;
                 }
 
+                @Override
+                public int getMaxFdAllocSize() {
+                    return 1024;
+                }
+
+                @Override
+                public int getBlockSize() {
+                    return 4096;
+                }
             };
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
@@ -29,6 +29,7 @@ import org.aion.base.db.IRepositoryCache;
 import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteArrayWrapper;
+import org.aion.db.impl.leveldb.LevelDBConstants;
 import org.aion.mcf.core.AccountState;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
@@ -114,13 +115,23 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
 
         @Override
         public int getMaxFdAllocSize() {
-            return 1024;
+            return LevelDBConstants.MAX_OPEN_FILES;
         }
 
         // default levelDB setting, may want to change this later
         @Override
         public int getBlockSize() {
-            return 4096;
+            return LevelDBConstants.BLOCK_SIZE;
+        }
+
+        @Override
+        public int getWriteBufferSize() {
+            return LevelDBConstants.WRITE_BUFFER_SIZE;
+        }
+
+        @Override
+        public int getCacheSize() {
+            return LevelDBConstants.CACHE_SIZE;
         }
     };
 
@@ -291,12 +302,23 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
 
                 @Override
                 public int getMaxFdAllocSize() {
-                    return 1024;
+                    return LevelDBConstants.MAX_OPEN_FILES;
+                }
+
+                // default levelDB setting, may want to change this later
+                @Override
+                public int getBlockSize() {
+                    return LevelDBConstants.BLOCK_SIZE;
                 }
 
                 @Override
-                public int getBlockSize() {
-                    return 4096;
+                public int getWriteBufferSize() {
+                    return LevelDBConstants.WRITE_BUFFER_SIZE;
+                }
+
+                @Override
+                public int getCacheSize() {
+                    return LevelDBConstants.CACHE_SIZE;
                 }
             };
         }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -77,34 +77,21 @@ public class AionRepositoryImpl extends AbstractRepository<AionBlock, A0BlockHea
         // repository singleton instance
         private final static AionRepositoryImpl inst = new AionRepositoryImpl(
                 new RepositoryConfig(new String[] { config.getDb().getVendor() },
-                        // config.getDb().getVendorList() database list
-                        config.getDb().getVendor(), // database
-                        new File(config.getBasePath(), config.getDb().getPath()).getAbsolutePath(), // db
-                                                                                                    // path
-                        -1, // config.getDb().getPrune() prune flag
-                        ContractDetailsAion.getInstance(), // contract details
-                                                           // provider
-                        config.getDb().isAutoCommitEnabled(), // if false,
-                                                              // flush/commit
-                                                              // must be called
-                        config.getDb().isDbCacheEnabled(), // caching inside the
-                                                           // database
-                        config.getDb().isDbCompressionEnabled(), // enables/disable
-                                                                 // the default
-                                                                 // database
-                                                                 // compression
-                        config.getDb().isHeapCacheEnabled(), // uses heap
-                                                             // caching of data
-                        config.getDb().getMaxHeapCacheSize(), // size of the
-                                                              // heap cache
-                        config.getDb().isHeapCacheStatsEnabled())); // enable
-                                                                    // stats for
-                                                                    // heap
-                                                                    // cache
+                        config.getDb().getVendor(),
+                        new File(config.getBasePath(), config.getDb().getPath()).getAbsolutePath(),
+                        -1,
+                        ContractDetailsAion.getInstance(),
+                        config.getDb().isAutoCommitEnabled(),
+                        config.getDb().isDbCacheEnabled(),
+                        config.getDb().isDbCompressionEnabled(),
+                        config.getDb().isHeapCacheEnabled(),
+                        config.getDb().getMaxHeapCacheSize(),
+                        config.getDb().isHeapCacheStatsEnabled(),
+                        config.getDb().getFdOpenAllocSize(),
+                        config.getDb().getBlockSize()));
     }
 
     public static AionRepositoryImpl inst() {
-
         return AionRepositoryImplHolder.inst;
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -88,7 +88,9 @@ public class AionRepositoryImpl extends AbstractRepository<AionBlock, A0BlockHea
                         config.getDb().getMaxHeapCacheSize(),
                         config.getDb().isHeapCacheStatsEnabled(),
                         config.getDb().getFdOpenAllocSize(),
-                        config.getDb().getBlockSize()));
+                        config.getDb().getBlockSize(),
+                        config.getDb().getWriteBufferSize(),
+                        config.getDb().getCacheSize()));
     }
 
     public static AionRepositoryImpl inst() {

--- a/modAionImpl/src/org/aion/zero/impl/db/RepositoryConfig.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RepositoryConfig.java
@@ -47,6 +47,9 @@ public class RepositoryConfig implements IRepositoryConfig {
     private final int block_size;
     private final int max_fd_alloc_size;
 
+    private final int write_buffer_size;
+    private final int cache_size;
+
     @Override
     public String[] getVendorList() {
         return vendorList;
@@ -112,6 +115,16 @@ public class RepositoryConfig implements IRepositoryConfig {
         return this.block_size;
     }
 
+    @Override
+    public int getWriteBufferSize() {
+        return this.write_buffer_size;
+    }
+
+    @Override
+    public int getCacheSize() {
+        return this.cache_size;
+    }
+
     public RepositoryConfig(final String[] vendorList, //
                             final String activeVendor, //
                             final String dbPath, //
@@ -124,7 +137,9 @@ public class RepositoryConfig implements IRepositoryConfig {
                             final String max_heap_cache_size, //
                             final boolean enable_heap_cache_stats,
                             final int max_fd_alloc_size,
-                            final int block_size) { //
+                            final int block_size,
+                            final int write_buffer_size,
+                            final int cache_size) { //
 
         this.vendorList = vendorList;
         this.activeVendor = activeVendor;
@@ -144,6 +159,9 @@ public class RepositoryConfig implements IRepositoryConfig {
 
         this.max_fd_alloc_size = max_fd_alloc_size;
         this.block_size = block_size;
+
+        this.write_buffer_size = write_buffer_size;
+        this.cache_size = cache_size;
     }
 
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/RepositoryConfig.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RepositoryConfig.java
@@ -44,6 +44,9 @@ public class RepositoryConfig implements IRepositoryConfig {
     private String max_heap_cache_size;
     private boolean enable_heap_cache_stats;
 
+    private final int block_size;
+    private final int max_fd_alloc_size;
+
     @Override
     public String[] getVendorList() {
         return vendorList;
@@ -97,20 +100,31 @@ public class RepositoryConfig implements IRepositoryConfig {
     @Override
     public boolean isHeapCacheStatsEnabled() {
         return enable_heap_cache_stats;
+    }
 
+    @Override
+    public int getMaxFdAllocSize() {
+        return this.max_fd_alloc_size;
+    }
+
+    @Override
+    public int getBlockSize() {
+        return this.block_size;
     }
 
     public RepositoryConfig(final String[] vendorList, //
-            final String activeVendor, //
-            final String dbPath, //
-            final int prune, //
-            final DetailsProvider detailsProvider, //
-            final boolean enable_auto_commit, //
-            final boolean enable_db_cache, //
-            final boolean enable_db_compression, //
-            final boolean enable_heap_cache, //
-            final String max_heap_cache_size, //
-            final boolean enable_heap_cache_stats) { //
+                            final String activeVendor, //
+                            final String dbPath, //
+                            final int prune, //
+                            final DetailsProvider detailsProvider, //
+                            final boolean enable_auto_commit, //
+                            final boolean enable_db_cache, //
+                            final boolean enable_db_compression, //
+                            final boolean enable_heap_cache, //
+                            final String max_heap_cache_size, //
+                            final boolean enable_heap_cache_stats,
+                            final int max_fd_alloc_size,
+                            final int block_size) { //
 
         this.vendorList = vendorList;
         this.activeVendor = activeVendor;
@@ -127,6 +141,9 @@ public class RepositoryConfig implements IRepositoryConfig {
         this.enable_heap_cache = enable_heap_cache;
         this.max_heap_cache_size = max_heap_cache_size;
         this.enable_heap_cache_stats = enable_heap_cache_stats;
+
+        this.max_fd_alloc_size = max_fd_alloc_size;
+        this.block_size = block_size;
     }
 
 }

--- a/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
+++ b/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
@@ -38,21 +38,21 @@ import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.Address;
+import org.aion.base.util.ByteUtil;
 import org.aion.db.impl.DBVendor;
+import org.aion.db.impl.leveldb.LevelDBConstants;
+import org.aion.mcf.vm.types.DataWord;
 import org.aion.zero.db.AionContractDetailsImpl;
 import org.aion.zero.impl.db.AionRepositoryImpl;
 import org.aion.zero.impl.db.ContractDetailsAion;
-import org.aion.mcf.vm.types.DataWord;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
-import org.spongycastle.util.encoders.Hex;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spongycastle.util.encoders.Hex.toHexString;
 
 public class AionContractDetailsTest {
 
@@ -61,7 +61,7 @@ public class AionContractDetailsTest {
     protected IRepositoryConfig repoConfig = new IRepositoryConfig() {
         @Override
         public String[] getVendorList() {
-            return new String[] { DBVendor.MOCKDB.toValue() };
+            return new String[]{DBVendor.MOCKDB.toValue()};
         }
 
         @Override
@@ -114,22 +114,39 @@ public class AionContractDetailsTest {
             return false;
         }
 
+        @Override
+        public int getMaxFdAllocSize() {
+            return LevelDBConstants.MAX_OPEN_FILES;
+        }
+
+        @Override
+        public int getBlockSize() {
+            return LevelDBConstants.BLOCK_SIZE;
+        }
     };
+
+    private static IContractDetails deserialize(byte[] rlp, IByteArrayKeyValueDatabase externalStorage) {
+        AionContractDetailsImpl result = new AionContractDetailsImpl();
+        result.setExternalStorageDataSource(externalStorage);
+        result.decode(rlp);
+
+        return result;
+    }
 
     @Test
     public void test_1() throws Exception {
 
-        byte[] code = Hex.decode("60016002");
+        byte[] code = ByteUtil.hexStringToBytes("60016002");
 
-        byte[] key_1 = Hex.decode("111111");
-        byte[] val_1 = Hex.decode("aaaaaa");
+        byte[] key_1 = ByteUtil.hexStringToBytes("111111");
+        byte[] val_1 = ByteUtil.hexStringToBytes("aaaaaa");
 
-        byte[] key_2 = Hex.decode("222222");
-        byte[] val_2 = Hex.decode("bbbbbb");
+        byte[] key_2 = ByteUtil.hexStringToBytes("222222");
+        byte[] val_2 = ByteUtil.hexStringToBytes("bbbbbb");
 
         AionContractDetailsImpl contractDetails = new AionContractDetailsImpl(
-            -1, //CfgAion.inst().getDb().getPrune(),
-            1000000 //CfgAion.inst().getDb().getDetailsInMemoryStorageLimit()
+                -1, //CfgAion.inst().getDb().getPrune(),
+                1000000 //CfgAion.inst().getDb().getDetailsInMemoryStorageLimit()
         );
         contractDetails.setCode(code);
         contractDetails.put(new DataWord(key_1), new DataWord(val_1));
@@ -139,63 +156,63 @@ public class AionContractDetailsTest {
 
         AionContractDetailsImpl contractDetails_ = new AionContractDetailsImpl(data);
 
-        assertEquals(Hex.toHexString(code),
-                Hex.toHexString(contractDetails_.getCode()));
+        assertEquals(ByteUtil.toHexString(code),
+                ByteUtil.toHexString(contractDetails_.getCode()));
 
-        assertEquals(Hex.toHexString(val_1),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_1)).getNoLeadZeroesData()));
+        assertEquals(ByteUtil.toHexString(val_1),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_1)).getNoLeadZeroesData()));
 
-        assertEquals(Hex.toHexString(val_2),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_2)).getNoLeadZeroesData()));
+        assertEquals(ByteUtil.toHexString(val_2),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_2)).getNoLeadZeroesData()));
     }
 
     @Test
     public void test_2() throws Exception {
 
-        byte[] code = Hex.decode("7c0100000000000000000000000000000000000000000000000000000000600035046333d546748114610065578063430fe5f01461007c5780634d432c1d1461008d578063501385b2146100b857806357eb3b30146100e9578063dbc7df61146100fb57005b6100766004356024356044356102f0565b60006000f35b61008760043561039e565b60006000f35b610098600435610178565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100c96004356024356044356101a0565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100f1610171565b8060005260206000f35b610106600435610133565b8360005282602052816040528073ffffffffffffffffffffffffffffffffffffffff1660605260806000f35b5b60006020819052908152604090208054600182015460028301546003909301549192909173ffffffffffffffffffffffffffffffffffffffff1684565b5b60015481565b5b60026020526000908152604090205473ffffffffffffffffffffffffffffffffffffffff1681565b73ffffffffffffffffffffffffffffffffffffffff831660009081526020819052604081206002015481908302341080156101fe575073ffffffffffffffffffffffffffffffffffffffff8516600090815260208190526040812054145b8015610232575073ffffffffffffffffffffffffffffffffffffffff85166000908152602081905260409020600101548390105b61023b57610243565b3391506102e8565b6101966103ca60003973ffffffffffffffffffffffffffffffffffffffff3381166101965285166101b68190526000908152602081905260408120600201546101d6526101f68490526102169080f073ffffffffffffffffffffffffffffffffffffffff8616600090815260208190526040902060030180547fffffffffffffffffffffffff0000000000000000000000000000000000000000168217905591508190505b509392505050565b73ffffffffffffffffffffffffffffffffffffffff33166000908152602081905260408120548190821461032357610364565b60018054808201909155600090815260026020526040902080547fffffffffffffffffffffffff000000000000000000000000000000000000000016331790555b50503373ffffffffffffffffffffffffffffffffffffffff1660009081526020819052604090209081556001810192909255600290910155565b3373ffffffffffffffffffffffffffffffffffffffff166000908152602081905260409020600201555600608061019660043960048051602451604451606451600080547fffffffffffffffffffffffff0000000000000000000000000000000000000000908116909517815560018054909516909317909355600355915561013390819061006390396000f3007c0100000000000000000000000000000000000000000000000000000000600035046347810fe381146100445780637e4a1aa81461005557806383d2421b1461006957005b61004f6004356100ab565b60006000f35b6100636004356024356100fc565b60006000f35b61007460043561007a565b60006000f35b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146100a2576100a8565b60078190555b50565b73ffffffffffffffffffffffffffffffffffffffff8116600090815260026020526040902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117905550565b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146101245761012f565b600582905560068190555b505056");
+        byte[] code = ByteUtil.hexStringToBytes("7c0100000000000000000000000000000000000000000000000000000000600035046333d546748114610065578063430fe5f01461007c5780634d432c1d1461008d578063501385b2146100b857806357eb3b30146100e9578063dbc7df61146100fb57005b6100766004356024356044356102f0565b60006000f35b61008760043561039e565b60006000f35b610098600435610178565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100c96004356024356044356101a0565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100f1610171565b8060005260206000f35b610106600435610133565b8360005282602052816040528073ffffffffffffffffffffffffffffffffffffffff1660605260806000f35b5b60006020819052908152604090208054600182015460028301546003909301549192909173ffffffffffffffffffffffffffffffffffffffff1684565b5b60015481565b5b60026020526000908152604090205473ffffffffffffffffffffffffffffffffffffffff1681565b73ffffffffffffffffffffffffffffffffffffffff831660009081526020819052604081206002015481908302341080156101fe575073ffffffffffffffffffffffffffffffffffffffff8516600090815260208190526040812054145b8015610232575073ffffffffffffffffffffffffffffffffffffffff85166000908152602081905260409020600101548390105b61023b57610243565b3391506102e8565b6101966103ca60003973ffffffffffffffffffffffffffffffffffffffff3381166101965285166101b68190526000908152602081905260408120600201546101d6526101f68490526102169080f073ffffffffffffffffffffffffffffffffffffffff8616600090815260208190526040902060030180547fffffffffffffffffffffffff0000000000000000000000000000000000000000168217905591508190505b509392505050565b73ffffffffffffffffffffffffffffffffffffffff33166000908152602081905260408120548190821461032357610364565b60018054808201909155600090815260026020526040902080547fffffffffffffffffffffffff000000000000000000000000000000000000000016331790555b50503373ffffffffffffffffffffffffffffffffffffffff1660009081526020819052604090209081556001810192909255600290910155565b3373ffffffffffffffffffffffffffffffffffffffff166000908152602081905260409020600201555600608061019660043960048051602451604451606451600080547fffffffffffffffffffffffff0000000000000000000000000000000000000000908116909517815560018054909516909317909355600355915561013390819061006390396000f3007c0100000000000000000000000000000000000000000000000000000000600035046347810fe381146100445780637e4a1aa81461005557806383d2421b1461006957005b61004f6004356100ab565b60006000f35b6100636004356024356100fc565b60006000f35b61007460043561007a565b60006000f35b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146100a2576100a8565b60078190555b50565b73ffffffffffffffffffffffffffffffffffffffff8116600090815260026020526040902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117905550565b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146101245761012f565b600582905560068190555b505056");
         Address address = Address.wrap(RandomUtils.nextBytes(Address.ADDRESS_LEN));
 
-        byte[] key_0 = Hex.decode("18d63b70aa690ad37cb50908746c9a55");
-        byte[] val_0 = Hex.decode("00000000000000000000000000000064");
+        byte[] key_0 = ByteUtil.hexStringToBytes("18d63b70aa690ad37cb50908746c9a55");
+        byte[] val_0 = ByteUtil.hexStringToBytes("00000000000000000000000000000064");
 
-        byte[] key_1 = Hex.decode("18d63b70aa690ad37cb50908746c9a56");
-        byte[] val_1 = Hex.decode("0000000000000000000000000000000c");
+        byte[] key_1 = ByteUtil.hexStringToBytes("18d63b70aa690ad37cb50908746c9a56");
+        byte[] val_1 = ByteUtil.hexStringToBytes("0000000000000000000000000000000c");
 
-        byte[] key_2 = Hex.decode("5a448d1967513482947d1d3f6104316f");
-        byte[] val_2 = Hex.decode("00000000000000000000000000000000");
+        byte[] key_2 = ByteUtil.hexStringToBytes("5a448d1967513482947d1d3f6104316f");
+        byte[] val_2 = ByteUtil.hexStringToBytes("00000000000000000000000000000000");
 
-        byte[] key_3 = Hex.decode("5a448d1967513482947d1d3f61043171");
-        byte[] val_3 = Hex.decode("00000000000000000000000000000014");
+        byte[] key_3 = ByteUtil.hexStringToBytes("5a448d1967513482947d1d3f61043171");
+        byte[] val_3 = ByteUtil.hexStringToBytes("00000000000000000000000000000014");
 
-        byte[] key_4 = Hex.decode("18d63b70aa690ad37cb50908746c9a54");
-        byte[] val_4 = Hex.decode("00000000000000000000000000000000");
+        byte[] key_4 = ByteUtil.hexStringToBytes("18d63b70aa690ad37cb50908746c9a54");
+        byte[] val_4 = ByteUtil.hexStringToBytes("00000000000000000000000000000000");
 
-        byte[] key_5 = Hex.decode("5a448d1967513482947d1d3f61043170");
-        byte[] val_5 = Hex.decode("00000000000000000000000000000078");
+        byte[] key_5 = ByteUtil.hexStringToBytes("5a448d1967513482947d1d3f61043170");
+        byte[] val_5 = ByteUtil.hexStringToBytes("00000000000000000000000000000078");
 
-        byte[] key_6 = Hex.decode("c83a08bbccc01a0644d599ccd2a7c2e0");
-        byte[] val_6 = Hex.decode("8fbec874791c4e3f9f48a59a44686efe");
+        byte[] key_6 = ByteUtil.hexStringToBytes("c83a08bbccc01a0644d599ccd2a7c2e0");
+        byte[] val_6 = ByteUtil.hexStringToBytes("8fbec874791c4e3f9f48a59a44686efe");
 
-        byte[] key_7 = Hex.decode("5aa541c6c03f602a426f04ae47508bb8");
-        byte[] val_7 = Hex.decode("7a657031000000000000000000000000");
+        byte[] key_7 = ByteUtil.hexStringToBytes("5aa541c6c03f602a426f04ae47508bb8");
+        byte[] val_7 = ByteUtil.hexStringToBytes("7a657031000000000000000000000000");
 
-        byte[] key_8 = Hex.decode("5aa541c6c03f602a426f04ae47508bb9");
-        byte[] val_8 = Hex.decode("000000000000000000000000000000c8");
+        byte[] key_8 = ByteUtil.hexStringToBytes("5aa541c6c03f602a426f04ae47508bb9");
+        byte[] val_8 = ByteUtil.hexStringToBytes("000000000000000000000000000000c8");
 
-        byte[] key_9 = Hex.decode("5aa541c6c03f602a426f04ae47508bba");
-        byte[] val_9 = Hex.decode("0000000000000000000000000000000a");
+        byte[] key_9 = ByteUtil.hexStringToBytes("5aa541c6c03f602a426f04ae47508bba");
+        byte[] val_9 = ByteUtil.hexStringToBytes("0000000000000000000000000000000a");
 
-        byte[] key_10 = Hex.decode("00000000000000000000000000000001");
-        byte[] val_10 = Hex.decode("00000000000000000000000000000003");
+        byte[] key_10 = ByteUtil.hexStringToBytes("00000000000000000000000000000001");
+        byte[] val_10 = ByteUtil.hexStringToBytes("00000000000000000000000000000003");
 
-        byte[] key_11 = Hex.decode("5aa541c6c03f602a426f04ae47508bbb");
-        byte[] val_11 = Hex.decode("194bcfc3670d8a1613e5b0c790036a35");
+        byte[] key_11 = ByteUtil.hexStringToBytes("5aa541c6c03f602a426f04ae47508bbb");
+        byte[] val_11 = ByteUtil.hexStringToBytes("194bcfc3670d8a1613e5b0c790036a35");
 
-        byte[] key_12 = Hex.decode("aee92919b8c3389af86ef24535e8a28c");
-        byte[] val_12 = Hex.decode("cfe293a85bef5915e1a7acb37bf0c685");
+        byte[] key_12 = ByteUtil.hexStringToBytes("aee92919b8c3389af86ef24535e8a28c");
+        byte[] val_12 = ByteUtil.hexStringToBytes("cfe293a85bef5915e1a7acb37bf0c685");
 
-        byte[] key_13 = Hex.decode("65c996598dc972688b7ace676c89077b");
-        byte[] val_13 = Hex.decode("d6ee27e285f2de7b68e8db25cf1b1063");
+        byte[] key_13 = ByteUtil.hexStringToBytes("65c996598dc972688b7ace676c89077b");
+        byte[] val_13 = ByteUtil.hexStringToBytes("d6ee27e285f2de7b68e8db25cf1b1063");
 
         AionContractDetailsImpl contractDetails = new AionContractDetailsImpl();
         contractDetails.setCode(code);
@@ -219,49 +236,49 @@ public class AionContractDetailsTest {
 
         AionContractDetailsImpl contractDetails_ = new AionContractDetailsImpl(data);
 
-        assertEquals(Hex.toHexString(code),
-                Hex.toHexString(contractDetails_.getCode()));
+        assertEquals(ByteUtil.toHexString(code),
+                ByteUtil.toHexString(contractDetails_.getCode()));
 
         assertTrue(address.equals(contractDetails_.getAddress()));
 
-        assertEquals(Hex.toHexString(val_1),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_1)).getData()));
+        assertEquals(ByteUtil.toHexString(val_1),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_1)).getData()));
 
-        assertEquals(Hex.toHexString(val_2),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_2)).getData()));
+        assertEquals(ByteUtil.toHexString(val_2),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_2)).getData()));
 
-        assertEquals(Hex.toHexString(val_3),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_3)).getData()));
+        assertEquals(ByteUtil.toHexString(val_3),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_3)).getData()));
 
-        assertEquals(Hex.toHexString(val_4),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_4)).getData()));
+        assertEquals(ByteUtil.toHexString(val_4),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_4)).getData()));
 
-        assertEquals(Hex.toHexString(val_5),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_5)).getData()));
+        assertEquals(ByteUtil.toHexString(val_5),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_5)).getData()));
 
-        assertEquals(Hex.toHexString(val_6),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_6)).getData()));
+        assertEquals(ByteUtil.toHexString(val_6),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_6)).getData()));
 
-        assertEquals(Hex.toHexString(val_7),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_7)).getData()));
+        assertEquals(ByteUtil.toHexString(val_7),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_7)).getData()));
 
-        assertEquals(Hex.toHexString(val_8),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_8)).getData()));
+        assertEquals(ByteUtil.toHexString(val_8),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_8)).getData()));
 
-        assertEquals(Hex.toHexString(val_9),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_9)).getData()));
+        assertEquals(ByteUtil.toHexString(val_9),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_9)).getData()));
 
-        assertEquals(Hex.toHexString(val_10),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_10)).getData()));
+        assertEquals(ByteUtil.toHexString(val_10),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_10)).getData()));
 
-        assertEquals(Hex.toHexString(val_11),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_11)).getData()));
+        assertEquals(ByteUtil.toHexString(val_11),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_11)).getData()));
 
-        assertEquals(Hex.toHexString(val_12),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_12)).getData()));
+        assertEquals(ByteUtil.toHexString(val_12),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_12)).getData()));
 
-        assertEquals(Hex.toHexString(val_13),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_13)).getData()));
+        assertEquals(ByteUtil.toHexString(val_13),
+                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_13)).getData()));
     }
 
     @Test
@@ -298,7 +315,7 @@ public class AionContractDetailsTest {
 
         assertEquals(deserialized.externalStorage, true);
         assertTrue(address.equals(deserialized.getAddress()));
-        assertEquals(toHexString(code), toHexString(deserialized.getCode()));
+        assertEquals(ByteUtil.toHexString(code), ByteUtil.toHexString(deserialized.getCode()));
 
         Map<DataWord, DataWord> storage = deserialized.getStorage();
         assertEquals(elements.size(), storage.size());
@@ -360,13 +377,5 @@ public class AionContractDetailsTest {
         for (DataWord key : elements.keySet()) {
             assertEquals(elements.get(key), storage.get(key));
         }
-    }
-
-    private static IContractDetails deserialize(byte[] rlp, IByteArrayKeyValueDatabase externalStorage) {
-        AionContractDetailsImpl result = new AionContractDetailsImpl();
-        result.setExternalStorageDataSource( externalStorage);
-        result.decode(rlp);
-
-        return result;
     }
 }

--- a/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
+++ b/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
@@ -119,9 +119,20 @@ public class AionContractDetailsTest {
             return LevelDBConstants.MAX_OPEN_FILES;
         }
 
+        // default levelDB setting, may want to change this later
         @Override
         public int getBlockSize() {
             return LevelDBConstants.BLOCK_SIZE;
+        }
+
+        @Override
+        public int getWriteBufferSize() {
+            return LevelDBConstants.WRITE_BUFFER_SIZE;
+        }
+
+        @Override
+        public int getCacheSize() {
+            return LevelDBConstants.CACHE_SIZE;
         }
     };
 

--- a/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
@@ -117,6 +117,16 @@ public class AionRepositoryImplTest {
             return false;
         }
 
+        // TODO: these are still set to old parameters
+        @Override
+        public int getMaxFdAllocSize() {
+            return 32;
+        }
+
+        @Override
+        public int getBlockSize() {
+            return 10 * 1024 * 1024;
+        }
     };
 
     @Test

--- a/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
@@ -40,6 +40,7 @@ import org.aion.base.db.IRepositoryCache;
 import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteUtil;
+import org.aion.db.impl.leveldb.LevelDBConstants;
 import org.aion.mcf.core.AccountState;
 import org.aion.crypto.HashUtil;
 import org.aion.db.impl.DBVendor;
@@ -117,15 +118,25 @@ public class AionRepositoryImplTest {
             return false;
         }
 
-        // TODO: these are still set to old parameters
         @Override
         public int getMaxFdAllocSize() {
-            return 32;
+            return LevelDBConstants.MAX_OPEN_FILES;
+        }
+
+        // default levelDB setting, may want to change this later
+        @Override
+        public int getBlockSize() {
+            return LevelDBConstants.BLOCK_SIZE;
         }
 
         @Override
-        public int getBlockSize() {
-            return 10 * 1024 * 1024;
+        public int getWriteBufferSize() {
+            return LevelDBConstants.WRITE_BUFFER_SIZE;
+        }
+
+        @Override
+        public int getCacheSize() {
+            return LevelDBConstants.CACHE_SIZE;
         }
     };
 

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -46,8 +46,8 @@
 		<enable_db_compression>true</enable_db_compression>
 		<max_fd_alloc_size>1024</max_fd_alloc_size>
 		<block_size>16kB</block_size>
-		<write_buffer_size>128mB</write_buffer_size>
-		<cache_size>16mB</cache_size>
+		<write_buffer_size>16mB</write_buffer_size>
+		<cache_size>128mB</cache_size>
 	</db>
 	<log>
 		<GEN>INFO</GEN>

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -46,6 +46,8 @@
 		<enable_db_compression>true</enable_db_compression>
 		<max_fd_alloc_size>1024</max_fd_alloc_size>
 		<block_size>16kB</block_size>
+		<write_buffer_size>128mB</write_buffer_size>
+		<cache_size>16mB</cache_size>
 	</db>
 	<log>
 		<GEN>INFO</GEN>

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -44,6 +44,8 @@
 		<max_heap_cache_size>1024</max_heap_cache_size>
 		<enable_db_cache>true</enable_db_cache>
 		<enable_db_compression>true</enable_db_compression>
+		<max_fd_alloc_size>1024</max_fd_alloc_size>
+		<block_size>16kB</block_size>
 	</db>
 	<log>
 		<GEN>INFO</GEN>

--- a/modDbImpl/module-info.java
+++ b/modDbImpl/module-info.java
@@ -7,4 +7,5 @@ module aion.db.impl {
     requires h2.mvstore;
 
 	exports org.aion.db.impl;
+	exports org.aion.db.impl.leveldb
 }

--- a/modDbImpl/module-info.java
+++ b/modDbImpl/module-info.java
@@ -7,5 +7,5 @@ module aion.db.impl {
     requires h2.mvstore;
 
 	exports org.aion.db.impl;
-	exports org.aion.db.impl.leveldb
+	exports org.aion.db.impl.leveldb;
 }

--- a/modDbImpl/src/org/aion/db/impl/DatabaseFactory.java
+++ b/modDbImpl/src/org/aion/db/impl/DatabaseFactory.java
@@ -64,6 +64,9 @@ public abstract class DatabaseFactory {
     private static final String PROP_ENABLE_HEAP_CACHE_STATS = "enable_heap_cache_stats";
     private static final String PROP_MAX_HEAP_CACHE_SIZE = "max_heap_cache_size";
 
+    public static final String PROP_MAX_FD_ALLOC = "max_fd_alloc_size";
+    public static final String PROP_BLOCK_SIZE = "block_size";
+
     public static IByteArrayKeyValueDatabase connect(Properties info) {
 
         DBVendor dbType = DBVendor.fromString(info.getProperty(PROP_DB_TYPE));
@@ -110,12 +113,22 @@ public abstract class DatabaseFactory {
         // select database implementation
         switch (dbType) {
             case LEVELDB:
+                // grab leveldb specific parameters
+                int max_fd_alloc_size = Integer.parseInt(info.getProperty(PROP_MAX_FD_ALLOC));
+                int block_size = Integer.parseInt(info.getProperty(PROP_BLOCK_SIZE));
+
                 if (enableHeapCache) {
-                    return new LevelDBWithCache(dbName, dbPath, enableDbCache, enableDbCompression, enableAutoCommit,
+                    return new LevelDBWithCache(dbName,
+                            dbPath,
+                            enableDbCache,
+                            enableDbCompression,
+                            enableAutoCommit,
                             info.getProperty(PROP_MAX_HEAP_CACHE_SIZE),
-                            Boolean.parseBoolean(info.getProperty(PROP_ENABLE_HEAP_CACHE_STATS)));
+                            Boolean.parseBoolean(info.getProperty(PROP_ENABLE_HEAP_CACHE_STATS)),
+                            max_fd_alloc_size,
+                            block_size);
                 } else {
-                    return new LevelDB(dbName, dbPath, enableDbCache, enableDbCompression);
+                    return new LevelDB(dbName, dbPath, enableDbCache, enableDbCompression, max_fd_alloc_size, block_size);
                 }
             case H2:
                 if (enableHeapCache) {

--- a/modDbImpl/src/org/aion/db/impl/DatabaseFactory.java
+++ b/modDbImpl/src/org/aion/db/impl/DatabaseFactory.java
@@ -67,6 +67,9 @@ public abstract class DatabaseFactory {
     public static final String PROP_MAX_FD_ALLOC = "max_fd_alloc_size";
     public static final String PROP_BLOCK_SIZE = "block_size";
 
+    public static final String PROP_WRITE_BUFFER_SIZE = "write_buffer_size";
+    public static final String PROP_CACHE_SIZE = "cache_size";
+
     public static IByteArrayKeyValueDatabase connect(Properties info) {
 
         DBVendor dbType = DBVendor.fromString(info.getProperty(PROP_DB_TYPE));
@@ -116,6 +119,8 @@ public abstract class DatabaseFactory {
                 // grab leveldb specific parameters
                 int max_fd_alloc_size = Integer.parseInt(info.getProperty(PROP_MAX_FD_ALLOC));
                 int block_size = Integer.parseInt(info.getProperty(PROP_BLOCK_SIZE));
+                int write_buffer_size = Integer.parseInt(info.getProperty(PROP_WRITE_BUFFER_SIZE));
+                int cache_size = Integer.parseInt(info.getProperty(PROP_CACHE_SIZE));
 
                 if (enableHeapCache) {
                     return new LevelDBWithCache(dbName,
@@ -126,9 +131,18 @@ public abstract class DatabaseFactory {
                             info.getProperty(PROP_MAX_HEAP_CACHE_SIZE),
                             Boolean.parseBoolean(info.getProperty(PROP_ENABLE_HEAP_CACHE_STATS)),
                             max_fd_alloc_size,
-                            block_size);
+                            block_size,
+                            write_buffer_size,
+                            cache_size);
                 } else {
-                    return new LevelDB(dbName, dbPath, enableDbCache, enableDbCompression, max_fd_alloc_size, block_size);
+                    return new LevelDB(dbName,
+                            dbPath,
+                            enableDbCache,
+                            enableDbCompression,
+                            max_fd_alloc_size,
+                            block_size,
+                            write_buffer_size,
+                            cache_size);
                 }
             case H2:
                 if (enableHeapCache) {

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -54,6 +54,8 @@ public class LevelDB extends AbstractDB {
 
     private final int maxOpenFiles;
     private final int blockSize;
+    private final int writeBufferSize;
+    private final int cacheSize;
 
     private DB db;
 
@@ -62,10 +64,14 @@ public class LevelDB extends AbstractDB {
                    boolean enableCache,
                    boolean enableCompression,
                    int maxOpenFiles,
-                   int blockSize) {
+                   int blockSize,
+                   int writeBufferSize,
+                   int cacheSize) {
         super(name, path, enableCache, enableCompression);
         this.maxOpenFiles = maxOpenFiles;
         this.blockSize = blockSize;
+        this.writeBufferSize = writeBufferSize;
+        this.cacheSize = cacheSize;
     }
 
     /**
@@ -80,7 +86,14 @@ public class LevelDB extends AbstractDB {
                    String path,
                    boolean enableCache,
                    boolean enableCompression) {
-        this(name, path, enableCache, enableCompression, LevelDBConstants.MAX_OPEN_FILES, LevelDBConstants.BLOCK_SIZE);
+        this(   name,
+                path,
+                enableCache,
+                enableCompression,
+                LevelDBConstants.MAX_OPEN_FILES,
+                LevelDBConstants.BLOCK_SIZE,
+                LevelDBConstants.WRITE_BUFFER_SIZE,
+                LevelDBConstants.CACHE_SIZE);
     }
 
     @Override

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -107,8 +107,8 @@ public class LevelDB extends AbstractDB {
         options.createIfMissing(true);
         options.compressionType(enableDbCompression ? CompressionType.SNAPPY : CompressionType.NONE);
         options.blockSize(this.blockSize);
-        options.writeBufferSize(DEFAULT_WRITE_BUFFER_SIZE_BYTES); // (levelDb default: 8mb)
-        options.cacheSize(enableDbCache ? DEFAULT_CACHE_SIZE_BYTES : 0);
+        options.writeBufferSize(this.writeBufferSize); // (levelDb default: 8mb)
+        options.cacheSize(enableDbCache ? this.cacheSize : 0);
         options.paranoidChecks(true);
         options.verifyChecksums(true);
         options.maxOpenFiles(this.maxOpenFiles);

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -52,10 +52,35 @@ import java.util.Set;
  */
 public class LevelDB extends AbstractDB {
 
+    private final int maxOpenFiles;
+    private final int blockSize;
+
     private DB db;
 
-    public LevelDB(String name, String path, boolean enableCache, boolean enableCompression) {
+    public LevelDB(String name,
+                   String path,
+                   boolean enableCache,
+                   boolean enableCompression,
+                   int maxOpenFiles,
+                   int blockSize) {
         super(name, path, enableCache, enableCompression);
+        this.maxOpenFiles = maxOpenFiles;
+        this.blockSize = blockSize;
+    }
+
+    /**
+     * <p>Original constructor for LevelDB, to keep compatibility with tests, for
+     * future use the user should set the {@link #maxOpenFiles} and {@link #blockSize}
+     * directly.</p>
+     *
+     * <p>Note: the values set in this constructor are not optimal, only historical.</p>
+     */
+    @Deprecated
+    public LevelDB(String name,
+                   String path,
+                   boolean enableCache,
+                   boolean enableCompression) {
+        this(name, path, enableCache, enableCompression, LevelDBConstants.MAX_OPEN_FILES, LevelDBConstants.BLOCK_SIZE);
     }
 
     @Override
@@ -68,12 +93,12 @@ public class LevelDB extends AbstractDB {
 
         options.createIfMissing(true);
         options.compressionType(enableDbCompression ? CompressionType.SNAPPY : CompressionType.NONE);
-        options.blockSize(10 * 1024 * 1024);
+        options.blockSize(this.blockSize);
         options.writeBufferSize(DEFAULT_WRITE_BUFFER_SIZE_BYTES); // (levelDb default: 8mb)
         options.cacheSize(enableDbCache ? DEFAULT_CACHE_SIZE_BYTES : 0);
         options.paranoidChecks(true);
         options.verifyChecksums(true);
-        options.maxOpenFiles(32);
+        options.maxOpenFiles(this.maxOpenFiles);
 
         return options;
     }

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBConstants.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBConstants.java
@@ -8,6 +8,8 @@ public class LevelDBConstants {
 
     public static int MAX_OPEN_FILES = 1024;
     public static int BLOCK_SIZE = 4096;
+    public static int WRITE_BUFFER_SIZE = 128 * 1024 * 1024;
+    public static int CACHE_SIZE = 16 * 1024 * 1024;
 
     private LevelDBConstants() {}
 }

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBConstants.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBConstants.java
@@ -8,8 +8,8 @@ public class LevelDBConstants {
 
     public static int MAX_OPEN_FILES = 1024;
     public static int BLOCK_SIZE = 4096;
-    public static int WRITE_BUFFER_SIZE = 128 * 1024 * 1024;
-    public static int CACHE_SIZE = 16 * 1024 * 1024;
+    public static int WRITE_BUFFER_SIZE = 16 * 1024 * 1024;
+    public static int CACHE_SIZE = 128 * 1024 * 1024;
 
     private LevelDBConstants() {}
 }

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBConstants.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBConstants.java
@@ -1,0 +1,13 @@
+package org.aion.db.impl.leveldb;
+
+/**
+ * Constants for LevelDB implementation, used as fallback
+ * when nothing else matches
+ */
+public class LevelDBConstants {
+
+    public static int MAX_OPEN_FILES = 1024;
+    public static int BLOCK_SIZE = 4096;
+
+    private LevelDBConstants() {}
+}

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBWithCache.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBWithCache.java
@@ -46,11 +46,20 @@ public class LevelDBWithCache extends AbstractDatabaseWithCache {
                             String max_cache_size,
                             boolean enableStats,
                             int maxOpenFiles,
-                            int blockSize) {
+                            int blockSize,
+                            int writeBufferSize,
+                            int cacheSize) {
         // when to commit is directed by this implementation
         super(enableAutoCommit, max_cache_size, enableStats);
         // the underlying database will always commit
-        database = new LevelDB(name, path, enableCache, enableCompression, maxOpenFiles, blockSize);
+        database = new LevelDB(name,
+                path,
+                enableCache,
+                enableCompression,
+                maxOpenFiles,
+                blockSize,
+                writeBufferSize,
+                cacheSize);
     }
 
     public LevelDBWithCache(String name,
@@ -60,7 +69,16 @@ public class LevelDBWithCache extends AbstractDatabaseWithCache {
                             boolean enableAutoCommit,
                             String max_cache_size,
                             boolean enableStats) {
-        this(name, path, enableCache, enableCompression, enableAutoCommit,
-                max_cache_size, enableStats, 32, 10 * 1024 * 1024);
+        this(   name,
+                path,
+                enableCache,
+                enableCompression,
+                enableAutoCommit,
+                max_cache_size,
+                enableStats,
+                LevelDBConstants.MAX_OPEN_FILES,
+                LevelDBConstants.BLOCK_SIZE,
+                LevelDBConstants.WRITE_BUFFER_SIZE,
+                LevelDBConstants.CACHE_SIZE);
     }
 }

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBWithCache.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDBWithCache.java
@@ -38,11 +38,29 @@ import org.aion.db.impl.AbstractDatabaseWithCache;
 
 public class LevelDBWithCache extends AbstractDatabaseWithCache {
 
-    public LevelDBWithCache(String name, String path, boolean enableCache, boolean enableCompression,
-            boolean enableAutoCommit, String max_cache_size, boolean enableStats) {
+    public LevelDBWithCache(String name,
+                            String path,
+                            boolean enableCache,
+                            boolean enableCompression,
+                            boolean enableAutoCommit,
+                            String max_cache_size,
+                            boolean enableStats,
+                            int maxOpenFiles,
+                            int blockSize) {
         // when to commit is directed by this implementation
         super(enableAutoCommit, max_cache_size, enableStats);
         // the underlying database will always commit
-        database = new LevelDB(name, path, enableCache, enableCompression);
+        database = new LevelDB(name, path, enableCache, enableCompression, maxOpenFiles, blockSize);
+    }
+
+    public LevelDBWithCache(String name,
+                            String path,
+                            boolean enableCache,
+                            boolean enableCompression,
+                            boolean enableAutoCommit,
+                            String max_cache_size,
+                            boolean enableStats) {
+        this(name, path, enableCache, enableCompression, enableAutoCommit,
+                max_cache_size, enableStats, 32, 10 * 1024 * 1024);
     }
 }

--- a/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
@@ -70,6 +70,9 @@ public class DatabaseFactoryTest {
         props.setProperty("db_type", DBVendor.LEVELDB.toValue());
         props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
         props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
+
         db = DatabaseFactory.connect(props);
         // System.out.println(db.getClass().getName());
         assertNotNull(db);

--- a/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
@@ -35,6 +35,7 @@
 package org.aion.db.impl;
 
 import org.aion.base.db.IByteArrayKeyValueDatabase;
+import org.aion.db.impl.leveldb.LevelDBConstants;
 import org.aion.db.impl.mockdb.MockDB;
 import org.aion.db.impl.mockdb.MockDBDriver;
 import org.junit.Test;
@@ -67,6 +68,8 @@ public class DatabaseFactoryTest {
 
         // LEVELDB
         props.setProperty("db_type", DBVendor.LEVELDB.toValue());
+        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
         db = DatabaseFactory.connect(props);
         // System.out.println(db.getClass().getName());
         assertNotNull(db);

--- a/modDbImpl/test/org/aion/db/impl/DatabaseTestUtils.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseTestUtils.java
@@ -71,8 +71,10 @@ public class DatabaseTestUtils {
         sharedProps.setProperty("enable_auto_commit", enabled);
         sharedProps.setProperty("max_heap_cache_size", "0");
         sharedProps.setProperty("max_heap_cache_size", disabled);
-        sharedProps.setProperty("max_fd_alloc_size", String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
-        sharedProps.setProperty("block_size", String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        sharedProps.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        sharedProps.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        sharedProps.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        sharedProps.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
 
         // all vendor options
         for (DBVendor vendor : vendors) {

--- a/modDbImpl/test/org/aion/db/impl/DatabaseTestUtils.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseTestUtils.java
@@ -35,6 +35,7 @@
 package org.aion.db.impl;
 
 import org.aion.db.impl.DBVendor;
+import org.aion.db.impl.leveldb.LevelDBConstants;
 
 import java.io.File;
 import java.util.*;
@@ -70,6 +71,8 @@ public class DatabaseTestUtils {
         sharedProps.setProperty("enable_auto_commit", enabled);
         sharedProps.setProperty("max_heap_cache_size", "0");
         sharedProps.setProperty("max_heap_cache_size", disabled);
+        sharedProps.setProperty("max_fd_alloc_size", String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        sharedProps.setProperty("block_size", String.valueOf(LevelDBConstants.BLOCK_SIZE));
 
         // all vendor options
         for (DBVendor vendor : vendors) {

--- a/modDbImpl/test/org/aion/db/impl/leveldb/LevelDBDriverTest.java
+++ b/modDbImpl/test/org/aion/db/impl/leveldb/LevelDBDriverTest.java
@@ -64,6 +64,8 @@ public class LevelDBDriverTest {
         props.setProperty("db_path", dbPath);
         props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
         props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNotNull(db);

--- a/modDbImpl/test/org/aion/db/impl/leveldb/LevelDBDriverTest.java
+++ b/modDbImpl/test/org/aion/db/impl/leveldb/LevelDBDriverTest.java
@@ -62,6 +62,8 @@ public class LevelDBDriverTest {
         props.setProperty("db_type", dbVendor);
         props.setProperty("db_name", dbName);
         props.setProperty("db_path", dbPath);
+        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNotNull(db);
@@ -81,7 +83,6 @@ public class LevelDBDriverTest {
     }
 
     // TODO: parametrize tests with null inputs
-
     @Test(expected = NullPointerException.class)
     public void testCreateWithNullName() {
         new LevelDB(null, dbPath, false, false);

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -44,8 +44,8 @@ public class CfgDb {
 
     public final int MIN_FD_OPEN_ALLOC = 1024;
     public final String DEFAULT_BLOCK_SIZE = "16kB";
-    public final String DEFAULT_WRITE_BUFFER_SIZE = "128mB";
-    public final String DEFAULT_CACHE_SIZE = "16mB";
+    public final String DEFAULT_WRITE_BUFFER_SIZE = "16mB";
+    public final String DEFAULT_CACHE_SIZE = "128mB";
 
     public CfgDb() {
         this.vendor = DBVendor.LEVELDB.toValue();
@@ -64,10 +64,10 @@ public class CfgDb {
         this.max_fd_open_alloc = MIN_FD_OPEN_ALLOC;
 
         // corresponds to DEFAULT_WRITE_BUFFER_SIZE
-        this.write_buffer_size = 128 * (int) Utils.MEGA_BYTE;
+        this.write_buffer_size = 16 * (int) Utils.MEGA_BYTE;
 
         // corresponds to DEFAULT_CACHE_SIZE
-        this.cache_size = 16 * (int) Utils.MEGA_BYTE;
+        this.cache_size = 128 * (int) Utils.MEGA_BYTE;
     }
 
     protected String path;

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -27,16 +27,23 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.aion.base.util.Utils;
 import org.aion.db.impl.DBVendor;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author chris
  */
 public class CfgDb {
+
+    public final int MIN_FD_OPEN_ALLOC = 1024;
+    public final String DEFAULT_BLOCK_SIZE = "4kB";
 
     public CfgDb() {
         this.vendor = DBVendor.LEVELDB.toValue();
@@ -49,6 +56,8 @@ public class CfgDb {
         // size 0 means unbound
         this.max_heap_cache_size = "1024";
         this.enable_heap_cache_stats = false;
+        this.block_size = 16 * (int) Utils.MEGA_BYTE;
+        this.max_fd_open_alloc = MIN_FD_OPEN_ALLOC;
     }
 
     protected String path;
@@ -63,6 +72,22 @@ public class CfgDb {
     private String max_heap_cache_size;
     private boolean enable_heap_cache_stats;
 
+    /**
+     * <p>The maximum block size</p>
+     *
+     * <p>This parameter is specific to {@link org.aion.db.impl.leveldb.LevelDB}</p>
+     */
+    private int block_size;
+
+    /**
+     * <p>The maximum allocated file descriptor that will be allocated per
+     * database, therefore the total amount of file descriptors that are required is
+     * {@code NUM_DB * max_fd_open_alloc}
+     *
+     * This parameter is specified to {@link org.aion.db.impl.leveldb.LevelDB}</p>
+     */
+    private int max_fd_open_alloc;
+
     public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
         loop:
         while (sr.hasNext()) {
@@ -71,30 +96,49 @@ public class CfgDb {
             case XMLStreamReader.START_ELEMENT:
                 String elementName = sr.getLocalName().toLowerCase();
                 switch (elementName) {
-                case "path":
-                    this.path = Cfg.readValue(sr);
-                    break;
-                case "vendor":
-                    this.vendor = Cfg.readValue(sr);
-                    break;
-                case "enable_auto_commit":
-                    this.enable_auto_commit = Boolean.parseBoolean(Cfg.readValue(sr));
-                    break;
-                case "enable_db_cache":
-                    this.enable_db_cache = Boolean.parseBoolean(Cfg.readValue(sr));
-                    break;
-                case "enable_db_compression":
-                    this.enable_db_compression = Boolean.parseBoolean(Cfg.readValue(sr));
-                    break;
-                case "enable_heap_cache":
-                    this.enable_heap_cache = Boolean.parseBoolean(Cfg.readValue(sr));
-                    break;
-                case "max_heap_cache_size":
-                    this.max_heap_cache_size = Cfg.readValue(sr);
-                    break;
-                case "enable_heap_cache_stats":
-                    this.enable_heap_cache_stats = Boolean.parseBoolean(Cfg.readValue(sr));
-                    break;
+                    case "path":
+                        this.path = Cfg.readValue(sr);
+                        break;
+                    case "vendor":
+                        this.vendor = Cfg.readValue(sr);
+                        break;
+                    case "enable_auto_commit":
+                        this.enable_auto_commit = Boolean.parseBoolean(Cfg.readValue(sr));
+                        break;
+                    case "enable_db_cache":
+                        this.enable_db_cache = Boolean.parseBoolean(Cfg.readValue(sr));
+                        break;
+                    case "enable_db_compression":
+                        this.enable_db_compression = Boolean.parseBoolean(Cfg.readValue(sr));
+                        break;
+                    case "enable_heap_cache":
+                        this.enable_heap_cache = Boolean.parseBoolean(Cfg.readValue(sr));
+                        break;
+                    case "max_heap_cache_size":
+                        this.max_heap_cache_size = Cfg.readValue(sr);
+                        break;
+                    case "enable_heap_cache_stats":
+                        this.enable_heap_cache_stats = Boolean.parseBoolean(Cfg.readValue(sr));
+                        break;
+                    case "block_size": {
+                        Optional<Long> maybeSize = Utils.parseSize(Cfg.readValue(sr));
+                        // TODO: ideally we should log out a message indicating we failed to parse
+                        if (maybeSize.isPresent()) {
+                            long s = maybeSize.get();
+
+                            // check for overflow
+                            // TODO: this is very non-descriptive behaviour, need to doc this properly
+                            if (s > Integer.MAX_VALUE)
+                                break;
+                            this.block_size = (int) s;
+                        }
+                        break;
+                    }
+                    case "max_fd_open_alloc": {
+                        int i = Integer.parseInt(Cfg.readValue(sr));
+                        this.max_fd_open_alloc = Math.max(MIN_FD_OPEN_ALLOC, i);
+                        break;
+                    }
                 default:
                     Cfg.skipElement(sr);
                     break;
@@ -156,6 +200,16 @@ public class CfgDb {
             xmlWriter.writeCharacters(String.valueOf(this.isHeapCacheStatsEnabled()));
             xmlWriter.writeEndElement();
 
+            xmlWriter.writeCharacters("\r\n\t\t");
+            xmlWriter.writeStartElement("block_size");
+            xmlWriter.writeCharacters(DEFAULT_BLOCK_SIZE);
+            xmlWriter.writeEndElement();
+
+            xmlWriter.writeCharacters("\r\n\t\t");
+            xmlWriter.writeStartElement("max_fd_open_alloc");
+            xmlWriter.writeCharacters(String.valueOf(MIN_FD_OPEN_ALLOC));
+            xmlWriter.writeEndElement();
+
             xmlWriter.writeCharacters("\r\n\t");
             xmlWriter.writeEndElement();
             xml = strWriter.toString();
@@ -204,6 +258,14 @@ public class CfgDb {
 
     public void setHeapCacheEnabled(boolean enable_heap_cache) {
         this.enable_heap_cache = enable_heap_cache;
+    }
+
+    public int getFdOpenAllocSize() {
+        return this.max_fd_open_alloc;
+    }
+
+    public int getBlockSize() {
+        return this.block_size;
     }
 }
 

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -67,7 +67,7 @@ public class CfgDb {
         this.write_buffer_size = 128 * (int) Utils.MEGA_BYTE;
 
         // corresponds to DEFAULT_CACHE_SIZE
-        this.cache_size = 128 * (int) Utils.MEGA_BYTE;
+        this.cache_size = 16 * (int) Utils.MEGA_BYTE;
     }
 
     protected String path;
@@ -326,6 +326,14 @@ public class CfgDb {
 
     public int getBlockSize() {
         return this.block_size;
+    }
+
+    public int getWriteBufferSize() {
+        return this.write_buffer_size;
+    }
+
+    public int getCacheSize() {
+        return this.cache_size;
     }
 }
 

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
 public class CfgDb {
 
     public final int MIN_FD_OPEN_ALLOC = 1024;
-    public final String DEFAULT_BLOCK_SIZE = "4kB";
+    public final String DEFAULT_BLOCK_SIZE = "16kB";
 
     public CfgDb() {
         this.vendor = DBVendor.LEVELDB.toValue();
@@ -56,7 +56,7 @@ public class CfgDb {
         // size 0 means unbound
         this.max_heap_cache_size = "1024";
         this.enable_heap_cache_stats = false;
-        this.block_size = 16 * (int) Utils.MEGA_BYTE;
+        this.block_size = 16 * (int) Utils.KILO_BYTE;
         this.max_fd_open_alloc = MIN_FD_OPEN_ALLOC;
     }
 

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -134,7 +134,7 @@ public class CfgDb {
                         }
                         break;
                     }
-                    case "max_fd_open_alloc": {
+                    case "max_fd_alloc_size": {
                         int i = Integer.parseInt(Cfg.readValue(sr));
                         this.max_fd_open_alloc = Math.max(MIN_FD_OPEN_ALLOC, i);
                         break;
@@ -206,7 +206,7 @@ public class CfgDb {
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("max_fd_open_alloc");
+            xmlWriter.writeStartElement("max_fd_alloc_size");
             xmlWriter.writeCharacters(String.valueOf(MIN_FD_OPEN_ALLOC));
             xmlWriter.writeEndElement();
 

--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -152,6 +152,8 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
 //                            + "\".\nPlease select a driver from the following vendor list: " + vendorListString);
         }
 
+        // TODO: these parameters should be converted to enum
+        // should correspond with those listed in {@code DatabaseFactory}
         Properties sharedProps = new Properties();
         sharedProps.setProperty("db_type", this.cfg.getActiveVendor());
         sharedProps.setProperty("db_path", this.cfg.getDbPath());
@@ -161,6 +163,8 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
         sharedProps.setProperty("enable_heap_cache", String.valueOf(this.cfg.isHeapCacheEnabled()));
         sharedProps.setProperty("max_heap_cache_size", this.cfg.getMaxHeapCacheSize());
         sharedProps.setProperty("enable_heap_cache_stats", String.valueOf(this.cfg.isHeapCacheStatsEnabled()));
+        sharedProps.setProperty("max_fd_alloc_size", String.valueOf(this.cfg.getMaxFdAllocSize()));
+        sharedProps.setProperty("block_size", String.valueOf(this.cfg.getBlockSize()));
 
         try {
             databaseGroup = new ArrayList<>();

--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -165,6 +165,8 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
         sharedProps.setProperty("enable_heap_cache_stats", String.valueOf(this.cfg.isHeapCacheStatsEnabled()));
         sharedProps.setProperty("max_fd_alloc_size", String.valueOf(this.cfg.getMaxFdAllocSize()));
         sharedProps.setProperty("block_size", String.valueOf(this.cfg.getBlockSize()));
+        sharedProps.setProperty("write_buffer_size", String.valueOf(this.cfg.getWriteBufferSize()));
+        sharedProps.setProperty("cache_size", String.valueOf(this.cfg.getCacheSize()));
 
         try {
             databaseGroup = new ArrayList<>();


### PR DESCRIPTION
This PR will apply the changes noted in #284 , we still need to benchmark the DB. Please do not close the issue yet as there are still some refinements that must be placed, namely:

* Proper handling of parse errors (currently they are silently ignored)
* Proper tuning of LevelDB

**Subtleties to note**, with this change, old config files will be missing four entires:

* ``max_fd_alloc_size``
* ``block_size``
* ``write_buffer_size``
* ``cache_size``

These should be set in the ``db`` portion of the config. Refer to the default config file in ``modBoot/resource/config.xml``

In the absence of these two parameters, ``CfgDb`` will attempt to use default values:
* max_fd_alloc_size = 1024
* block_size = 16kB (16 * 1024)
* write_buffer_size = 128mB
* cache_size = 16mB

These two values may not be the optimal, I have not tuned them yet! So please set these parameters when you update. Recall that the original parameters were:

* max_fd_alloc_size = 32
* block_size = 10mB (10 * 1024 * 1024)
* write_buffer_size = 128mB
* cache_size = 16mB

**NOTE:** it is imperative that you don't make syntax errors, otherwise the config file (atleast right now) will silently default to a predefined value.