### PR TITLE
bugfix: only inserts should be pushed to disk

### DIFF
--- a/modMcf/src/org/aion/mcf/trie/Cache.java
+++ b/modMcf/src/org/aion/mcf/trie/Cache.java
@@ -164,9 +164,9 @@ public class Cache {
                 // batchMemorySize += length(key, value);
             }
         }
-        for (ByteArrayWrapper removedNode : removedNodes) {
+        /* for (ByteArrayWrapper removedNode : removedNodes) {
             batch.put(removedNode.getData(), null);
-        }
+        } */
 
         this.dataSource.putBatch(batch);
         this.isDirty = false;


### PR DESCRIPTION
the JournalPruneDataSource used to filter out delete updates