### PR TITLE
splitting the compact from the -r functionality

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -129,6 +129,9 @@ public class Cli {
                         }
                     }
                     break;
+                case "--db-compact":
+                    RecoveryUtils.dbCompact();
+                    break;
                 case "-v":
                     System.out.println("\nVersion");
                     System.out.println("--------------------------------------------");

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -85,7 +85,6 @@ public class RecoveryUtils {
 
         IBlockStoreBase store = blockchain.getBlockStore();
 
-
         IBlock bestBlock = store.getBestBlock();
         if (bestBlock == null) {
             System.out.println("Empty database. Nothing to do.");
@@ -96,10 +95,32 @@ public class RecoveryUtils {
         store.pruneAndCorrect();
         store.flush();
 
-        // compact database after the changes were applied
-        blockchain.getRepository().compact();
-
         blockchain.getRepository().close();
+    }
+
+    /**
+     * Used by the CLI call.
+     */
+    public static void dbCompact() {
+        // ensure mining is disabled
+        CfgAion cfg = CfgAion.inst();
+        cfg.dbFromXML();
+        cfg.getConsensus().setMining(false);
+
+        cfg.getDb().setHeapCacheEnabled(false);
+
+        Map<String, String> cfgLog = new HashMap<>();
+        cfgLog.put("DB", "INFO");
+        cfgLog.put("GEN", "INFO");
+
+        AionLoggerFactory.init(cfgLog);
+
+        // get the current blockchain
+        AionRepositoryImpl repository = AionRepositoryImpl.inst();
+
+        // compact database after the changes were applied
+        repository.compact();
+        repository.close();
     }
 
     /**


### PR DESCRIPTION
The `./aion.sh -r` functionality walks through the main chain from the topmost block through links to parents till genesis. It removes the side chains and recomputes the total difficulty for each block. 

Because it deletes data from the database, a compact call is applied after the cleanup described above.

This PR separates the compact functionality from the block info cleanup. Now each can be called separately.
