### PR TITLE
pendingState and txpool refactor

### DIFF
--- a/modAionBase/src/org/aion/base/util/Utils.java
+++ b/modAionBase/src/org/aion/base/util/Utils.java
@@ -50,6 +50,8 @@ public class Utils {
 
     private static SecureRandom random = new SecureRandom();
 
+    public static final Object dummy = new Object();
+
     /**
      * @param number
      *            should be in form '0x34fabd34....'

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -675,68 +675,25 @@ public class AionPendingStateImpl
         }
     }
 
-//    @SuppressWarnings("unchecked")
-//    @Deprecated
-//    private void clearPending(IAionBlock block, List<AionTxReceipt> receipts) {
-//
-//        List<AionTransaction> txList = block.getTransactionsList();
-//
-//        if (LOG.isDebugEnabled()) {
-//            LOG.debug("clearPending block#[{}] tx#[{}]", block.getNumber(), txList.size());
-//        }
-//
-//        if (!txList.isEmpty()) {
-//            List<AionTransaction> txn = this.txPool.remove(txList);
-//
-//            int cnt = 0;
-//            for (AionTransaction tx : txn) {
-//                if (LOG.isTraceEnabled()) {
-//                    LOG.trace("Clear pending transaction, hash: [{}]", Hex.toHexString(tx.getHash()));
-//                }
-//
-//                AionTxReceipt receipt;
-//                if (receipts != null) {
-//                    receipt = receipts.get(cnt);
-//                } else {
-//                    AionTxInfo info = getTransactionInfo(tx.getHash(), block.getHash());
-//                    receipt = info.getReceipt();
-//                }
-//                fireTxUpdate(receipt, PendingTransactionState.INCLUDED, block);
-//                cnt++;
-//            }
-//        }
-//    }
-
     @SuppressWarnings("unchecked")
     private void clearPending(IAionBlock block, List<AionTxReceipt> receipts) {
 
-        List<AionTransaction> txList = block.getTransactionsList();
-        Map<Address, BigInteger> accountNonce = new HashMap<>();
-        if (txList != null) {
+        if (block.getTransactionsList() != null) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("clearPending block#[{}] tx#[{}]", block.getNumber(), txList.size());
+                LOG.debug("clearPending block#[{}] tx#[{}]", block.getNumber(), block.getTransactionsList().size());
             }
 
-            for (AionTransaction tx  : txList) {
+            Map<Address, BigInteger> accountNonce = new HashMap<>();
+            int cnt = 0;
+            for (AionTransaction tx  : block.getTransactionsList()) {
                 if (accountNonce.get(tx.getFrom()) != null) {
                     continue;
                 }
 
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("clear address {}", tx.getFrom().toString());
-                }
-
                 accountNonce.put(tx.getFrom(), this.repository.getNonce(tx.getFrom()));
-            }
-        }
 
-        if (!accountNonce.isEmpty()) {
-            this.txPool.remove(accountNonce);
-
-            int cnt = 0;
-            for (AionTransaction tx : txList) {
                 if (LOG.isTraceEnabled()) {
-                    LOG.trace("Clear pending transaction, hash: [{}]", Hex.toHexString(tx.getHash()));
+                    LOG.trace("Clear pending transaction, addr: {} hash: {}", tx.getFrom().toString(), Hex.toHexString(tx.getHash()));
                 }
 
                 AionTxReceipt receipt;
@@ -748,6 +705,10 @@ public class AionPendingStateImpl
                 }
                 fireTxUpdate(receipt, PendingTransactionState.INCLUDED, block);
                 cnt++;
+            }
+
+            if (!accountNonce.isEmpty()) {
+                this.txPool.remove(accountNonce);
             }
         }
     }

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -688,12 +688,10 @@ public class AionPendingStateImpl
             Map<Address, BigInteger> accountNonce = new HashMap<>();
             int cnt = 0;
             for (AionTransaction tx  : block.getTransactionsList()) {
-                if (accountNonce.get(tx.getFrom()) != null) {
-                    continue;
+                if (accountNonce.get(tx.getFrom()) == null) {
+                    accountNonce.put(tx.getFrom(), this.repository.getNonce(tx.getFrom()));
                 }
-
-                accountNonce.put(tx.getFrom(), this.repository.getNonce(tx.getFrom()));
-
+                
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Clear pending transaction, addr: {} hash: {}", tx.getFrom().toString(), Hex.toHexString(tx.getHash()));
                 }

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -219,8 +219,8 @@ public class AionPendingStateImpl
             // The BlockEnergyLimit will be updated when the best block found.
             prop.put(ITxPool.PROP_BLOCK_NRG_LIMIT, String.valueOf(CfgAion.inst().getConsensus().getEnergyStrategy().getUpperBound()));
             prop.put(ITxPool.PROP_BLOCK_SIZE_LIMIT, "16000000");
-            prop.put(ITxPool.PROP_TXN_TIMEOUT, "86400");
-            TxPoolModule txPoolModule = null;
+            prop.put(ITxPool.PROP_TX_TIMEOUT, "86400");
+            TxPoolModule txPoolModule;
             try {
                 txPoolModule = TxPoolModule.getSingleton(prop);
                 this.txPool = (ITxPool<AionTransaction>) txPoolModule.getTxPool();

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -85,6 +85,8 @@ public class AionPendingStateImpl
 
     private static final int MAX_VALIDATED_PENDING_TXS = 8192;
 
+    private final int MAX_TXCACHE_FLUSH_SIZE = MAX_VALIDATED_PENDING_TXS >> 2 ;
+
     private IAionBlockchain blockchain;
 
     private TransactionStore<AionTransaction, AionTxReceipt, AionTxInfo> transactionStore;
@@ -360,7 +362,7 @@ public class AionPendingStateImpl
                     int limit = 0;
                     Set<Address> addr = pendingTxCache.getCacheTxAccount();
                     if (!addr.isEmpty()) {
-                        limit = pendingTxCache.getTxRtnLimit() / addr.size();
+                        limit = MAX_TXCACHE_FLUSH_SIZE / addr.size();
 
                         if (limit == 0) {
                             limit = 1;

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -439,8 +439,8 @@ public class AionPendingStateImpl
         return newTx;
     }
 
-    private boolean inPool(BigInteger txNonce, AionTransaction tx) {
-        return (this.txPool.bestPoolNonce(tx.getFrom()).compareTo(txNonce) > -1);
+    private boolean inPool(BigInteger txNonce, Address from) {
+        return (this.txPool.bestPoolNonce(from).compareTo(txNonce) > -1);
     }
 
 
@@ -476,7 +476,7 @@ public class AionPendingStateImpl
         }
 
         AionTxExecSummary txSum;
-        boolean ip = inPool(txNonce, tx);
+        boolean ip = inPool(txNonce, tx.getFrom());
         if (ip) {
             // check energy usage
             AionTransaction poolTx = txPool.getPoolTx(tx.getFrom(), txNonce);

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
@@ -44,8 +44,6 @@ public class PendingTxCache {
     private AtomicInteger currentSize = new AtomicInteger(0);
     private int cacheAccountLimit = 100_000;
 
-    private final int txRtnLimit = 1000;
-
     PendingTxCache(final int cacheMax) {
         cacheTxMap = Collections.synchronizedMap(new LRUMap<>(cacheAccountLimit));
         PendingTxCache.CacheMax = cacheMax *100_000;
@@ -232,9 +230,5 @@ public class PendingTxCache {
         cacheTxMap.computeIfAbsent(from, k -> new TreeMap<>());
 
         return cacheTxMap.get(from);
-    }
-
-    public int getTxRtnLimit() {
-        return txRtnLimit;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
@@ -40,7 +40,7 @@ public class PendingTxCache {
 
     private Map<Address, TreeMap<BigInteger,AionTransaction>> cacheTxMap;
     protected static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.TX.name());
-    private static int CacheMax = 256*100_000; //256MB
+    private static int CacheMax = 256*100_000; //25.6MB
     private AtomicInteger currentSize = new AtomicInteger(0);
     private int cacheAccountLimit = 100_000;
 

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 public class PendingTxCache {
 
@@ -189,7 +190,7 @@ public class PendingTxCache {
             }
         }
 
-        Map<BigInteger, AionTransaction> timeMap = new TreeMap<>();
+        Map<BigInteger, AionTransaction> timeMap = new LinkedHashMap<>();
         for (TreeMap<BigInteger,AionTransaction> e : cacheTxMap.values()) {
             if (!e.isEmpty()) {
                 BigInteger ts = e.firstEntry().getValue().getTimeStampBI();
@@ -201,11 +202,7 @@ public class PendingTxCache {
             }
         }
 
-        for(AionTransaction tx : timeMap.values()) {
-            processableTx.add(tx);
-        }
-
-        return processableTx;
+        return timeMap.values().isEmpty() ? new ArrayList<>() : timeMap.values().stream().collect(Collectors.toList());
     }
     public boolean isInCache(Address addr , BigInteger nonce) {
         if (this.cacheTxMap.get(addr) != null) {

--- a/modAionImpl/src/org/aion/zero/impl/valid/TXValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/TXValidator.java
@@ -55,6 +55,10 @@ public class TXValidator {
         }
     }
 
+    public static boolean isInCache(ByteArrayWrapper hash) {
+        return cache.get(hash) != null;
+    }
+
     public static boolean isValid0(AionTransaction tx) {
         byte[] check = tx.getNonce();
         if (check == null || check.length > DataWord.BYTES) {

--- a/modMcf/src/org/aion/mcf/config/CfgTx.java
+++ b/modMcf/src/org/aion/mcf/config/CfgTx.java
@@ -36,7 +36,7 @@ import java.io.Writer;
 public class CfgTx {
 
     public CfgTx() {
-        this.cacheMax = 256;   // by MB;
+        this.cacheMax = 256;   // by 0.1M;
         this.buffer = false;
         this.poolDump =false;
     }

--- a/modMcf/src/org/aion/mcf/db/TransactionStore.java
+++ b/modMcf/src/org/aion/mcf/db/TransactionStore.java
@@ -39,10 +39,11 @@ import java.util.List;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static org.aion.base.util.Utils.dummy;
+
 public class TransactionStore<TX extends AbstractTransaction, TXR extends AbstractTxReceipt<TX>, INFO extends AbstractTxInfo<TXR, TX>>
         implements Flushable, Closeable {
     private final LRUMap<ByteArrayWrapper, Object> lastSavedTxHash = new LRUMap<>(5000);
-    private final Object object = new Object();
     private final ObjectDataSource<List<INFO>> source;
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
@@ -58,7 +59,7 @@ public class TransactionStore<TX extends AbstractTransaction, TXR extends Abstra
             byte[] txHash = tx.getReceipt().getTransaction().getHash();
 
             List<INFO> existingInfos = null;
-            if (lastSavedTxHash.put(new ByteArrayWrapper(txHash), object) != null || !lastSavedTxHash.isFull()) {
+            if (lastSavedTxHash.put(new ByteArrayWrapper(txHash), dummy) != null || !lastSavedTxHash.isFull()) {
                 existingInfos = source.get(txHash);
             }
 

--- a/modTxPool/src/org/aion/txpool/ITxPool.java
+++ b/modTxPool/src/org/aion/txpool/ITxPool.java
@@ -38,9 +38,10 @@ import java.util.Map;
  */
 public interface ITxPool<TX extends ITransaction> {
 
-    String PROP_TXN_TIMEOUT = "txn-timeout";
+    String PROP_TX_TIMEOUT = "tx-timeout";
     String PROP_BLOCK_SIZE_LIMIT = "blk-size-limit";
     String PROP_BLOCK_NRG_LIMIT = "blk-nrg-limit";
+    String PROP_TX_SEQ_MAX = "tx-seq-max";
 
     List<TX> add(List<TX> tx);
 

--- a/modTxPool/src/org/aion/txpool/ITxPool.java
+++ b/modTxPool/src/org/aion/txpool/ITxPool.java
@@ -70,4 +70,5 @@ public interface ITxPool<TX extends ITransaction> {
     List<TX> snapshotAll();
 
     TX getPoolTx(Address from, BigInteger txNonce);
+
 }

--- a/modTxPoolImpl/src/org/aion/txpool/common/AbstractTxPool.java
+++ b/modTxPoolImpl/src/org/aion/txpool/common/AbstractTxPool.java
@@ -55,7 +55,7 @@ public abstract class AbstractTxPool<TX extends ITransaction> {
     protected final int TXN_TIMEOUT_MAX = 86_400; // 1 day
     protected final int BLK_SIZE_MAX = 16_000_000; // 16MB
     protected final int BLK_SIZE_MIN = 1_000_000; // 1MB
-    protected final int BLK_NRG_MAX = 50_000_000;
+    protected final int BLK_NRG_MAX = 100_000_000;
     protected final int BLK_NRG_MIN = 1_000_000;
     protected final int SEQ_TX_MAX = 25;
     protected final int SEQ_TX_MIN = 5;

--- a/modTxPoolImpl/src/org/aion/txpool/common/AbstractTxPool.java
+++ b/modTxPoolImpl/src/org/aion/txpool/common/AbstractTxPool.java
@@ -137,18 +137,18 @@ public abstract class AbstractTxPool<TX extends ITransaction> {
         return this.poolStateView.get(acc);
     }
 
-    protected synchronized List<TX> getOutdatedListImpl() {
+    protected List<TX> getOutdatedListImpl() {
         List<TX> rtn = new ArrayList<>(this.outDated);
         this.outDated.clear();
 
         return rtn;
     }
 
-    protected synchronized void addOutDatedList(List<TX> txl) {
+    protected void addOutDatedList(List<TX> txl) {
         this.outDated.addAll(txl);
     }
 
-    public synchronized void clear() {
+    public void clear() {
         this.mainMap.clear();
         this.timeView.clear();
         this.feeView.clear();

--- a/modTxPoolImpl/src/org/aion/txpool/common/AbstractTxPool.java
+++ b/modTxPoolImpl/src/org/aion/txpool/common/AbstractTxPool.java
@@ -43,18 +43,22 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public abstract class AbstractTxPool<TX extends ITransaction> {
 
-    protected static final AtomicLong blkNrgLimit = new AtomicLong(10_000_000L);
-    protected static final int multiplyM = 1_000_000;
     protected static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.TXPOOL.toString());
-    private static final int SEQUENTAILTXNCOUNT_MAX = 25;
-    protected static long txn_timeout = 86_400; // 1 day by second
-    protected static int blkSizeLimit = 16_000_000; // 16MB
-    protected final long TXN_TIMEOUT_MIN = 10; // 10s
-    protected final long TXN_TIMEOUT_MAX = 86_400; // 1 day
+
+    protected int seqTxCountMax = 16;
+    protected int txn_timeout = 86_400; // 1 day by second
+    protected int blkSizeLimit = 16_000_000; // 16MB
+
+    protected final AtomicLong blkNrgLimit = new AtomicLong(10_000_000L);
+    protected final int multiplyM = 1_000_000;
+    protected final int TXN_TIMEOUT_MIN = 10; // 10s
+    protected final int TXN_TIMEOUT_MAX = 86_400; // 1 day
     protected final int BLK_SIZE_MAX = 16_000_000; // 16MB
     protected final int BLK_SIZE_MIN = 1_000_000; // 1MB
-    protected final long BLK_NRG_MAX = 50_000_000;
-    protected final long BLK_NRG_MIN = 1_000_000;
+    protected final int BLK_NRG_MAX = 50_000_000;
+    protected final int BLK_NRG_MIN = 1_000_000;
+    protected final int SEQ_TX_MAX = 25;
+    protected final int SEQ_TX_MIN = 5;
     /**
      * mainMap : Map<ByteArrayWrapper, TXState>
      *
@@ -315,7 +319,7 @@ public abstract class AbstractTxPool<TX extends ITransaction> {
                             // check the previous txn status in the old PoolState
                             if (isClean(ps, as)
                                     && ps.firstNonce.equals(txNonceStart)
-                                    && ps.combo == SEQUENTAILTXNCOUNT_MAX) {
+                                    && ps.combo == seqTxCountMax) {
                                 ps.resetInFeePool();
                                 newPoolState.add(ps);
 
@@ -323,7 +327,7 @@ public abstract class AbstractTxPool<TX extends ITransaction> {
                                     LOG.trace("AbstractTxPool.updateAccPoolState add fn [{}]", ps.firstNonce.toString());
                                 }
 
-                                txNonceStart = txNonceStart.add(BigInteger.valueOf(SEQUENTAILTXNCOUNT_MAX));
+                                txNonceStart = txNonceStart.add(BigInteger.valueOf(seqTxCountMax));
                             } else {
                                 // remove old poolState in the feeMap
                                 if (this.feeView.get(ps.getFee()) != null) {
@@ -359,7 +363,7 @@ public abstract class AbstractTxPool<TX extends ITransaction> {
                                 fee = en.getValue().getValue();
                                 totalFee = totalFee.add(fee);
 
-                                if (++cnt == SEQUENTAILTXNCOUNT_MAX) {
+                                if (++cnt == seqTxCountMax) {
                                     if (LOG.isTraceEnabled()) {
                                         LOG.trace(
                                                 "AbstractTxPool.updateAccPoolState case1 - nonce:[{}] totalFee:[{}] cnt:[{}]",

--- a/modTxPoolImpl/src/org/aion/txpool/zero/TxPoolA0.java
+++ b/modTxPoolImpl/src/org/aion/txpool/zero/TxPoolA0.java
@@ -52,8 +52,8 @@ public class TxPoolA0<TX extends ITransaction> extends AbstractTxPool<TX> implem
     }
 
     private void setPoolArgs(Properties config) {
-        if (Optional.ofNullable(config.get(PROP_TXN_TIMEOUT)).isPresent()) {
-            txn_timeout = Integer.valueOf(config.get(PROP_TXN_TIMEOUT).toString());
+        if (Optional.ofNullable(config.get(PROP_TX_TIMEOUT)).isPresent()) {
+            txn_timeout = Integer.valueOf(config.get(PROP_TX_TIMEOUT).toString());
             if (txn_timeout < TXN_TIMEOUT_MIN) {
                 txn_timeout = TXN_TIMEOUT_MIN;
             } else if (txn_timeout > TXN_TIMEOUT_MAX) {
@@ -73,8 +73,16 @@ public class TxPoolA0<TX extends ITransaction> extends AbstractTxPool<TX> implem
         }
 
         if (Optional.ofNullable(config.get(PROP_BLOCK_NRG_LIMIT)).isPresent()) {
-            long sz_limit = Long.valueOf((String) config.get(PROP_BLOCK_NRG_LIMIT));
-            updateBlkNrgLimit(sz_limit);
+            updateBlkNrgLimit(Long.valueOf((String) config.get(PROP_BLOCK_NRG_LIMIT)));
+        }
+
+        if (Optional.ofNullable(config.get(PROP_TX_SEQ_MAX)).isPresent()) {
+            seqTxCountMax = Integer.valueOf(config.get(PROP_TX_SEQ_MAX).toString());
+            if (seqTxCountMax < SEQ_TX_MIN) {
+                seqTxCountMax = SEQ_TX_MIN;
+            } else if (seqTxCountMax > SEQ_TX_MAX) {
+                seqTxCountMax = SEQ_TX_MAX;
+            }
         }
     }
 


### PR DESCRIPTION
1. add check Tx cached method in the TxValidator, all the Txs from network ( from BroadcastTxHandler) will check from the TxValidator cached map first then do validate.
2. take out all of the synchronize in txpool due to all of operation has been sync in the pendingState layer.
3. simplify addPendingTransactions method.
4. move dummy object to the module aionbase.