### PR TITLE
[SYNC] Add more information on failure

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.aion.base.util.ByteArrayWrapper;
+import org.aion.base.util.ByteUtil;
 import org.aion.base.util.Hex;
 import org.aion.mcf.valid.BlockHeaderValidator;
 import org.aion.zero.impl.blockchain.ChainConfiguration;
@@ -254,8 +255,8 @@ public final class SyncMgr {
                         _displayId,
                         current.getNumber(),
                         prev.getNumber() + 1,
-                        current.getParentHash(),
-                        prev.getHash());
+                        ByteUtil.toHexString(current.getParentHash()),
+                        ByteUtil.toHexString(prev.getHash()));
                 return;
             }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -250,7 +250,12 @@ public final class SyncMgr {
 
             // break if not consisting
             if(prev != null && (current.getNumber() != (prev.getNumber() + 1) || !Arrays.equals(current.getParentHash(), prev.getHash()))) {
-                log.debug("<inconsistent-block-headers>");
+                log.debug("<inconsistent-block-headers from={}, num={}, prev+1={}, p_hash={}, prev={}>",
+                        _displayId,
+                        current.getNumber(),
+                        prev.getNumber() + 1,
+                        current.getParentHash(),
+                        prev.getHash());
                 return;
             }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastNewBlockHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastNewBlockHandler.java
@@ -35,6 +35,7 @@
 
 package org.aion.zero.impl.sync.handler;
 
+import org.aion.base.util.ByteUtil;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Handler;
 import org.aion.p2p.Ver;
@@ -71,8 +72,15 @@ public final class BroadcastNewBlockHandler extends Handler {
         if (_msgBytes == null)
             return;
         byte[] rawdata = BroadcastNewBlock.decode(_msgBytes);
-        if (rawdata == null)
+        if (rawdata == null) {
+            log.error("<new-block-handler decode-error, from {} len: {}>",
+                    _displayId,
+                    _msgBytes.length);
+            if (log.isTraceEnabled()) {
+                log.trace("new-block-handler dump: {}", ByteUtil.toHexString(_msgBytes));
+            }
             return;
+        }
 
         AionBlock block = new AionBlock(rawdata);
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
@@ -35,6 +35,7 @@
 
 package org.aion.zero.impl.sync.handler;
 
+import org.aion.base.util.ByteUtil;
 import org.aion.mcf.blockchain.IPendingStateInternal;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Handler;
@@ -74,7 +75,16 @@ public final class BroadcastTxHandler extends Handler {
             return;
 
         List<byte[]> broadCastTx = BroadcastTx.decode(_msgBytes);
+
+        if (broadCastTx == null) {
+            log.error("<broadcast-tx decode-error unable to decode tx-list from {}, len: {]>", _displayId, _msgBytes.length);
+            if (log.isTraceEnabled()) {
+                log.trace("broadcast-tx dump: {}", ByteUtil.toHexString(_msgBytes));
+            }
+        }
+
         if (broadCastTx.isEmpty()) {
+            log.trace("<broadcast-tx from: {} empty>", _displayId);
             return;
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqBlocksBodiesHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqBlocksBodiesHandler.java
@@ -38,6 +38,7 @@ package org.aion.zero.impl.sync.handler;
 import java.util.*;
 
 import org.aion.base.util.ByteArrayWrapper;
+import org.aion.base.util.ByteUtil;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Handler;
 import org.aion.p2p.IP2pMgr;
@@ -107,7 +108,14 @@ public final class ReqBlocksBodiesHandler extends Handler {
             this.log.debug("<req-bodies req-size={} res-size={} node={}>", reqBlocks.getBlocksHashes().size(),
                     blockBodies.size(), _displayId);
 
-        } else
-            this.log.error("<req-bodies decode-msg>");
+        } else {
+            this.log.error("<req-bodies decode-error, unable to decode bodies from {}, len: {}>",
+                    _displayId,
+                    _msgBytes.length);
+
+            if (this.log.isTraceEnabled()) {
+                this.log.trace("req-bodies dump: {}", ByteUtil.toHexString(_msgBytes));
+            }
+        }
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqBlocksHeadersHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqBlocksHeadersHandler.java
@@ -88,7 +88,7 @@ public final class ReqBlocksHeadersHandler extends Handler {
             ResBlocksHeaders rbhs = new ResBlocksHeaders(headers);
             this.p2pMgr.send(_nodeIdHashcode, rbhs);
         } else
-            this.log.error("<req-headers decode-msg msg-bytes={} node={}>",
+            this.log.error("<req-headers decode-error msg-bytes={} node={}>",
                     _msgBytes == null ? 0 : _msgBytes.length, _nodeIdHashcode);
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
@@ -36,6 +36,8 @@
 package org.aion.zero.impl.sync.handler;
 
 import java.util.List;
+
+import org.aion.base.util.ByteUtil;
 import org.aion.p2p.Handler;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Ver;
@@ -67,7 +69,12 @@ public final class ResBlocksBodiesHandler extends Handler {
         ResBlocksBodies resBlocksBodies = ResBlocksBodies.decode(_msgBytes);
         List<byte[]> bodies = resBlocksBodies.getBlocksBodies();
         if(bodies == null) {
-            log.error("<res-bodies-invalid node={}>", _displayId);
+            log.error("<res-bodies decoder-error from {}, len: {]>", _displayId, _msgBytes.length);
+
+            if (log.isTraceEnabled()) {
+                log.trace("res-bodies dump: {}", ByteUtil.toHexString(_msgBytes));
+            }
+
         } else {
             if (bodies.isEmpty()) {
                 log.info("<res-bodies-empty node={}>", _displayId);

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksHeadersHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksHeadersHandler.java
@@ -36,6 +36,8 @@
 package org.aion.zero.impl.sync.handler;
 
 import java.util.List;
+
+import org.aion.base.util.ByteUtil;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Handler;
 import org.aion.p2p.Ver;
@@ -84,11 +86,16 @@ public final class ResBlocksHeadersHandler extends Handler {
                     _displayId
                 );
             }
-        } else
+        } else {
             this.log.error(
-                    "<res-headers decode-msg msg-bytes={} node={} >",
+                    "<res-headers decode-error msg-bytes={} node={}>",
                     _msgBytes.length,
                     _displayId
             );
+
+            if (this.log.isTraceEnabled()) {
+                this.log.trace("res-headers decode-error dump: {}", ByteUtil.toHexString(_msgBytes));
+            }
+        }
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
@@ -35,6 +35,7 @@
 
 package org.aion.zero.impl.sync.handler;
 
+import org.aion.base.util.ByteUtil;
 import org.aion.p2p.*;
 import org.slf4j.Logger;
 import org.aion.zero.impl.sync.SyncMgr;
@@ -66,6 +67,15 @@ public final class ResStatusHandler extends Handler {
         if (_msgBytes == null || _msgBytes.length == 0)
             return;
         ResStatus rs = ResStatus.decode(_msgBytes);
+
+        if (rs == null) {
+            this.log.debug("<res-status decode-error from {} len: {}>", _displayId, _msgBytes.length);
+
+            if (this.log.isTraceEnabled()) {
+                this.log.trace("res-status decode-error dump: {}", ByteUtil.toHexString(_msgBytes));
+            }
+        }
+
         INode node = this.p2pMgr.getActiveNodes().get(_nodeIdHashcode);
         this.p2pMgr.getNodeMgr().updateAllNodesInfo(node);
         if (node != null) {


### PR DESCRIPTION
This PR:

* Adds more logs onto sync failures, so we can debug the outputs

To enable these outputs, turn sync logs to ``TRACE``