### PR TITLE
PendingStateImpl tune-up and tx broadcast rate control adjustment

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
@@ -80,7 +80,7 @@ public class AionImpl implements IAionChain {
         LOG_GEN.info("<node-started endpoint=p2p://" + cfg.getId() + "@" + cfg.getNet().getP2p().getIp() + ":"
                 + cfg.getNet().getP2p().getPort() + ">");
 
-        collector = new TxCollector(this.aionHub.getP2pMgr());
+        collector = new TxCollector(this.aionHub.getP2pMgr(), LOG_TX);
     }
 
 
@@ -136,7 +136,6 @@ public class AionImpl implements IAionChain {
 
     public void broadcastTransactions(List<AionTransaction> transaction) {
         for(AionTransaction tx : transaction) {
-            LOG_TX.trace("TxBC {}", tx.getNonceBI().toString());
             tx.getEncoded();
         }
         collector.submitTx(transaction);

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
@@ -136,6 +136,7 @@ public class AionImpl implements IAionChain {
 
     public void broadcastTransactions(List<AionTransaction> transaction) {
         for(AionTransaction tx : transaction) {
+            LOG_TX.trace("TxBC {}", tx.getNonceBI().toString());
             tx.getEncoded();
         }
         collector.submitTx(transaction);

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -409,7 +409,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
                         }
 
                         if (LOG.isTraceEnabled()) {
-                            LOG.trace("Adding transaction to cache: from = {}, nonce = {}", tx.getFrom(), txNonce);
+                            LOG.trace("addPendingTransactions addToCache due to largeNonce: from = {}, nonce = {}", tx.getFrom(), txNonce);
                         }
                     }
                 } else if (cmp == 0) {
@@ -424,7 +424,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
                             }
 
                             if (LOG.isTraceEnabled()) {
-                                LOG.trace("Adding transaction to cache: from = {}, nonce = {}", tx.getFrom(), txNonce);
+                                LOG.trace("addPendingTransactions addToCache due to poolMax: from = {}, nonce = {}", tx.getFrom(), txNonce);
                             }
                         }
 
@@ -445,7 +445,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
                     }
 
                     if (LOG.isTraceEnabled()) {
-                        LOG.trace("cache: from {}, size {}", tx.getFrom(), cache.size());
+                        LOG.trace("addPendingTransactions from cache: from {}, size {}", tx.getFrom(), cache.size());
                     }
 
                     do {
@@ -533,8 +533,8 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
     }
 
     private void fireTxUpdate(AionTxReceipt txReceipt, PendingTransactionState state, IAionBlock block) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(String.format("PendingTransactionUpdate: (Tot: %3s) %12s : %s %8s %s [%s]", getPendingTxSize(),
+        if (LOG.isTraceEnabled()) {
+            LOG.trace(String.format("PendingTransactionUpdate: (Tot: %3s) %12s : %s %8s %s [%s]", getPendingTxSize(),
                     state, txReceipt.getTransaction().getFrom().toString().substring(0, 8),
                     ByteUtil.byteArrayToLong(txReceipt.getTransaction().getNonce()), block.getShortDescr(),
                     txReceipt.getError()));
@@ -594,7 +594,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
             tx.setNrgConsume(txSum.getReceipt().getEnergyUsed());
 
             if (LOG.isTraceEnabled()) {
-                LOG.trace("addPendingTransactionImpl: [{}]", tx.toString());
+                LOG.trace("addPendingTransactionImpl validTx {}", tx.toString());
             }
 
             if (bufferEnable) {

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -54,7 +54,10 @@ import org.aion.zero.impl.db.AionRepositoryImpl;
 import org.aion.zero.impl.types.AionBlock;
 import org.aion.zero.impl.types.AionTxInfo;
 import org.aion.zero.impl.valid.TXValidator;
-import org.aion.zero.types.*;
+import org.aion.zero.types.AionTransaction;
+import org.aion.zero.types.AionTxExecSummary;
+import org.aion.zero.types.AionTxReceipt;
+import org.aion.zero.types.IAionBlock;
 import org.slf4j.Logger;
 
 import java.math.BigInteger;
@@ -140,7 +143,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
             List<AionTransaction> newPending = txPool.add(txs);
 
             if (LOG.isTraceEnabled()) {
-                LOG.trace("txBufferSize {} return size {}", txs.size(), newPending.size());
+                LOG.trace("processTxBuffer buffer#{} poolNewTx#{}", txs.size(), newPending.size());
             }
 
             int cnt = 0;
@@ -156,6 +159,9 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
             }
 
             if (!txs.isEmpty() && !loadPendingTx) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("processTxBuffer tx#{}",  txs.size());
+                }
                 AionImpl.inst().broadcastTransactions(txs);
             }
 
@@ -459,7 +465,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
 
                         txNonce = txNonce.add(BigInteger.ONE);
                     } while (cache != null && (tx = cache.get(txNonce)) != null && (limit-- > 0)
-                            && txPool.size() < MAX_VALIDATED_PENDING_TXS);
+                            && (txPool.size() + txBuffer.size() < MAX_VALIDATED_PENDING_TXS));
                 } else if (bestRepoNonce(tx.getFrom()).compareTo(txNonce) < 1) {
                     // repay Tx
                     if (addPendingTransactionImpl(tx, txNonce)) {
@@ -734,8 +740,8 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
 
         List<AionTransaction> newPendingTx = this.pendingTxCache.flush(nonceMap);
 
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("PendingStateImpl.flushCachePendingTx: newPendingTx_size[{}]", newPendingTx.size());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("PendingStateImpl.flushCachePendingTx: newPendingTx_size[{}]", newPendingTx.size());
         }
 
         if (!newPendingTx.isEmpty()) {

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -464,8 +464,10 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
                         }
 
                         txNonce = txNonce.add(BigInteger.ONE);
-                    } while (cache != null && (tx = cache.get(txNonce)) != null && (limit-- > 0)
-                            && (txPool.size() + txBuffer.size() < MAX_VALIDATED_PENDING_TXS));
+                    } while (cache != null &&
+                            (tx = cache.get(txNonce)) != null &&
+                            (limit-- > 0) &&
+                            (txBuffer == null ? txPool.size() : txPool.size() + txBuffer.size()) < MAX_VALIDATED_PENDING_TXS);
                 } else if (bestRepoNonce(tx.getFrom()).compareTo(txNonce) < 1) {
                     // repay Tx
                     if (addPendingTransactionImpl(tx, txNonce)) {

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -157,7 +157,6 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
 
             if (!txs.isEmpty() && !loadPendingTx) {
                 AionImpl.inst().broadcastTransactions(txs);
-
             }
 
             txBuffer.clear();

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -587,8 +587,8 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
         }
 
         if (txSum.isRejected()) {
-            if (LOG.isErrorEnabled()) {
-                LOG.error("addPendingTransactionImpl tx is rejected due to: {}", txSum.getReceipt().getError());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("addPendingTransactionImpl tx is rejected due to: {}", txSum.getReceipt().getError());
             }
             fireTxUpdate(txSum.getReceipt(), PendingTransactionState.DROPPED, best.get());
             return false;

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/PendingTxCache.java
@@ -218,8 +218,8 @@ public class PendingTxCache {
             return new ArrayList<>();
         }
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("cacheTx.flush cacheTx# {}", cacheTxSize());
+        if (LOG.isInfoEnabled()) {
+            LOG.info("cacheTx.flush cacheTx# {}", cacheTxSize());
         }
 
         int cacheTxNumber = 0;
@@ -252,8 +252,8 @@ public class PendingTxCache {
             }
         }
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("cacheTx.flush after cacheTx# {}", cacheTxNumber);
+        if (LOG.isInfoEnabled()) {
+            LOG.info("cacheTx.flush after cacheTx# {}", cacheTxNumber);
         }
 
         Map<BigInteger, AionTransaction> timeMap = new LinkedHashMap<>();

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
@@ -158,11 +158,9 @@ public final class BroadcastTxHandler extends Handler {
         for (byte[] raw : broadCastTx) {
             try {
                 AionTransaction tx = new AionTransaction(raw);
-                System.out.println("castRawTx nonce: " + tx.getNonceBI().toString());
                 if (tx.getHash() != null) {
                     if (!TXValidator.isInCache(ByteArrayWrapper.wrap(tx.getHash()))) {
                         if (TXValidator.isValid(tx)) {
-                            System.out.println("castRawTx validTx nonce: " + tx.getNonceBI().toString());
                             rtn.add(tx);
                         }
                     }
@@ -171,6 +169,10 @@ public final class BroadcastTxHandler extends Handler {
                 // do nothing, invalid transaction from bad peer
                 System.out.println("castRawTx exception: " + e.toString());
             }
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("BroadcastTxHandler.castRawTx Tx#{} validTx#{}", broadCastTx.size(), rtn.size());
         }
 
         return rtn;

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
@@ -167,7 +167,9 @@ public final class BroadcastTxHandler extends Handler {
                 }
             } catch (Exception e) {
                 // do nothing, invalid transaction from bad peer
-                System.out.println("castRawTx exception: " + e.toString());
+                if (log.isDebugEnabled()) {
+                    log.debug("castRawTx exception: " + e.toString());
+                }
             }
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
@@ -158,15 +158,18 @@ public final class BroadcastTxHandler extends Handler {
         for (byte[] raw : broadCastTx) {
             try {
                 AionTransaction tx = new AionTransaction(raw);
+                System.out.println("castRawTx nonce: " + tx.getNonceBI().toString());
                 if (tx.getHash() != null) {
                     if (!TXValidator.isInCache(ByteArrayWrapper.wrap(tx.getHash()))) {
                         if (TXValidator.isValid(tx)) {
+                            System.out.println("castRawTx validTx nonce: " + tx.getNonceBI().toString());
                             rtn.add(tx);
                         }
                     }
                 }
             } catch (Exception e) {
                 // do nothing, invalid transaction from bad peer
+                System.out.println("castRawTx exception: " + e.toString());
             }
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/tx/TxCollector.java
+++ b/modAionImpl/src/org/aion/zero/impl/tx/TxCollector.java
@@ -2,6 +2,7 @@ package org.aion.zero.impl.tx;
 
 import org.aion.p2p.IP2pMgr;
 import org.aion.zero.types.AionTransaction;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,10 +40,12 @@ public class TxCollector {
     private LinkedBlockingQueue<AionTransaction> transactionQueue;
 
     private ReentrantLock broadcastLock = new ReentrantLock();
+    private Logger LOG;
 
 
-    public TxCollector(IP2pMgr p2p) {
+    public TxCollector(IP2pMgr p2p, final Logger logTx) {
         this.p2p = p2p;
+        this.LOG = logTx;
 
         // Leave unbounded for now, may need to restrict queue size and drop tx until able to process tx
         transactionQueue = new LinkedBlockingQueue<>();
@@ -52,6 +55,9 @@ public class TxCollector {
         int initDelay = 10;
         broadcastTxExec.scheduleAtFixedRate(this::broadcastTransactionsTask, initDelay, broadcastLoop, TimeUnit.SECONDS);
 
+    }
+
+    public TxCollector(IP2pMgr p2pMgr) {
     }
 
     /*
@@ -111,9 +117,10 @@ public class TxCollector {
         this.lastBroadcast.set(System.currentTimeMillis());
 
         if (!transactions.isEmpty()) {
-            for (AionTransaction tx : transactions) {
-                System.out.println("TxCollector: " + tx.getNonceBI().toString());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("TxCollector.broadcastTx Tx#{}", transactions.size());
             }
+
             TxBroadcaster.getInstance().submitTransaction(new A0TxTask(transactions, this.p2p));
         }
     }

--- a/modAionImpl/src/org/aion/zero/impl/tx/TxCollector.java
+++ b/modAionImpl/src/org/aion/zero/impl/tx/TxCollector.java
@@ -111,6 +111,9 @@ public class TxCollector {
         this.lastBroadcast.set(System.currentTimeMillis());
 
         if (!transactions.isEmpty()) {
+            for (AionTransaction tx : transactions) {
+                System.out.println("TxCollector: " + tx.getNonceBI().toString());
+            }
             TxBroadcaster.getInstance().submitTransaction(new A0TxTask(transactions, this.p2p));
         }
     }

--- a/modEvtMgrImpl/src/org/aion/evtmgr/impl/es/EventExecuteService.java
+++ b/modEvtMgrImpl/src/org/aion/evtmgr/impl/es/EventExecuteService.java
@@ -1,14 +1,14 @@
 package org.aion.evtmgr.impl.es;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.LinkedBlockingQueue;
 import org.aion.evtmgr.IEvent;
 import org.aion.evtmgr.impl.evt.EventDummy;
 import org.slf4j.Logger;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class EventExecuteService {
 
@@ -77,7 +77,7 @@ public class EventExecuteService {
             try {
                 return callbackEvt.add(event);
             } catch (IllegalStateException e) {
-                LOG.error("ExecutorService Q is full!");
+                LOG.warn("ExecutorService Q is full!");
                 return false;
             }
         } else {

--- a/modP2p/src/org/aion/p2p/Header.java
+++ b/modP2p/src/org/aion/p2p/Header.java
@@ -28,7 +28,6 @@ package org.aion.p2p;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.aion.p2p.P2pConstant;
 
 /**
  * @author chris

--- a/modP2p/src/org/aion/p2p/P2pConstant.java
+++ b/modP2p/src/org/aion/p2p/P2pConstant.java
@@ -23,6 +23,9 @@ public class P2pConstant {
             // max p2p in package capped at 10.
             READ_MAX_RATE = 10,
 
+            // max p2p in package capped for tx broadcast.
+            READ_MAX_RATE_TXBC = 20,
+
             // write queue timeout
             WRITE_MSG_TIMEOUT = 1000;
 

--- a/modP2pImpl/src/org/aion/p2p/impl1/ChannelBuffer.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/ChannelBuffer.java
@@ -25,7 +25,6 @@
 package org.aion.p2p.impl1;
 
 import org.aion.p2p.Header;
-import org.aion.p2p.P2pConstant;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -66,7 +65,7 @@ class ChannelBuffer {
                 prev.cnt = 0;
                 prev.ts = now;
             }
-            boolean shouldRoute = prev.cnt < P2pConstant.READ_MAX_RATE;
+            boolean shouldRoute = prev.cnt < _minTimeDiff;
             prev.cnt++;
 
             return shouldRoute;

--- a/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
@@ -99,6 +99,9 @@ public final class P2pMgr implements IP2pMgr {
 
     private int errTolerance;
 
+    //TODO: need refactor by passing the parameter in the later version.
+    private final static int txBroadCastRoute = ((Ver.V0 << 16) + (Ctrl.SYNC << 8) + 6);
+
     enum Dest {
         INBOUND, OUTBOUND, ACTIVE;
     }
@@ -808,10 +811,10 @@ public final class P2pMgr implements IP2pMgr {
 
         int route = h.getRoute();
 
-        boolean underRC = rb.shouldRoute(route, P2pConstant.READ_MAX_RATE);
+        boolean underRC = (route == txBroadCastRoute ? rb.shouldRoute(route, P2pConstant.READ_MAX_RATE_TXBC) : rb.shouldRoute(route, P2pConstant.READ_MAX_RATE));
 
         if (!underRC) {
-            System.out.println("DEBUG p2p shouldnot route " + route + " nid_" + rb.nodeIdHash + " cid_"
+            System.out.println("DEBUG p2p should not route " + route + " nid_" + rb.nodeIdHash + " cid_"
                     + _sk.channel().hashCode());
             return currCnt;
         }

--- a/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
@@ -808,7 +808,8 @@ public final class P2pMgr implements IP2pMgr {
 
         int route = h.getRoute();
 
-        boolean underRC = (route == txBroadCastRoute ? rb.shouldRoute(route, P2pConstant.READ_MAX_RATE_TXBC) : rb.shouldRoute(route, P2pConstant.READ_MAX_RATE));
+        boolean underRC = rb.shouldRoute(route,
+                ((route == txBroadCastRoute) ? P2pConstant.READ_MAX_RATE_TXBC : P2pConstant.READ_MAX_RATE));
 
         if (!underRC) {
             return currCnt;

--- a/modTxPoolImpl/src/org/aion/txpool/zero/TxPoolA0.java
+++ b/modTxPoolImpl/src/org/aion/txpool/zero/TxPoolA0.java
@@ -506,9 +506,8 @@ import java.util.stream.Collectors;
                                     return rtn;
                                 }
                             } else {
-                                if (LOG.isDebugEnabled()) {
-                                    LOG.debug("Reach blockLimit: txSize[{}], nrgConsume[{}], tx#[{}]", cnt_txSz,
-                                            cnt_nrg, rtn.size());
+                                if (LOG.isInfoEnabled()) {
+                                    LOG.info("TxPoolA0.snapshot return Tx[{}] TxSize[{}] Nrg[{}] Pool[{}]", rtn.size(), cnt_txSz, cnt_nrg, getMainMap().size());
                                 }
 
                                 return rtn;


### PR DESCRIPTION
1. decrease the tx flooding number from cached layer to pool layer. 
2. adjust tx broadcast rate control in p2p module 10/s -> 20/s base on the max buffer send in the pendingStateImpl.
3. refine log