### PR TITLE
Change syncing strategy

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -159,8 +159,9 @@ public class AionHub {
 				cfgNetP2p.getBootlistSyncOnly(), false, "", cfgNetP2p.getErrorTolerance());
 
 		this.syncMgr = SyncMgr.inst();
-		this.syncMgr.init(this.p2pMgr, this.eventMgr, this.cfg.getSync().getBlocksBackwardMax(),
-				this.cfg.getSync().getBlocksImportMax(), this.cfg.getSync().getBlocksQueueMax(),
+		this.syncMgr.init(this.p2pMgr, this.eventMgr,this.cfg.getSync().getBlocksBackwardMin(),
+				this.cfg.getSync().getBlocksBackwardMax(), this.cfg.getSync().getBlocksRequestMax(),
+				this.cfg.getSync().getBlocksResponseMax(), this.cfg.getSync().getBlocksQueueMax(),
 				this.cfg.getSync().getShowStatus(), this.cfg.getReports().isEnabled(), reportsFolder);
 
 		ChainConfiguration chainConfig = new ChainConfiguration();
@@ -183,9 +184,9 @@ public class AionHub {
         List<Handler> cbs = new ArrayList<>();
         cbs.add(new ReqStatusHandler(syncLog, this.blockchain, this.p2pMgr, cfg.getGenesis().getHash()));
         cbs.add(new ResStatusHandler(syncLog, this.p2pMgr, this.syncMgr));
-        cbs.add(new ReqBlocksHeadersHandler(syncLog, this.blockchain, this.p2pMgr, cfg.getSync().getBlocksImportMax()));
+        cbs.add(new ReqBlocksHeadersHandler(syncLog, this.blockchain, this.p2pMgr, cfg.getSync().getBlocksResponseMax()));
         cbs.add(new ResBlocksHeadersHandler(syncLog, this.syncMgr, this.p2pMgr));
-        cbs.add(new ReqBlocksBodiesHandler(syncLog, this.blockchain, this.p2pMgr, cfg.getSync().getBlocksImportMax()));
+        cbs.add(new ReqBlocksBodiesHandler(syncLog, this.blockchain, this.p2pMgr, cfg.getSync().getBlocksResponseMax()));
         cbs.add(new ResBlocksBodiesHandler(syncLog, this.syncMgr, this.p2pMgr));
         cbs.add(new BroadcastTxHandler(syncLog, this.mempool, this.p2pMgr));
         cbs.add(new BroadcastNewBlockHandler(syncLog, this.propHandler, this.p2pMgr));

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -63,10 +63,13 @@ public final class SyncMgr {
 
     private final static Logger log = AionLoggerFactory.getLogger(LogEnum.SYNC.name());
 
-    private int syncBackwardMax = 16;
-    private int syncImportMax = 32;
+    private int syncBackwardMin;
+    private int syncBackwardMax;
 
-    private int blocksQueueMax = 64; // block header wrappers
+    private int syncRequestMax;
+    private int syncResponseMax;
+
+    private int blocksQueueMax; // block header wrappers
 
     private AionBlockchainImpl chain;
 
@@ -176,13 +179,19 @@ public final class SyncMgr {
 //        }
     }
 
-    public void init(final IP2pMgr _p2pMgr, final IEventMgr _evtMgr, final int _syncBackwardMax, final int _syncImportMax,
-            final int _blocksQueueMax, final boolean _showStatus, final boolean _printReport, final String _reportFolder) {
+    public void init(final IP2pMgr _p2pMgr, final IEventMgr _evtMgr, final int _syncBackwardMin, final int _syncBackwardMax,
+                     final int _syncRequestMax, final int _syncResponseMax, final int _blocksQueueMax,
+                     final boolean _showStatus, final boolean _printReport, final String _reportFolder) {
         this.p2pMgr = _p2pMgr;
         this.chain = AionBlockchainImpl.inst();
         this.evtMgr = _evtMgr;
+
+        this.syncBackwardMin = _syncBackwardMin;
         this.syncBackwardMax = _syncBackwardMax;
-        this.syncImportMax = _syncImportMax;
+
+        this.syncRequestMax = _syncRequestMax;
+        this.syncResponseMax = _syncResponseMax;
+
         this.blocksQueueMax = _blocksQueueMax;
 
         this.blockHeaderValidator = new ChainConfiguration().createBlockHeaderValidator();
@@ -211,7 +220,8 @@ public final class SyncMgr {
             return;
         }
 
-        workers.submit(new TaskGetHeaders(p2pMgr, Math.max(1, this.chain.getBestBlock().getNumber() + 1 - syncBackwardMax), this.syncImportMax, _selfTd, log));
+        workers.submit(new TaskGetHeaders(p2pMgr, chain.getBestBlock().getNumber(), _selfTd,
+                syncBackwardMin, syncBackwardMax, syncRequestMax,  log));
     }
 
     /**

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
@@ -35,7 +35,9 @@ import org.aion.zero.impl.sync.msg.ReqBlocksHeaders;
 import org.slf4j.Logger;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 /**
@@ -45,48 +47,63 @@ final class TaskGetHeaders implements Runnable {
 
     private final IP2pMgr p2p;
 
-    private long fromBlock;
-
-    private final int syncMax;
+    private final long selfNumber;
 
     private final BigInteger selfTd;
 
+    private final int backwardMin;
+
+    private final int backwardMax;
+
+    private final int requestMax;
+
     private final Logger log;
 
-    TaskGetHeaders(final IP2pMgr _p2p, long _fromBlock, int _syncMax, BigInteger _selfTd, Logger log){
-        this.p2p = _p2p;
-        this.fromBlock = _fromBlock;
-        this.syncMax = _syncMax;
-        this.selfTd = _selfTd;
+    private final Random random = new Random(System.currentTimeMillis());
+
+    TaskGetHeaders(IP2pMgr p2p, long selfNumber, BigInteger selfTd,
+                   int backwardMin, int backwardMax, int requestMax, Logger log) {
+        this.p2p = p2p;
+        this.selfNumber = selfNumber;
+        this.selfTd = selfTd;
+        this.backwardMin = backwardMin;
+        this.backwardMax = backwardMax;
+        this.requestMax = requestMax;
         this.log = log;
     }
 
     @Override
     public void run() {
+        // get all active nodes
+        Collection<INode> nodes = this.p2p.getActiveNodes().values();
 
-        Set<Integer> ids = new HashSet<>();
-        Collection<INode> preFilter = this.p2p.getActiveNodes().values();
-
-        List<INode> filtered = preFilter.stream().filter(
+        // filter nodes by total difficulty
+        List<INode> nodesFiltered = nodes.stream().filter(
                 (n) -> n.getTotalDifficulty() != null &&
                         n.getTotalDifficulty().compareTo(this.selfTd) >= 0
         ).collect(Collectors.toList());
-
-        if (filtered.size() > 0) {
-            Random r = new Random(System.currentTimeMillis());
-            for (int i = 0; i < 2; i++) {
-                INode node = filtered.get(r.nextInt(filtered.size()));
-                if (!ids.contains(node.getIdHash())) {
-                    ids.add(node.getIdHash());
-                    ReqBlocksHeaders rbh = new ReqBlocksHeaders(this.fromBlock, this.syncMax);
-
-                    if (log.isDebugEnabled()) {
-                        log.debug("<get-headers from-num={} size={} node={}>", fromBlock, syncMax, node.getIdShort());
-                    }
-
-                    this.p2p.send(node.getIdHash(), rbh);
-                }
-            }
+        if (nodesFiltered.isEmpty()) {
+            return;
         }
+
+        // pick a random node
+        INode node = nodesFiltered.get(random.nextInt(nodesFiltered.size()));
+        long nodeNumber = node.getBestBlockNumber();
+        long from = 0;
+        if (nodeNumber >= selfNumber + 128) {
+            from = Math.max(1, selfNumber - backwardMin);
+        } else if (nodeNumber >= selfNumber - 128) {
+            from = Math.max(1, selfNumber - backwardMax);
+        } else {
+            // no need to request from this node. His TD is probably corrupted.
+            return;
+        }
+
+        // send request
+        if (log.isDebugEnabled()) {
+            log.debug("<get-headers from-num={} size={} node={}>", from, requestMax, node.getIdShort());
+        }
+        ReqBlocksHeaders rbh = new ReqBlocksHeaders(from, requestMax);
+        this.p2p.send(node.getIdHash(), rbh);
     }
 }

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -207,7 +207,10 @@ public abstract class ApiAion extends Api {
         SyncInfo sync = new SyncInfo();
         sync.done = this.ac.isSyncComplete();
         sync.chainStartingBlkNumber = this.ac.getInitialStartingBlockNumber().orElse(0L);
-        sync.blksImportMax = CfgAion.inst().getSync().getBlocksImportMax();
+        sync.blocksBackwardMin = CfgAion.inst().getSync().getBlocksBackwardMin();
+        sync.blocksBackwardMax = CfgAion.inst().getSync().getBlocksBackwardMax();
+        sync.blocksRequestMax = CfgAion.inst().getSync().getBlocksRequestMax();
+        sync.blocksResponseMax = CfgAion.inst().getSync().getBlocksResponseMax();
         sync.networkBestBlkNumber = this.ac.getNetworkBestBlockNumber().orElse(0L);
         sync.chainBestBlkNumber = this.ac.getLocalBestBlockNumber().orElse(0L);
         return sync;

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -262,7 +262,10 @@ public class ApiWeb3Aion extends ApiAion {
             obj.put("startingBlock", new NumericalValue(syncInfo.chainStartingBlkNumber).toHexString());
             obj.put("currentBlock", new NumericalValue(syncInfo.chainBestBlkNumber).toHexString());
             obj.put("highestBlock", new NumericalValue(syncInfo.networkBestBlkNumber).toHexString());
-            obj.put("importMax", new NumericalValue(syncInfo.blksImportMax).toHexString());
+            obj.put("blocksBackwardMin", new NumericalValue(syncInfo.blocksBackwardMin).toHexString());
+            obj.put("blocksBackwardMax", new NumericalValue(syncInfo.blocksBackwardMax).toHexString());
+            obj.put("blocksRequestMax", new NumericalValue(syncInfo.blocksRequestMax).toHexString());
+            obj.put("blocksResponseMax", new NumericalValue(syncInfo.blocksResponseMax).toHexString());
             return new RpcMsg(obj);
         } else {
             // create obj for when syncing is ongoing

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -909,7 +909,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             try {
                 Message.rsp_syncInfo rsp = Message.rsp_syncInfo.newBuilder().setChainBestBlock(sync.chainBestBlkNumber)
                         .setNetworkBestBlock(sync.networkBestBlkNumber).setSyncing(!sync.done)
-                        .setMaxImportBlocks(sync.blksImportMax).build();
+                        .setMaxImportBlocks(sync.blocksRequestMax).build();
 
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());

--- a/modApiServer/src/org/aion/api/server/types/SyncInfo.java
+++ b/modApiServer/src/org/aion/api/server/types/SyncInfo.java
@@ -34,6 +34,11 @@ public class SyncInfo {
 
     public long networkBestBlkNumber;
 
-    public int blksImportMax;
-    
+    public int blocksBackwardMin;
+
+    public int blocksBackwardMax;
+
+    public int blocksRequestMax;
+
+    public int blocksResponseMax;
 }

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -37,14 +37,23 @@
 			<port>30303</port>
 			<discover>false</discover>
 			<show-status>false</show-status>
+			<show-log>false</show-log>
 			<max-active-nodes>128</max-active-nodes>
 		</p2p>
 	</net>
 	<sync>
-		<blocks-backward-max>16</blocks-backward-max>
-		<blocks-import-max>32</blocks-import-max>
-		<blocks-queue-max>48</blocks-queue-max>
-		<show-status>true</show-status>
+		<!-- Min number of blocks to go backward -->
+		<blocks-backward-min>8</blocks-backward-min>
+		<!-- Max number of blocks to go backward -->
+		<blocks-backward-max>64</blocks-backward-max>
+		<!-- Max number of blocks to request -->
+		<blocks-request-max>96</blocks-request-max>
+		<!-- Max number of blocks to respond -->
+		<blocks-response-max>96</blocks-response-max>
+		<!-- Downloaded blocks queue limit. This affects memory footage -->
+		<blocks-queue-max>32</blocks-queue-max>
+		<!-- Display syncing status -->
+		<show-status>false</show-status>
 	</sync>
 	<consensus>
 		<mining>true</mining>

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -48,9 +48,7 @@
 		<blocks-backward-max>64</blocks-backward-max>
 		<!-- Max number of blocks to request -->
 		<blocks-request-max>96</blocks-request-max>
-		<!-- Max number of blocks to respond -->
-		<blocks-response-max>96</blocks-response-max>
-		<!-- Downloaded blocks queue limit. This affects memory footage -->
+		<!-- Downloaded blocks queue limit. This affects memory footprint -->
 		<blocks-queue-max>32</blocks-queue-max>
 		<!-- Display syncing status -->
 		<show-status>false</show-status>

--- a/modMcf/src/org/aion/mcf/config/CfgSync.java
+++ b/modMcf/src/org/aion/mcf/config/CfgSync.java
@@ -49,7 +49,7 @@ public final class CfgSync {
     private boolean showStatus;
 
     public CfgSync() {
-        this.blocksBackwardMax = 8;
+        this.blocksBackwardMin = 8;
         this.blocksBackwardMax = 64;
 
         this.blocksRequestMax = 96;

--- a/modMcf/src/org/aion/mcf/config/CfgSync.java
+++ b/modMcf/src/org/aion/mcf/config/CfgSync.java
@@ -38,18 +38,25 @@ import java.io.Writer;
  */
 public final class CfgSync {
 
+    private int blocksBackwardMin;
     private int blocksBackwardMax;
-    private int blocksImportMax;
+
+    private int blocksRequestMax;
+    private int blocksResponseMax;
 
     private int blocksQueueMax;
 
     private boolean showStatus;
 
     public CfgSync() {
-        this.blocksBackwardMax = 16;
-        this.blocksImportMax = 32;
+        this.blocksBackwardMax = 8;
+        this.blocksBackwardMax = 64;
+
+        this.blocksRequestMax = 96;
+        this.blocksResponseMax = 96;
 
         this.blocksQueueMax = 48;
+
         this.showStatus = false;
     }
 
@@ -61,11 +68,17 @@ public final class CfgSync {
             case XMLStreamReader.START_ELEMENT:
                 String elementName = sr.getLocalName().toLowerCase();
                 switch (elementName) {
+                case "blocks-backward-min":
+                    this.blocksBackwardMin = Integer.parseInt(Cfg.readValue(sr));
+                    break;
                 case "blocks-backward-max":
                     this.blocksBackwardMax = Integer.parseInt(Cfg.readValue(sr));
                     break;
-                case "blocks-import-max":
-                    this.blocksImportMax = Integer.parseInt(Cfg.readValue(sr));
+                case "blocks-request-max":
+                    this.blocksRequestMax = Integer.parseInt(Cfg.readValue(sr));
+                    break;
+                case "blocks-response-max":
+                    this.blocksResponseMax = Integer.parseInt(Cfg.readValue(sr));
                     break;
                 case "blocks-queue-max":
                     this.blocksQueueMax = Integer.parseInt(Cfg.readValue(sr));
@@ -96,16 +109,28 @@ public final class CfgSync {
             xmlWriter.writeCharacters("\r\n\t");
             xmlWriter.writeStartElement("sync");
 
+            // sub-element blocks-backward-min
+            xmlWriter.writeCharacters("\r\n\t\t");
+            xmlWriter.writeStartElement("blocks-backward-min");
+            xmlWriter.writeCharacters(this.getBlocksBackwardMin() + "");
+            xmlWriter.writeEndElement();
+
             // sub-element blocks-backward-max
             xmlWriter.writeCharacters("\r\n\t\t");
             xmlWriter.writeStartElement("blocks-backward-max");
             xmlWriter.writeCharacters(this.getBlocksBackwardMax() + "");
             xmlWriter.writeEndElement();
 
-            // sub-element blocks-import-max
+            // sub-element blocks-request-max
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("blocks-import-max");
-            xmlWriter.writeCharacters(this.getBlocksImportMax() + "");
+            xmlWriter.writeStartElement("blocks-request-max");
+            xmlWriter.writeCharacters(this.getBlocksBackwardMax() + "");
+            xmlWriter.writeEndElement();
+
+            // sub-element blocks-response-max
+            xmlWriter.writeCharacters("\r\n\t\t");
+            xmlWriter.writeStartElement("blocks-response-max");
+            xmlWriter.writeCharacters(this.getBlocksBackwardMax() + "");
             xmlWriter.writeEndElement();
 
             // sub-element blocks-queue-max
@@ -135,12 +160,20 @@ public final class CfgSync {
         }
     }
 
+    public int getBlocksBackwardMin() {
+        return this.blocksBackwardMin;
+    }
+
     public int getBlocksBackwardMax() {
         return this.blocksBackwardMax;
     }
 
-    public int getBlocksImportMax() {
-        return this.blocksImportMax;
+    public int getBlocksRequestMaxMax() {
+        return this.blocksRequestMax;
+    }
+
+    public int getBlocksResponseMaxMax() {
+        return this.blocksResponseMax;
     }
 
     public int getBlocksQueueMax() {

--- a/modMcf/src/org/aion/mcf/config/CfgSync.java
+++ b/modMcf/src/org/aion/mcf/config/CfgSync.java
@@ -168,11 +168,11 @@ public final class CfgSync {
         return this.blocksBackwardMax;
     }
 
-    public int getBlocksRequestMaxMax() {
+    public int getBlocksRequestMax() {
         return this.blocksRequestMax;
     }
 
-    public int getBlocksResponseMaxMax() {
+    public int getBlocksResponseMax() {
         return this.blocksResponseMax;
     }
 


### PR DESCRIPTION
New configuration:
```xml
<sync>
  <!-- Min number of blocks to go backward -->
  <blocks-backward-min>8</blocks-backward-min>
  <!-- Max number of blocks to go backward -->
  <blocks-backward-max>64</blocks-backward-max>
  <!-- Max number of blocks to request -->
  <blocks-request-max>96</blocks-request-max>
  <!-- Max number of blocks to respond -->
  <blocks-response-max>96</blocks-response-max>
  <!-- Downloaded blocks queue limit. This could affect memory usage -->
  <blocks-queue-max>32</blocks-queue-max>
  <!-- Display syncing status -->
  <show-status>false</show-status>
</sync>
```