### PR TITLE
commented out nrg oracle and pending receipts

### DIFF
--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -64,7 +64,7 @@ import java.util.stream.Collectors;
 import static org.aion.evtmgr.impl.evt.EventTx.STATE.GETSTATE;
 
 public abstract class ApiAion extends Api {
-    protected NrgOracle nrgOracle;
+    //protected NrgOracle nrgOracle;
     protected IAionChain ac;
     protected final static short FLTRS_MAX = 1024;
     protected final long DEFAULT_NRG_LIMIT = 500_000L;
@@ -619,7 +619,8 @@ public abstract class ApiAion extends Api {
     }
 
     public long getRecommendedNrgPrice() {
-        return this.nrgOracle.getNrgPrice();
+        return CfgAion.inst().getApi().getNrg().getNrgPriceDefault();
+        //return this.nrgOracle.getNrgPrice();
     }
 
     public long getDefaultNrgLimit() {

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -137,13 +137,14 @@ final class ApiWeb3Aion extends ApiAion implements IRpc {
             txHr.eventCallback(new EventCallback(ees, LOG));
         }
 
+        /*
         // instantiate nrg price oracle
         IAionBlockchain bc = (IAionBlockchain)_ac.getBlockchain();
         IHandler hldr = evtMgr.getHandler(IHandler.TYPE.BLOCK0.getValue());
         long nrgPriceDefault = CfgAion.inst().getApi().getNrg().getNrgPriceDefault();
         long nrgPriceMax = CfgAion.inst().getApi().getNrg().getNrgPriceMax();
         this.nrgOracle = new NrgOracle(bc, hldr, nrgPriceDefault, nrgPriceMax);
-
+        */
     }
 
     // --------------------------------------------------------------------
@@ -479,12 +480,14 @@ final class ApiWeb3Aion extends ApiAion implements IRpc {
     public Object eth_getTransactionReceipt(String _txHash) {
         byte[] txHash = TypeConverter.StringHexToByteArray(_txHash);
         TxRecpt r = getTransactionReceipt(txHash);
-
-        // if we can't find the receipt on the mainchain, try looking for it in pending receipts cache
+        /*
+        // Disable for now since our web3 client doesn't support this feature.
+        // If we can't find the receipt on the mainchain, try looking for it in pending receipts cache
         if (r == null) {
             AionTxReceipt pendingReceipt = pendingReceipts.get(new ByteArrayWrapper(txHash));
             r = new TxRecpt(pendingReceipt, null, null, null, true);
         }
+        */
 
         if (r == null) return null;
 
@@ -901,7 +904,7 @@ final class ApiWeb3Aion extends ApiAion implements IRpc {
     }
 
     void shutDown() {
-        nrgOracle.shutDown();
+        //nrgOracle.shutDown();
         shutDownES();
     }
 }


### PR DESCRIPTION
Some people reporting issues due to features:

* pending receipts breaks old web3 client
* NrgOracle causing some boot-time issues (critical), can't reproduce, so to be safe commenting it out since it's a non-critical feature. 