### PR TITLE
heuristic for skipping tryToConnect for obviously large blocks

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.lang.Math.max;
@@ -470,6 +471,15 @@ public class AionBlockchainImpl implements IAionBlockchain {
         }
 
         return summary;
+    }
+
+    private AtomicLong bestBlockNumber = new AtomicLong(0L);
+
+    /**
+     * Heuristic for tryToConnect with large block.
+     */
+    public boolean skipTryToConnect(long blockNumber) {
+        return blockNumber - 1 > bestBlockNumber.get();
     }
 
     public synchronized ImportResult tryToConnect(final AionBlock block) {
@@ -1004,6 +1014,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
     public synchronized void setBestBlock(AionBlock block) {
         bestBlock = block;
         updateBestKnownBlock(block);
+        bestBlockNumber.set(bestBlock.getNumber());
     }
 
     @Override

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -476,10 +476,11 @@ public class AionBlockchainImpl implements IAionBlockchain {
     private AtomicLong bestBlockNumber = new AtomicLong(0L);
 
     /**
-     * Heuristic for tryToConnect with large block.
+     * Heuristic for skipping the call to tryToConnect with very large or very small block number.
      */
     public boolean skipTryToConnect(long blockNumber) {
-        return blockNumber - 1 > bestBlockNumber.get();
+        long current = bestBlockNumber.get();
+        return blockNumber > current + 32 || blockNumber < current - 32;
     }
 
     public synchronized ImportResult tryToConnect(final AionBlock block) {

--- a/modAionImpl/src/org/aion/zero/impl/core/IAionBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/core/IAionBlockchain.java
@@ -54,4 +54,9 @@ public interface IAionBlockchain
      *         otherwise
      */
     boolean recoverWorldState(IRepository repository, long blockNumber);
+
+    /**
+     * Heuristic for tryToConnect with large block.
+     */
+    boolean skipTryToConnect(long blockNumber);
 }

--- a/modAionImpl/src/org/aion/zero/impl/core/IAionBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/core/IAionBlockchain.java
@@ -56,7 +56,7 @@ public interface IAionBlockchain
     boolean recoverWorldState(IRepository repository, long blockNumber);
 
     /**
-     * Heuristic for tryToConnect with large block.
+     * Heuristic for skipping the call to tryToConnect with very large or very small block number.
      */
     boolean skipTryToConnect(long blockNumber);
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BlockPropagationHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BlockPropagationHandler.java
@@ -163,12 +163,18 @@ public class BlockPropagationHandler {
 
         // process
         long t1 = System.currentTimeMillis();
-        ImportResult result = this.blockchain.skipTryToConnect(block.getNumber()) ?
-                ImportResult.NO_PARENT :
-                this.blockchain.tryToConnect(block);
-        long t2 = System.currentTimeMillis();
-        log.info("<import-status: node = {}, number = {}, txs = {}, result = {}, time elapsed = {} ms>",
-                _displayId, block.getNumber(), block.getTransactionsList().size(), result, t2 - t1);
+        ImportResult result ;
+
+        if (this.blockchain.skipTryToConnect(block.getNumber())) {
+            result = ImportResult.NO_PARENT;
+            log.info("<import-status: node = {}, number = {}, txs = {}, result = NOT_CHECKED>", _displayId,
+                    block.getNumber(), block.getTransactionsList().size(), result);
+        } else {
+            result = this.blockchain.tryToConnect(block);
+            long t2 = System.currentTimeMillis();
+            log.info("<import-status: node = {}, number = {}, txs = {}, result = {}, time elapsed = {} ms>", _displayId,
+                    block.getNumber(), block.getTransactionsList().size(), result, t2 - t1);
+        }
 
         // process resulting state
         if (sent && result.isSuccessful())

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BlockPropagationHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BlockPropagationHandler.java
@@ -163,7 +163,9 @@ public class BlockPropagationHandler {
 
         // process
         long t1 = System.currentTimeMillis();
-        ImportResult result = this.blockchain.tryToConnect(block);
+        ImportResult result = this.blockchain.skipTryToConnect(block.getNumber()) ?
+                ImportResult.NO_PARENT :
+                this.blockchain.tryToConnect(block);
         long t2 = System.currentTimeMillis();
         log.info("<import-status: node = {}, number = {}, txs = {}, result = {}, time elapsed = {} ms>",
                 _displayId, block.getNumber(), block.getTransactionsList().size(), result, t2 - t1);


### PR DESCRIPTION
The p2p workers need not acquire locks on the blockchain to do `tryToConnect` when the block is obviously much larger and will return `NO_PARENT`.