### PR TITLE
minor cleanup in the database module

### DIFF
--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -68,8 +68,6 @@
 	<db>
 		<path>database</path>
 		<vendor>leveldb</vendor>
-		<enable_heap_cache>false</enable_heap_cache>
-		<max_heap_cache_size>1024</max_heap_cache_size>
 		<enable_db_cache>true</enable_db_cache>
 		<enable_db_compression>false</enable_db_compression>
 		<max_fd_alloc_size>1024</max_fd_alloc_size>

--- a/modDbImpl/src/org/aion/db/impl/DatabaseFactory.java
+++ b/modDbImpl/src/org/aion/db/impl/DatabaseFactory.java
@@ -110,7 +110,8 @@ public abstract class DatabaseFactory {
         if (enableHeapCache) {
             return new LockedDatabase(connectWithCache(info));
         } else {
-            if (DBVendor.fromString(info.getProperty(PROP_DB_TYPE)) == DBVendor.LEVELDB) {
+            DBVendor vendor = DBVendor.fromString(info.getProperty(PROP_DB_TYPE));
+            if (vendor == DBVendor.LEVELDB || vendor == DBVendor.ROCKSDB) {
                 return new SpecialLockedDatabase(connectBasic(info));
             } else {
                 return new LockedDatabase(connectBasic(info));

--- a/modDbImpl/src/org/aion/db/impl/mockdb/MockDBDriver.java
+++ b/modDbImpl/src/org/aion/db/impl/mockdb/MockDBDriver.java
@@ -8,6 +8,8 @@ import org.slf4j.Logger;
 
 import java.util.Properties;
 
+import static org.aion.db.impl.DatabaseFactory.Props;
+
 /**
  * Mock implementation of a key value database using a ConcurrentHashMap as our
  * underlying implementation, mostly for testing, when the Driver API interface
@@ -22,17 +24,14 @@ public class MockDBDriver implements IDriver {
     private static final int MAJOR_VERSION = 1;
     private static final int MINOR_VERSION = 0;
 
-    private static final String PROP_DB_TYPE = "db_type";
-    private static final String PROP_DB_NAME = "db_name";
-
     /**
      * @inheritDoc
      */
     @Override
     public IByteArrayKeyValueDatabase connect(Properties info) {
 
-        String dbType = info.getProperty(PROP_DB_TYPE);
-        String dbName = info.getProperty(PROP_DB_NAME);
+        String dbType = info.getProperty(Props.DB_TYPE);
+        String dbName = info.getProperty(Props.DB_NAME);
 
         if (!dbType.equals(this.getClass().getName())) {
             LOG.error("Invalid dbType provided: {}", dbType);

--- a/modDbImpl/test/org/aion/db/impl/AccessWithExceptionTest.java
+++ b/modDbImpl/test/org/aion/db/impl/AccessWithExceptionTest.java
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import java.util.*;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.aion.db.impl.DatabaseFactory.Props.DB_NAME;
 
 @RunWith(JUnitParamsRunner.class)
 public class AccessWithExceptionTest {
@@ -89,7 +90,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testIsEmptyWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -101,7 +102,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testKeysWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -113,7 +114,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testGetWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -125,7 +126,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testPutWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -137,7 +138,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testDeleteWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -149,7 +150,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testPutBatchWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -166,7 +167,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testDeleteBatchWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -183,7 +184,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testCommitWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -196,7 +197,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testSizeWithClosedDatabase(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.isOpen()).isFalse();
 
@@ -208,7 +209,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testGetWithNullKey(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
 
@@ -220,7 +221,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testPutWithNullKey(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
 
@@ -232,7 +233,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testDeleteWithNullKey(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
 
@@ -244,7 +245,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testPutBatchWithNullKey(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
 
@@ -261,7 +262,7 @@ public class AccessWithExceptionTest {
     @Parameters(method = "databaseInstanceDefinitions")
     public void testDeleteBatchWithNullKey(Properties dbDef) {
         // create database
-        dbDef.setProperty("db_name", DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + DatabaseTestUtils.getNext());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
 

--- a/modDbImpl/test/org/aion/db/impl/ConcurrencyTest.java
+++ b/modDbImpl/test/org/aion/db/impl/ConcurrencyTest.java
@@ -43,6 +43,8 @@ import org.junit.runner.RunWith;
 import java.util.*;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.aion.db.impl.DatabaseFactory.Props.DB_NAME;
+import static org.aion.db.impl.DatabaseFactory.Props.ENABLE_LOCKING;
 import static org.aion.db.impl.DatabaseTestUtils.assertConcurrent;
 
 /**
@@ -93,7 +95,8 @@ public class ConcurrencyTest {
         return DatabaseTestUtils.unlockedDatabaseInstanceDefinitions();
     }
 
-    private void addThread4IsEmpty(List<Runnable> threads, IByteArrayKeyValueDatabase db) {
+    private void addThread4IsEmpty(List<Runnable> threads,
+                                   IByteArrayKeyValueDatabase db) {
         threads.add(() -> {
             boolean check = db.isEmpty();
             if (DISPLAY_MESSAGES) {
@@ -102,7 +105,8 @@ public class ConcurrencyTest {
         });
     }
 
-    private void addThread4Keys(List<Runnable> threads, IByteArrayKeyValueDatabase db) {
+    private void addThread4Keys(List<Runnable> threads,
+                                IByteArrayKeyValueDatabase db) {
         threads.add(() -> {
             Set<byte[]> keys = db.keys();
             if (DISPLAY_MESSAGES) {
@@ -111,7 +115,9 @@ public class ConcurrencyTest {
         });
     }
 
-    private void addThread4Get(List<Runnable> threads, IByteArrayKeyValueDatabase db, String key) {
+    private void addThread4Get(List<Runnable> threads,
+                               IByteArrayKeyValueDatabase db,
+                               String key) {
         threads.add(() -> {
             boolean hasValue = db.get(key.getBytes()).isPresent();
             if (DISPLAY_MESSAGES) {
@@ -121,21 +127,27 @@ public class ConcurrencyTest {
         });
     }
 
-    private void addThread4Put(List<Runnable> threads, IByteArrayKeyValueDatabase db, String key) {
+    private void addThread4Put(List<Runnable> threads,
+                               IByteArrayKeyValueDatabase db,
+                               String key) {
         threads.add(() -> {
             db.put(key.getBytes(), DatabaseTestUtils.randomBytes(32));
             if (DISPLAY_MESSAGES) { System.out.println(Thread.currentThread().getName() + ": " + key + " ADDED");}
         });
     }
 
-    private void addThread4Delete(List<Runnable> threads, IByteArrayKeyValueDatabase db, String key) {
+    private void addThread4Delete(List<Runnable> threads,
+                                  IByteArrayKeyValueDatabase db,
+                                  String key) {
         threads.add(() -> {
             db.delete(key.getBytes());
             if (DISPLAY_MESSAGES) {System.out.println(Thread.currentThread().getName() + ": " + key + " DELETED");}
         });
     }
 
-    private void addThread4PutBatch(List<Runnable> threads, IByteArrayKeyValueDatabase db, String key) {
+    private void addThread4PutBatch(List<Runnable> threads,
+                                    IByteArrayKeyValueDatabase db,
+                                    String key) {
         threads.add(() -> {
             Map<byte[], byte[]> map = new HashMap<>();
             map.put((key + 1).getBytes(), DatabaseTestUtils.randomBytes(32));
@@ -150,7 +162,9 @@ public class ConcurrencyTest {
         });
     }
 
-    private void addThread4DeleteBatch(List<Runnable> threads, IByteArrayKeyValueDatabase db, String key) {
+    private void addThread4DeleteBatch(List<Runnable> threads,
+                                       IByteArrayKeyValueDatabase db,
+                                       String key) {
         threads.add(() -> {
             List<byte[]> list = new ArrayList<>();
             list.add((key + 1).getBytes());
@@ -166,7 +180,8 @@ public class ConcurrencyTest {
 
     }
 
-    private void addThread4Open(List<Runnable> threads, IByteArrayKeyValueDatabase db) {
+    private void addThread4Open(List<Runnable> threads,
+                                IByteArrayKeyValueDatabase db) {
         threads.add(() -> {
             db.open();
             if (DISPLAY_MESSAGES) {
@@ -176,7 +191,8 @@ public class ConcurrencyTest {
 
     }
 
-    private void addThread4Close(List<Runnable> threads, IByteArrayKeyValueDatabase db) {
+    private void addThread4Close(List<Runnable> threads,
+                                 IByteArrayKeyValueDatabase db) {
         threads.add(() -> {
             db.close();
             if (DISPLAY_MESSAGES) {
@@ -186,7 +202,8 @@ public class ConcurrencyTest {
 
     }
 
-    private void addThread4Size(List<Runnable> threads, IByteArrayKeyValueDatabase db) {
+    private void addThread4Size(List<Runnable> threads,
+                                IByteArrayKeyValueDatabase db) {
         threads.add(() -> {
             long size = db.approximateSize();
             if (DISPLAY_MESSAGES) {
@@ -199,8 +216,8 @@ public class ConcurrencyTest {
     @Test
     @Parameters(method = "databaseInstanceDefinitions")
     public void testConcurrentAccessOnOpenDatabase(Properties dbDef) throws InterruptedException {
-        dbDef.setProperty(DatabaseFactory.PROP_DB_NAME, DatabaseTestUtils.dbName + getNext());
-        dbDef.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "true");
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + getNext());
+        dbDef.setProperty(ENABLE_LOCKING, "true");
         // open database
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
@@ -253,8 +270,8 @@ public class ConcurrencyTest {
     @Test
     @Parameters(method = "databaseInstanceDefinitions")
     public void testConcurrentPut(Properties dbDef) throws InterruptedException {
-        dbDef.setProperty(DatabaseFactory.PROP_DB_NAME, DatabaseTestUtils.dbName + getNext());
-        dbDef.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "true");
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + getNext());
+        dbDef.setProperty(ENABLE_LOCKING, "true");
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
 
@@ -279,8 +296,8 @@ public class ConcurrencyTest {
     @Test
     @Parameters(method = "databaseInstanceDefinitions")
     public void testConcurrentPutBatch(Properties dbDef) throws InterruptedException {
-        dbDef.setProperty(DatabaseFactory.PROP_DB_NAME, DatabaseTestUtils.dbName + getNext());
-        dbDef.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "true");
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + getNext());
+        dbDef.setProperty(ENABLE_LOCKING, "true");
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();
 
@@ -305,8 +322,8 @@ public class ConcurrencyTest {
     @Test
     @Parameters(method = "databaseInstanceDefinitions")
     public void testConcurrentUpdate(Properties dbDef) throws InterruptedException {
-        dbDef.setProperty(DatabaseFactory.PROP_DB_NAME, DatabaseTestUtils.dbName + getNext());
-        dbDef.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "true");
+        dbDef.setProperty(DB_NAME, DatabaseTestUtils.dbName + getNext());
+        dbDef.setProperty(ENABLE_LOCKING, "true");
         // open database
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(dbDef);
         assertThat(db.open()).isTrue();

--- a/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
@@ -51,6 +51,7 @@ import java.io.File;
 import java.util.Properties;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.aion.db.impl.DatabaseFactory.Props;
 import static org.junit.Assert.assertNull;
 
 public class DatabaseFactoryTest {
@@ -64,44 +65,44 @@ public class DatabaseFactoryTest {
     @Test
     public void testReturnBasicDatabase() {
         Properties props = new Properties();
-        props.setProperty(DatabaseFactory.PROP_DB_NAME, dbName + DatabaseTestUtils.getNext());
-        props.setProperty(DatabaseFactory.PROP_DB_PATH, dbPath);
+        props.setProperty(Props.DB_NAME, dbName + DatabaseTestUtils.getNext());
+        props.setProperty(Props.DB_PATH, dbPath);
 
         // MOCKDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.MOCKDB.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.MOCKDB.toValue());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(MockDB.class.getSimpleName());
 
         // LEVELDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.LEVELDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
-        props.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.LEVELDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
 
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(LevelDB.class.getSimpleName());
 
         // ROCKSDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.ROCKSDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.ROCKSDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
 
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(RocksDBWrapper.class.getSimpleName());
 
         // H2
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.H2.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.H2.toValue());
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(H2MVMap.class.getSimpleName());
 
         // MockDBDriver class
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, MockDBDriver.class.getName());
+        props.setProperty(Props.DB_TYPE, MockDBDriver.class.getName());
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(MockDB.class.getSimpleName());
@@ -110,48 +111,48 @@ public class DatabaseFactoryTest {
     @Test
     public void testReturnLockedDatabase() {
         Properties props = new Properties();
-        props.setProperty(DatabaseFactory.PROP_DB_NAME, dbName + DatabaseTestUtils.getNext());
-        props.setProperty(DatabaseFactory.PROP_DB_PATH, dbPath);
-        props.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "true");
+        props.setProperty(Props.DB_NAME, dbName + DatabaseTestUtils.getNext());
+        props.setProperty(Props.DB_PATH, dbPath);
+        props.setProperty(Props.ENABLE_LOCKING, "true");
 
         // MOCKDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.MOCKDB.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.MOCKDB.toValue());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(LockedDatabase.class.getSimpleName());
         assertThat(db.toString()).contains(MockDB.class.getSimpleName());
 
         // LEVELDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.LEVELDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
-        props.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.LEVELDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(SpecialLockedDatabase.class.getSimpleName());
         assertThat(db.toString()).contains(LevelDB.class.getSimpleName());
 
         // ROCKSDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.ROCKSDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.ROCKSDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(SpecialLockedDatabase.class.getSimpleName());
         assertThat(db.toString()).contains(RocksDBWrapper.class.getSimpleName());
 
         // H2
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.H2.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.H2.toValue());
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(LockedDatabase.class.getSimpleName());
         assertThat(db.toString()).contains(H2MVMap.class.getSimpleName());
 
         // DatabaseWithCache class
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.MOCKDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_ENABLE_HEAP_CACHE, "true");
+        props.setProperty(Props.DB_TYPE, DBVendor.MOCKDB.toValue());
+        props.setProperty(Props.ENABLE_HEAP_CACHE, "true");
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(LockedDatabase.class.getSimpleName());
@@ -161,20 +162,20 @@ public class DatabaseFactoryTest {
     @Test
     public void testReturnDatabaseWithCacheParameterSet1() {
         Properties props = new Properties();
-        props.setProperty(DatabaseFactory.PROP_DB_NAME, dbName + DatabaseTestUtils.getNext());
-        props.setProperty(DatabaseFactory.PROP_DB_PATH, dbPath);
-        props.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "false");
-        props.setProperty(DatabaseFactory.PROP_ENABLE_HEAP_CACHE, "true");
-        props.setProperty(DatabaseFactory.PROP_ENABLE_AUTO_COMMIT, "false");
-        props.setProperty(DatabaseFactory.PROP_MAX_HEAP_CACHE_SIZE, "20");
-        props.setProperty(DatabaseFactory.PROP_ENABLE_HEAP_CACHE_STATS, "true");
+        props.setProperty(Props.DB_NAME, dbName + DatabaseTestUtils.getNext());
+        props.setProperty(Props.DB_PATH, dbPath);
+        props.setProperty(Props.ENABLE_LOCKING, "false");
+        props.setProperty(Props.ENABLE_HEAP_CACHE, "true");
+        props.setProperty(Props.ENABLE_AUTO_COMMIT, "false");
+        props.setProperty(Props.MAX_HEAP_CACHE_SIZE, "20");
+        props.setProperty(Props.ENABLE_HEAP_CACHE_STATS, "true");
 
         String autoCmtCheck = "autocommit=OFF";
         String sizeCheck = "size<20";
         String statsCheck = "stats=ON";
 
         // MOCKDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.MOCKDB.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.MOCKDB.toValue());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -184,11 +185,11 @@ public class DatabaseFactoryTest {
         assertThat(db.toString()).contains(statsCheck);
 
         // LEVELDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.LEVELDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
-        props.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.LEVELDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -198,10 +199,10 @@ public class DatabaseFactoryTest {
         assertThat(db.toString()).contains(statsCheck);
 
         // ROCKSDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.ROCKSDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.ROCKSDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -210,9 +211,8 @@ public class DatabaseFactoryTest {
         assertThat(db.toString()).contains(sizeCheck);
         assertThat(db.toString()).contains(statsCheck);
 
-
         // H2
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.H2.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.H2.toValue());
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -225,20 +225,20 @@ public class DatabaseFactoryTest {
     @Test
     public void testReturnDatabaseWithCacheParameterSet2() {
         Properties props = new Properties();
-        props.setProperty(DatabaseFactory.PROP_DB_NAME, dbName + DatabaseTestUtils.getNext());
-        props.setProperty(DatabaseFactory.PROP_DB_PATH, dbPath);
-        props.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "false");
-        props.setProperty(DatabaseFactory.PROP_ENABLE_HEAP_CACHE, "true");
-        props.setProperty(DatabaseFactory.PROP_ENABLE_AUTO_COMMIT, "true");
-        props.setProperty(DatabaseFactory.PROP_MAX_HEAP_CACHE_SIZE, "0");
-        props.setProperty(DatabaseFactory.PROP_ENABLE_HEAP_CACHE_STATS, "false");
+        props.setProperty(Props.DB_NAME, dbName + DatabaseTestUtils.getNext());
+        props.setProperty(Props.DB_PATH, dbPath);
+        props.setProperty(Props.ENABLE_LOCKING, "false");
+        props.setProperty(Props.ENABLE_HEAP_CACHE, "true");
+        props.setProperty(Props.ENABLE_AUTO_COMMIT, "true");
+        props.setProperty(Props.MAX_HEAP_CACHE_SIZE, "0");
+        props.setProperty(Props.ENABLE_HEAP_CACHE_STATS, "false");
 
         String autoCmtCheck = "autocommit=ON";
         String sizeCheck = "size=UNBOUND";
         String statsCheck = "stats=OFF";
 
         // MOCKDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.MOCKDB.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.MOCKDB.toValue());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -248,11 +248,11 @@ public class DatabaseFactoryTest {
         assertThat(db.toString()).contains(statsCheck);
 
         // LEVELDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.LEVELDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
-        props.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.LEVELDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -262,10 +262,10 @@ public class DatabaseFactoryTest {
         assertThat(db.toString()).contains(statsCheck);
 
         // ROCKSDB
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.ROCKSDB.toValue());
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_TYPE, DBVendor.ROCKSDB.toValue());
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -275,7 +275,7 @@ public class DatabaseFactoryTest {
         assertThat(db.toString()).contains(statsCheck);
 
         // H2
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, DBVendor.H2.toValue());
+        props.setProperty(Props.DB_TYPE, DBVendor.H2.toValue());
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
         assertThat(db.getClass().getSimpleName()).isEqualTo(DatabaseWithCache.class.getSimpleName());
@@ -288,11 +288,11 @@ public class DatabaseFactoryTest {
     @Test
     public void testDriverRandomClassReturnNull() {
         Properties props = new Properties();
-        props.setProperty(DatabaseFactory.PROP_DB_NAME, dbName + DatabaseTestUtils.getNext());
-        props.setProperty(DatabaseFactory.PROP_DB_PATH, dbPath);
+        props.setProperty(Props.DB_NAME, dbName + DatabaseTestUtils.getNext());
+        props.setProperty(Props.DB_PATH, dbPath);
 
         // random class that is not an IDriver
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, MockDB.class.getName());
+        props.setProperty(Props.DB_TYPE, MockDB.class.getName());
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         // System.out.println(db);
         assertNull(db);
@@ -301,11 +301,11 @@ public class DatabaseFactoryTest {
     @Test
     public void testDriverRandomStringReturnNull() {
         Properties props = new Properties();
-        props.setProperty(DatabaseFactory.PROP_DB_NAME, dbName + DatabaseTestUtils.getNext());
-        props.setProperty(DatabaseFactory.PROP_DB_PATH, dbPath);
+        props.setProperty(Props.DB_NAME, dbName + DatabaseTestUtils.getNext());
+        props.setProperty(Props.DB_PATH, dbPath);
 
         // random string
-        props.setProperty(DatabaseFactory.PROP_DB_TYPE, "not a class");
+        props.setProperty(Props.DB_TYPE, "not a class");
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         // System.out.println(db);
         assertNull(db);

--- a/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseFactoryTest.java
@@ -139,7 +139,7 @@ public class DatabaseFactoryTest {
         props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
         db = DatabaseFactory.connect(props);
         assertThat(db).isNotNull();
-        assertThat(db.getClass().getSimpleName()).isEqualTo(LockedDatabase.class.getSimpleName());
+        assertThat(db.getClass().getSimpleName()).isEqualTo(SpecialLockedDatabase.class.getSimpleName());
         assertThat(db.toString()).contains(RocksDBWrapper.class.getSimpleName());
 
         // H2

--- a/modDbImpl/test/org/aion/db/impl/DatabaseTestUtils.java
+++ b/modDbImpl/test/org/aion/db/impl/DatabaseTestUtils.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static org.aion.db.impl.DatabaseFactory.Props;
 import static org.junit.Assert.assertTrue;
 
 public class DatabaseTestUtils {
@@ -64,44 +65,44 @@ public class DatabaseTestUtils {
     public static List<Object> unlockedDatabaseInstanceDefinitionsInternal() {
 
         Properties sharedProps = new Properties();
-        sharedProps.setProperty("db_path", dbPath);
+        sharedProps.setProperty(Props.DB_PATH, dbPath);
 
         List<Object> parameters = new ArrayList<>();
 
-        sharedProps.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, disabled);
+        sharedProps.setProperty(Props.ENABLE_LOCKING, disabled);
         // adding database variations without heap caching
-        sharedProps.setProperty("enable_heap_cache", disabled);
+        sharedProps.setProperty(Props.ENABLE_HEAP_CACHE, disabled);
         // the following parameters are irrelevant
-        sharedProps.setProperty("enable_auto_commit", enabled);
-        sharedProps.setProperty("max_heap_cache_size", "0");
-        sharedProps.setProperty("max_heap_cache_size", disabled);
-        sharedProps.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
-        sharedProps.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
-        sharedProps.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
-        sharedProps.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
+        sharedProps.setProperty(Props.ENABLE_AUTO_COMMIT, enabled);
+        sharedProps.setProperty(Props.MAX_HEAP_CACHE_SIZE, "0");
+        sharedProps.setProperty(Props.ENABLE_HEAP_CACHE_STATS, disabled);
+        sharedProps.setProperty(Props.MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        sharedProps.setProperty(Props.BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        sharedProps.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        sharedProps.setProperty(Props.DB_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
 
         // all vendor options
         for (DBVendor vendor : vendors) {
-            sharedProps.setProperty("db_type", vendor.toValue());
+            sharedProps.setProperty(Props.DB_TYPE, vendor.toValue());
 
             addDatabaseWithCacheAndCompression(vendor, sharedProps, parameters);
         }
 
         // adding database variations with heap caching
-        sharedProps.setProperty("enable_heap_cache", enabled);
+        sharedProps.setProperty(Props.ENABLE_HEAP_CACHE, enabled);
 
         // all vendor options
         for (DBVendor vendor : vendors) {
-            sharedProps.setProperty("db_type", vendor.toValue());
+            sharedProps.setProperty(Props.DB_TYPE, vendor.toValue());
             // enable/disable auto_commit
             for (String auto_commit : options) {
-                sharedProps.setProperty("enable_auto_commit", auto_commit);
+                sharedProps.setProperty(Props.ENABLE_AUTO_COMMIT, auto_commit);
                 // unbounded/bounded max_heap_cache_size
                 for (String max_heap_cache_size : sizeHeapCache) {
-                    sharedProps.setProperty("max_heap_cache_size", max_heap_cache_size);
+                    sharedProps.setProperty(Props.MAX_HEAP_CACHE_SIZE, max_heap_cache_size);
                     // enable/disable heap_cache_stats
                     for (String heap_cache_stats : options) {
-                        sharedProps.setProperty("enable_heap_cache_stats", heap_cache_stats);
+                        sharedProps.setProperty(Props.ENABLE_HEAP_CACHE_STATS, heap_cache_stats);
 
                         addDatabaseWithCacheAndCompression(vendor, sharedProps, parameters);
                     }
@@ -119,7 +120,7 @@ public class DatabaseTestUtils {
 
         for (Object prop : parametersUnlocked) {
             Properties p = (Properties) ((Properties) prop).clone();
-            p.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, enabled);
+            p.setProperty(Props.ENABLE_LOCKING, enabled);
 
             parameters.add(p);
         }
@@ -129,15 +130,16 @@ public class DatabaseTestUtils {
         return parameters.toArray();
     }
 
-    private static void addDatabaseWithCacheAndCompression(DBVendor vendor, Properties sharedProps,
+    private static void addDatabaseWithCacheAndCompression(DBVendor vendor,
+                                                           Properties sharedProps,
                                                            List<Object> parameters) {
         if (vendor != DBVendor.MOCKDB) {
             // enable/disable db_cache
             for (String db_cache : options) {
-                sharedProps.setProperty("enable_db_cache", db_cache);
+                sharedProps.setProperty(Props.ENABLE_DB_CACHE, db_cache);
                 // enable/disable db_compression
                 for (String db_compression : options) {
-                    sharedProps.setProperty("enable_db_compression", db_compression);
+                    sharedProps.setProperty(Props.ENABLE_DB_COMPRESSION, db_compression);
 
                     // generating new database configuration
                     parameters.add(sharedProps.clone());
@@ -158,7 +160,8 @@ public class DatabaseTestUtils {
     /**
      * From <a href="https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency">JUnit Wiki on multithreaded code and concurrency</a>
      */
-    public static void assertConcurrent(final String message, final List<? extends Runnable> runnables,
+    public static void assertConcurrent(final String message,
+                                        final List<? extends Runnable> runnables,
                                         final int maxTimeoutSeconds) throws InterruptedException {
         final int numThreads = runnables.size();
         final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
@@ -187,7 +190,7 @@ public class DatabaseTestUtils {
             // start all test runners
             afterInitBlocker.countDown();
             assertTrue(message + " timeout! More than" + maxTimeoutSeconds + "seconds",
-                    allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
+                       allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
         } finally {
             threadPool.shutdownNow();
         }

--- a/modDbImpl/test/org/aion/db/impl/h2/H2MVMapDriverTest.java
+++ b/modDbImpl/test/org/aion/db/impl/h2/H2MVMapDriverTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.Properties;
 
+import static org.aion.db.impl.DatabaseFactory.Props;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -58,9 +59,9 @@ public class H2MVMapDriverTest {
     public void testDriverReturnDatabase() {
 
         Properties props = new Properties();
-        props.setProperty("db_type", dbVendor);
-        props.setProperty("db_name", dbName);
-        props.setProperty("db_path", dbPath);
+        props.setProperty(Props.DB_TYPE, dbVendor);
+        props.setProperty(Props.DB_NAME, dbName);
+        props.setProperty(Props.DB_PATH, dbPath);
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNotNull(db);
@@ -71,9 +72,9 @@ public class H2MVMapDriverTest {
     public void testDriverReturnNull() {
 
         Properties props = new Properties();
-        props.setProperty("db_type", "BAD VENDOR");
-        props.setProperty("db_name", dbName);
-        props.setProperty("db_path", dbPath);
+        props.setProperty(Props.DB_TYPE, "BAD VENDOR");
+        props.setProperty(Props.DB_NAME, dbName);
+        props.setProperty(Props.DB_PATH, dbPath);
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNull(db);

--- a/modDbImpl/test/org/aion/db/impl/leveldb/LevelDBDriverTest.java
+++ b/modDbImpl/test/org/aion/db/impl/leveldb/LevelDBDriverTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.Properties;
 
+import static org.aion.db.impl.DatabaseFactory.Props;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -58,13 +59,13 @@ public class LevelDBDriverTest {
     public void testDriverReturnDatabase() {
 
         Properties props = new Properties();
-        props.setProperty("db_type", dbVendor);
-        props.setProperty("db_name", dbName);
-        props.setProperty("db_path", dbPath);
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
-        props.setProperty(DatabaseFactory.PROP_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
+        props.setProperty(Props.DB_TYPE, dbVendor);
+        props.setProperty(Props.DB_NAME, dbName);
+        props.setProperty(Props.DB_PATH, dbPath);
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(LevelDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(LevelDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(LevelDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_CACHE_SIZE, String.valueOf(LevelDBConstants.CACHE_SIZE));
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNotNull(db);
@@ -75,9 +76,9 @@ public class LevelDBDriverTest {
     public void testDriverReturnNull() {
 
         Properties props = new Properties();
-        props.setProperty("db_type", "BAD VENDOR");
-        props.setProperty("db_name", dbName);
-        props.setProperty("db_path", dbPath);
+        props.setProperty(Props.DB_TYPE, "BAD VENDOR");
+        props.setProperty(Props.DB_NAME, dbName);
+        props.setProperty(Props.DB_PATH, dbPath);
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNull(db);

--- a/modDbImpl/test/org/aion/db/impl/mockdb/MockDBDriverTest.java
+++ b/modDbImpl/test/org/aion/db/impl/mockdb/MockDBDriverTest.java
@@ -42,6 +42,8 @@ import org.junit.Test;
 
 import java.util.Properties;
 
+import static org.aion.db.impl.DatabaseFactory.Props.DB_NAME;
+import static org.aion.db.impl.DatabaseFactory.Props.DB_TYPE;
 import static org.junit.Assert.*;
 
 public class MockDBDriverTest {
@@ -57,8 +59,8 @@ public class MockDBDriverTest {
         driver = new MockDBDriver();
 
         props = new Properties();
-        props.setProperty("db_type", vendor.toValue());
-        props.setProperty("db_name", "test");
+        props.setProperty(DB_TYPE, vendor.toValue());
+        props.setProperty(DB_NAME, "test");
 
         db = null;
     }
@@ -69,7 +71,7 @@ public class MockDBDriverTest {
         db = DatabaseFactory.connect(props);
         assertNotNull(db);
 
-        props.setProperty("db_type", driver.getClass().getName());
+        props.setProperty(DB_TYPE, driver.getClass().getName());
         db = driver.connect(props);
         assertNotNull(db);
     }
@@ -77,7 +79,7 @@ public class MockDBDriverTest {
     @Test
     public void testDriverReturnNull() {
         // It should return null if given incorrect properties.
-        props.setProperty("db_type", "leveldb");
+        props.setProperty(DB_TYPE, "leveldb");
         db = DatabaseFactory.connect(props);
         assertNull(db);
 

--- a/modDbImpl/test/org/aion/db/impl/rocksdb/RocksDBDriverTest.java
+++ b/modDbImpl/test/org/aion/db/impl/rocksdb/RocksDBDriverTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.Properties;
 
+import static org.aion.db.impl.DatabaseFactory.Props;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -24,12 +25,12 @@ public class RocksDBDriverTest {
     public void testDriverReturnDatabase() {
 
         Properties props = new Properties();
-        props.setProperty("db_type", dbVendor);
-        props.setProperty("db_name", dbName);
-        props.setProperty("db_path", dbPath);
-        props.setProperty(DatabaseFactory.PROP_BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
-        props.setProperty(DatabaseFactory.PROP_MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
-        props.setProperty(DatabaseFactory.PROP_WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
+        props.setProperty(Props.DB_TYPE, dbVendor);
+        props.setProperty(Props.DB_NAME, dbName);
+        props.setProperty(Props.DB_PATH, dbPath);
+        props.setProperty(Props.BLOCK_SIZE, String.valueOf(RocksDBConstants.BLOCK_SIZE));
+        props.setProperty(Props.MAX_FD_ALLOC, String.valueOf(RocksDBConstants.MAX_OPEN_FILES));
+        props.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(RocksDBConstants.WRITE_BUFFER_SIZE));
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNotNull(db);
@@ -40,9 +41,9 @@ public class RocksDBDriverTest {
     public void testDriverReturnNull() {
 
         Properties props = new Properties();
-        props.setProperty("db_type", "BAD VENDOR");
-        props.setProperty("db_name", dbName);
-        props.setProperty("db_path", dbPath);
+        props.setProperty(Props.DB_TYPE, "BAD VENDOR");
+        props.setProperty(Props.DB_NAME, dbName);
+        props.setProperty(Props.DB_PATH, dbPath);
 
         IByteArrayKeyValueDatabase db = DatabaseFactory.connect(props);
         assertNull(db);
@@ -51,17 +52,41 @@ public class RocksDBDriverTest {
     // TODO: parametrize tests with null inputs
     @Test(expected = NullPointerException.class)
     public void testCreateWithNullName() {
-        new RocksDBWrapper(null, dbPath, false, false, RocksDBConstants.MAX_OPEN_FILES, RocksDBConstants.BLOCK_SIZE, RocksDBConstants.WRITE_BUFFER_SIZE, RocksDBConstants.READ_BUFFER_SIZE, RocksDBConstants.CACHE_SIZE);
+        new RocksDBWrapper(null,
+                           dbPath,
+                           false,
+                           false,
+                           RocksDBConstants.MAX_OPEN_FILES,
+                           RocksDBConstants.BLOCK_SIZE,
+                           RocksDBConstants.WRITE_BUFFER_SIZE,
+                           RocksDBConstants.READ_BUFFER_SIZE,
+                           RocksDBConstants.CACHE_SIZE);
     }
 
     @Test(expected = NullPointerException.class)
     public void testCreateWithNullPath() {
-        new RocksDBWrapper(dbName, null, false, false, RocksDBConstants.MAX_OPEN_FILES, RocksDBConstants.BLOCK_SIZE, RocksDBConstants.WRITE_BUFFER_SIZE, RocksDBConstants.READ_BUFFER_SIZE, RocksDBConstants.CACHE_SIZE);
+        new RocksDBWrapper(dbName,
+                           null,
+                           false,
+                           false,
+                           RocksDBConstants.MAX_OPEN_FILES,
+                           RocksDBConstants.BLOCK_SIZE,
+                           RocksDBConstants.WRITE_BUFFER_SIZE,
+                           RocksDBConstants.READ_BUFFER_SIZE,
+                           RocksDBConstants.CACHE_SIZE);
     }
 
     @Test(expected = NullPointerException.class)
     public void testCreateWithNullNameAndPath() {
-        new RocksDBWrapper(null, null, false, false, RocksDBConstants.MAX_OPEN_FILES, RocksDBConstants.BLOCK_SIZE, RocksDBConstants.WRITE_BUFFER_SIZE, RocksDBConstants.READ_BUFFER_SIZE, RocksDBConstants.CACHE_SIZE);
+        new RocksDBWrapper(null,
+                           null,
+                           false,
+                           false,
+                           RocksDBConstants.MAX_OPEN_FILES,
+                           RocksDBConstants.BLOCK_SIZE,
+                           RocksDBConstants.WRITE_BUFFER_SIZE,
+                           RocksDBConstants.READ_BUFFER_SIZE,
+                           RocksDBConstants.CACHE_SIZE);
     }
 
 }

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -51,7 +51,7 @@ public class CfgDb {
         this.vendor = DBVendor.LEVELDB.toValue();
         this.path = "database";
 
-        this.enable_auto_commit = false;
+        this.enable_auto_commit = true;
         this.enable_db_cache = true;
         this.enable_db_compression = true;
         this.enable_heap_cache = false;
@@ -220,11 +220,6 @@ public class CfgDb {
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement(Props.ENABLE_AUTO_COMMIT);
-            xmlWriter.writeCharacters(String.valueOf(this.isAutoCommitEnabled()));
-            xmlWriter.writeEndElement();
-
-            xmlWriter.writeCharacters("\r\n\t\t");
             xmlWriter.writeStartElement(Props.ENABLE_DB_CACHE);
             xmlWriter.writeCharacters(String.valueOf(this.isDbCacheEnabled()));
             xmlWriter.writeEndElement();
@@ -232,21 +227,6 @@ public class CfgDb {
             xmlWriter.writeCharacters("\r\n\t\t");
             xmlWriter.writeStartElement(Props.ENABLE_DB_COMPRESSION);
             xmlWriter.writeCharacters(String.valueOf(this.isDbCompressionEnabled()));
-            xmlWriter.writeEndElement();
-
-            xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement(Props.ENABLE_HEAP_CACHE);
-            xmlWriter.writeCharacters(String.valueOf(this.isHeapCacheEnabled()));
-            xmlWriter.writeEndElement();
-
-            xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement(Props.MAX_HEAP_CACHE_SIZE);
-            xmlWriter.writeCharacters(String.valueOf(this.getMaxHeapCacheSize()));
-            xmlWriter.writeEndElement();
-
-            xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement(Props.ENABLE_HEAP_CACHE_STATS);
-            xmlWriter.writeCharacters(String.valueOf(this.isHeapCacheStatsEnabled()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -22,20 +22,19 @@
  ******************************************************************************/
 package org.aion.mcf.config;
 
+import org.aion.base.util.Utils;
+import org.aion.db.impl.DBVendor;
+
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
-
-import org.aion.base.util.Utils;
-import org.aion.db.impl.DBVendor;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import static org.aion.db.impl.DatabaseFactory.Props;
 
 /**
  * @author chris
@@ -132,77 +131,70 @@ public class CfgDb {
         while (sr.hasNext()) {
             int eventType = sr.next();
             switch (eventType) {
-            case XMLStreamReader.START_ELEMENT:
-                String elementName = sr.getLocalName().toLowerCase();
-                switch (elementName) {
-                    case "path":
-                        this.path = Cfg.readValue(sr);
-                        break;
-                    case "vendor":
-                        this.vendor = Cfg.readValue(sr);
-                        break;
-                    case "enable_auto_commit":
-                        this.enable_auto_commit = Boolean.parseBoolean(Cfg.readValue(sr));
-                        break;
-                    case "enable_db_cache":
-                        this.enable_db_cache = Boolean.parseBoolean(Cfg.readValue(sr));
-                        break;
-                    case "enable_db_compression":
-                        this.enable_db_compression = Boolean.parseBoolean(Cfg.readValue(sr));
-                        break;
-                    case "enable_heap_cache":
-                        this.enable_heap_cache = Boolean.parseBoolean(Cfg.readValue(sr));
-                        break;
-                    case "max_heap_cache_size":
-                        this.max_heap_cache_size = Cfg.readValue(sr);
-                        break;
-                    case "enable_heap_cache_stats":
-                        this.enable_heap_cache_stats = Boolean.parseBoolean(Cfg.readValue(sr));
-                        break;
-                    case "block_size": {
-                        this.block_size = parseFileSizeSafe(Cfg.readValue(sr), this.block_size);
-                        break;
+                case XMLStreamReader.START_ELEMENT:
+                    String elementName = sr.getLocalName().toLowerCase();
+                    switch (elementName) {
+                        case "path":
+                            this.path = Cfg.readValue(sr);
+                            break;
+                        case "vendor":
+                            this.vendor = Cfg.readValue(sr);
+                            break;
+                        case Props.ENABLE_AUTO_COMMIT:
+                            this.enable_auto_commit = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
+                        case Props.ENABLE_DB_CACHE:
+                            this.enable_db_cache = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
+                        case Props.ENABLE_DB_COMPRESSION:
+                            this.enable_db_compression = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
+                        case Props.ENABLE_HEAP_CACHE:
+                            this.enable_heap_cache = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
+                        case Props.MAX_HEAP_CACHE_SIZE:
+                            this.max_heap_cache_size = Cfg.readValue(sr);
+                            break;
+                        case Props.ENABLE_HEAP_CACHE_STATS:
+                            this.enable_heap_cache_stats = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
+                        case Props.BLOCK_SIZE:
+                            this.block_size = parseFileSizeSafe(Cfg.readValue(sr), this.block_size);
+                            break;
+                        case Props.MAX_FD_ALLOC:
+                            int i = Integer.parseInt(Cfg.readValue(sr));
+                            this.max_fd_open_alloc = Math.max(MIN_FD_OPEN_ALLOC, i);
+                            break;
+                        case Props.WRITE_BUFFER_SIZE:
+                            this.block_size = parseFileSizeSafe(Cfg.readValue(sr), this.write_buffer_size);
+                            break;
+                        case Props.READ_BUFFER_SIZE:
+                            this.read_buffer_size = parseFileSizeSafe(Cfg.readValue(sr), this.read_buffer_size);
+                            break;
+                        case Props.DB_CACHE_SIZE:
+                            this.cache_size = parseFileSizeSafe(Cfg.readValue(sr), this.cache_size);
+                            break;
+                        default:
+                            Cfg.skipElement(sr);
+                            break;
                     }
-                    case "max_fd_alloc_size": {
-                        int i = Integer.parseInt(Cfg.readValue(sr));
-                        this.max_fd_open_alloc = Math.max(MIN_FD_OPEN_ALLOC, i);
-                        break;
-                    }
-                    case "write_buffer_size": {
-                        this.block_size = parseFileSizeSafe(Cfg.readValue(sr), this.write_buffer_size);
-                        break;
-                    }
-                    case "read_buffer_size": {
-                        this.read_buffer_size = parseFileSizeSafe(Cfg.readValue(sr), this.read_buffer_size);
-                        break;
-                    }
-                    case "cache_size": {
-                        this.cache_size = parseFileSizeSafe(Cfg.readValue(sr), this.cache_size);
-                        break;
-                    }
-                default:
-                    Cfg.skipElement(sr);
                     break;
-                }
-                break;
-            case XMLStreamReader.END_ELEMENT:
-                break loop;
+                case XMLStreamReader.END_ELEMENT:
+                    break loop;
             }
         }
     }
 
-    private static int parseFileSizeSafe(String input, int fallback) {
-        if (input == null || input.isEmpty())
-            return fallback;
+    private static int parseFileSizeSafe(String input,
+                                         int fallback) {
+        if (input == null || input.isEmpty()) { return fallback; }
 
         Optional<Long> maybeSize = Utils.parseSize(input);
-        if (!maybeSize.isPresent())
-            return fallback;
+        if (!maybeSize.isPresent()) { return fallback; }
 
         // present
         long size = maybeSize.get();
-        if (size > Integer.MAX_VALUE || size <= 0)
-            return fallback;
+        if (size > Integer.MAX_VALUE || size <= 0) { return fallback; }
 
         return (int) size;
     }
@@ -228,57 +220,57 @@ public class CfgDb {
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("enable_auto_commit");
+            xmlWriter.writeStartElement(Props.ENABLE_AUTO_COMMIT);
             xmlWriter.writeCharacters(String.valueOf(this.isAutoCommitEnabled()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("enable_db_cache");
+            xmlWriter.writeStartElement(Props.ENABLE_DB_CACHE);
             xmlWriter.writeCharacters(String.valueOf(this.isDbCacheEnabled()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("enable_db_compression");
+            xmlWriter.writeStartElement(Props.ENABLE_DB_COMPRESSION);
             xmlWriter.writeCharacters(String.valueOf(this.isDbCompressionEnabled()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("enable_heap_cache");
+            xmlWriter.writeStartElement(Props.ENABLE_HEAP_CACHE);
             xmlWriter.writeCharacters(String.valueOf(this.isHeapCacheEnabled()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("max_heap_cache_size");
+            xmlWriter.writeStartElement(Props.MAX_HEAP_CACHE_SIZE);
             xmlWriter.writeCharacters(String.valueOf(this.getMaxHeapCacheSize()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("enable_heap_cache_stats");
+            xmlWriter.writeStartElement(Props.ENABLE_HEAP_CACHE_STATS);
             xmlWriter.writeCharacters(String.valueOf(this.isHeapCacheStatsEnabled()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("block_size");
+            xmlWriter.writeStartElement(Props.BLOCK_SIZE);
             xmlWriter.writeCharacters(DEFAULT_BLOCK_SIZE);
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("max_fd_alloc_size");
+            xmlWriter.writeStartElement(Props.MAX_FD_ALLOC);
             xmlWriter.writeCharacters(String.valueOf(MIN_FD_OPEN_ALLOC));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("write_buffer_size");
+            xmlWriter.writeStartElement(Props.WRITE_BUFFER_SIZE);
             xmlWriter.writeCharacters(String.valueOf(DEFAULT_WRITE_BUFFER_SIZE));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("read_buffer_size");
+            xmlWriter.writeStartElement(Props.READ_BUFFER_SIZE);
             xmlWriter.writeCharacters(String.valueOf(DEFAULT_READ_BUFFER_SIZE));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("cache_size");
+            xmlWriter.writeStartElement(Props.DB_CACHE_SIZE);
             xmlWriter.writeCharacters(String.valueOf(DEFAULT_CACHE_SIZE));
             xmlWriter.writeEndElement();
 

--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -27,13 +27,11 @@ import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.IBlockHeader;
 import org.aion.base.type.ITransaction;
 import org.aion.db.impl.DBVendor;
-import org.aion.mcf.core.AccountState;
-import org.aion.mcf.db.exception.InvalidFilePathException;
 import org.aion.db.impl.DatabaseFactory;
-//import org.aion.dbmgr.exception.DriverManagerNoSuitableDriverRegisteredException;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
-// import org.aion.mcf.trie.JournalPruneDataSource;
+import org.aion.mcf.core.AccountState;
+import org.aion.mcf.db.exception.InvalidFilePathException;
 import org.aion.mcf.trie.Trie;
 import org.aion.mcf.types.AbstractBlock;
 import org.aion.mcf.vm.types.DataWord;
@@ -43,6 +41,12 @@ import java.io.File;
 import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.aion.db.impl.DatabaseFactory.Props;
+
+//import org.aion.dbmgr.exception.DriverManagerNoSuitableDriverRegisteredException;
+// import org.aion.mcf.trie.JournalPruneDataSource;
+
 
 /**
  * Abstract Repository class.
@@ -156,18 +160,18 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
         // TODO: these parameters should be converted to enum
         // should correspond with those listed in {@code DatabaseFactory}
         Properties sharedProps = new Properties();
-        sharedProps.setProperty("db_type", this.cfg.getActiveVendor());
-        sharedProps.setProperty("db_path", this.cfg.getDbPath());
-        sharedProps.setProperty("enable_auto_commit", String.valueOf(this.cfg.isAutoCommitEnabled()));
-        sharedProps.setProperty("enable_db_cache", String.valueOf(this.cfg.isDbCacheEnabled()));
-        sharedProps.setProperty("enable_db_compression", String.valueOf(this.cfg.isDbCompressionEnabled()));
-        sharedProps.setProperty("enable_heap_cache", String.valueOf(this.cfg.isHeapCacheEnabled()));
-        sharedProps.setProperty("max_heap_cache_size", this.cfg.getMaxHeapCacheSize());
-        sharedProps.setProperty("enable_heap_cache_stats", String.valueOf(this.cfg.isHeapCacheStatsEnabled()));
-        sharedProps.setProperty("max_fd_alloc_size", String.valueOf(this.cfg.getMaxFdAllocSize()));
-        sharedProps.setProperty("block_size", String.valueOf(this.cfg.getBlockSize()));
-        sharedProps.setProperty("write_buffer_size", String.valueOf(this.cfg.getWriteBufferSize()));
-        sharedProps.setProperty("cache_size", String.valueOf(this.cfg.getCacheSize()));
+        sharedProps.setProperty(Props.DB_TYPE, this.cfg.getActiveVendor());
+        sharedProps.setProperty(Props.DB_PATH, this.cfg.getDbPath());
+        sharedProps.setProperty(Props.ENABLE_AUTO_COMMIT, String.valueOf(this.cfg.isAutoCommitEnabled()));
+        sharedProps.setProperty(Props.ENABLE_DB_CACHE, String.valueOf(this.cfg.isDbCacheEnabled()));
+        sharedProps.setProperty(Props.ENABLE_DB_COMPRESSION, String.valueOf(this.cfg.isDbCompressionEnabled()));
+        sharedProps.setProperty(Props.ENABLE_HEAP_CACHE, String.valueOf(this.cfg.isHeapCacheEnabled()));
+        sharedProps.setProperty(Props.MAX_HEAP_CACHE_SIZE, this.cfg.getMaxHeapCacheSize());
+        sharedProps.setProperty(Props.ENABLE_HEAP_CACHE_STATS, String.valueOf(this.cfg.isHeapCacheStatsEnabled()));
+        sharedProps.setProperty(Props.MAX_FD_ALLOC, String.valueOf(this.cfg.getMaxFdAllocSize()));
+        sharedProps.setProperty(Props.BLOCK_SIZE, String.valueOf(this.cfg.getBlockSize()));
+        sharedProps.setProperty(Props.WRITE_BUFFER_SIZE, String.valueOf(this.cfg.getWriteBufferSize()));
+        sharedProps.setProperty(Props.DB_CACHE_SIZE, String.valueOf(this.cfg.getCacheSize()));
 
         try {
             databaseGroup = new ArrayList<>();
@@ -176,32 +180,32 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
              * Setup datastores
              */
             // locking enabled for state
-            sharedProps.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "true");
+            sharedProps.setProperty(Props.ENABLE_LOCKING, "true");
 
-            sharedProps.setProperty("db_name", STATE_DB);
+            sharedProps.setProperty(Props.DB_NAME, STATE_DB);
             this.stateDatabase = connectAndOpen(sharedProps);
             databaseGroup.add(stateDatabase);
 
             // locking disabled for other databases
-            sharedProps.setProperty(DatabaseFactory.PROP_ENABLE_LOCKING, "false");
+            sharedProps.setProperty(Props.ENABLE_LOCKING, "false");
 
-            sharedProps.setProperty("db_name", TRANSACTION_DB);
+            sharedProps.setProperty(Props.DB_NAME, TRANSACTION_DB);
             this.transactionDatabase = connectAndOpen(sharedProps);
             databaseGroup.add(transactionDatabase);
 
-            sharedProps.setProperty("db_name", DETAILS_DB);
+            sharedProps.setProperty(Props.DB_NAME, DETAILS_DB);
             this.detailsDatabase = connectAndOpen(sharedProps);
             databaseGroup.add(detailsDatabase);
 
-            sharedProps.setProperty("db_name", STORAGE_DB);
+            sharedProps.setProperty(Props.DB_NAME, STORAGE_DB);
             this.storageDatabase = connectAndOpen(sharedProps);
             databaseGroup.add(storageDatabase);
 
-            sharedProps.setProperty("db_name", INDEX_DB);
+            sharedProps.setProperty(Props.DB_NAME, INDEX_DB);
             this.indexDatabase = connectAndOpen(sharedProps);
             databaseGroup.add(indexDatabase);
 
-            sharedProps.setProperty("db_name", BLOCK_DB);
+            sharedProps.setProperty(Props.DB_NAME, BLOCK_DB);
             this.blockDatabase = connectAndOpen(sharedProps);
             databaseGroup.add(blockDatabase);
 
@@ -235,14 +239,14 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
 
         // check object status
         if (db == null) {
-            LOG.error("Database <{}> connection could not be established for <{}>.", info.getProperty("db_type"),
-                    info.getProperty("db_name"));
+            LOG.error("Database <{}> connection could not be established for <{}>.", info.getProperty(Props.DB_TYPE),
+                    info.getProperty(Props.DB_NAME));
         }
 
         // check persistence status
         if (!db.isCreatedOnDisk()) {
-            LOG.error("Database <{}> cannot be saved to disk for <{}>.", info.getProperty("db_type"),
-                    info.getProperty("db_name"));
+            LOG.error("Database <{}> cannot be saved to disk for <{}>.", info.getProperty(Props.DB_TYPE),
+                    info.getProperty(Props.DB_NAME));
         }
 
         return db;


### PR DESCRIPTION
* loose locking for RocksDB since its read/write operations are thread safe
* uniform use of the config values for database properties in CfgDb.java and DatabaseFactory.java
* making the heap cache parameters a hidden configuration since the recommendation is to disable the use of the heap cache