### PR TITLE
batching operations in transaction store

### DIFF
--- a/modAionBase/src/org/aion/base/db/IKeyValueStore.java
+++ b/modAionBase/src/org/aion/base/db/IKeyValueStore.java
@@ -158,6 +158,9 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
      */
     void putBatch(Map<K, V> inputMap);
 
+    void putToBatch(byte[] key, byte[] value);
+    void commitBatch();
+
     /**
      * Similar to delete, except operates on a list of keys
      *

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -775,8 +775,9 @@ public class AionBlockchainImpl implements IAionBlockchain {
 
         if (rebuild) {
             for (int i = 0; i < receipts.size(); i++) {
-                transactionStore.put(new AionTxInfo(receipts.get(i), block.getHash(), i));
+                transactionStore.putToBatch(new AionTxInfo(receipts.get(i), block.getHash(), i));
             }
+            transactionStore.flushBatch();
 
             ((AionRepositoryImpl) repository).commitBlock(block.getHeader());
 
@@ -1069,8 +1070,9 @@ public class AionBlockchainImpl implements IAionBlockchain {
         }
 
         for (int i = 0; i < receipts.size(); i++) {
-            transactionStore.put(new AionTxInfo(receipts.get(i), block.getHash(), i));
+            transactionStore.putToBatch(new AionTxInfo(receipts.get(i), block.getHash(), i));
         }
+        transactionStore.flushBatch();
 
         ((AionRepositoryImpl) repository).commitBlock(block.getHeader());
 

--- a/modDbImpl/src/org/aion/db/generic/LockedDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/LockedDatabase.java
@@ -310,6 +310,44 @@ public class LockedDatabase implements IByteArrayKeyValueDatabase {
     }
 
     @Override
+    public void putToBatch(byte[] key, byte[] value) {
+        // acquire write lock
+        lock.writeLock().lock();
+
+        try {
+            database.putToBatch(key, value);
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                LOG.error("Could not put batch due to ", e);
+            }
+        } finally {
+            // releasing write lock
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void commitBatch() {
+        // acquire write lock
+        lock.writeLock().lock();
+
+        try {
+            database.commitBatch();
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                LOG.error("Could not put batch due to ", e);
+            }
+        } finally {
+            // releasing write lock
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
     public void deleteBatch(Collection<byte[]> keys) {
         // acquire write lock
         lock.writeLock().lock();

--- a/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
@@ -196,8 +196,7 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
     }
 
     @Override
-    public void put(byte[] key,
-                    byte[] value) {
+    public void put(byte[] key, byte[] value) {
         long t1 = System.nanoTime();
         database.put(key, value);
         long t2 = System.nanoTime();
@@ -221,6 +220,24 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         long t2 = System.nanoTime();
 
         LOG.debug(database.toString() + " putBatch(" + keyValuePairs.size() + ") in " + (t2 - t1) + " ns.");
+    }
+
+    @Override
+    public void putToBatch(byte[] key, byte[] value) {
+        long t1 = System.nanoTime();
+        database.putToBatch(key, value);
+        long t2 = System.nanoTime();
+
+        LOG.debug(database.toString() + " putToBatch(key,value) in " + (t2 - t1) + " ns.");
+    }
+
+    @Override
+    public void commitBatch() {
+        long t1 = System.nanoTime();
+        database.commitBatch();
+        long t2 = System.nanoTime();
+
+        LOG.debug(database.toString() + " commitBatch() in " + (t2 - t1) + " ns.");
     }
 
     @Override

--- a/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
+++ b/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
@@ -308,6 +308,17 @@ public class H2MVMap extends AbstractDB {
     }
 
     @Override
+    public void putToBatch(byte[] k, byte[] v) {
+        // same as put since batch operations are not supported
+        put(k, v);
+    }
+
+    @Override
+    public void commitBatch() {
+        // nothing to do since batch operations are not supported
+    }
+
+    @Override
     public void deleteBatch(Collection<byte[]> keys) {
         check(keys);
 

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -313,6 +313,42 @@ public class LevelDB extends AbstractDB {
         }
     }
 
+    WriteBatch batch = null;
+
+    @Override
+    public void putToBatch(byte[] key, byte[] value) {
+        check(key);
+
+        check();
+
+        if (batch == null) {
+            batch = db.createWriteBatch();
+        }
+
+        if (value == null) {
+            batch.delete(key);
+        } else {
+            batch.put(key, value);
+        }
+    }
+
+    @Override
+    public void commitBatch() {
+        if (batch != null) {
+            try {
+                db.write(batch);
+            } catch (DBException e) {
+                LOG.error("Unable to execute batch put/update operation on " + this.toString() + ".", e);
+            }
+            try {
+                batch.close();
+            } catch (IOException e) {
+                LOG.error("Unable to close WriteBatch object in " + this.toString() + ".", e);
+            }
+            batch = null;
+        }
+    }
+
     @Override
     public void deleteBatch(Collection<byte[]> keys) {
         check(keys);

--- a/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
+++ b/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
@@ -135,6 +135,17 @@ public class MockDB extends AbstractDB {
     }
 
     @Override
+    public void putToBatch(byte[] k, byte[] v) {
+        // same as put since batch operations are not supported
+        put(k, v);
+    }
+
+    @Override
+    public void commitBatch() {
+        // nothing to do since batch operations are not supported
+    }
+
+    @Override
     public void deleteBatch(Collection<byte[]> keys) {
         check(keys);
 

--- a/modMcf/src/org/aion/mcf/db/TransactionStore.java
+++ b/modMcf/src/org/aion/mcf/db/TransactionStore.java
@@ -52,7 +52,7 @@ public class TransactionStore<TX extends AbstractTransaction, TXR extends Abstra
         source = new ObjectDataSource(src, serializer);
     }
 
-    public boolean put(INFO tx) {
+    public boolean putToBatch(INFO tx) {
         lock.writeLock().lock();
 
         try {
@@ -73,12 +73,16 @@ public class TransactionStore<TX extends AbstractTransaction, TXR extends Abstra
                 }
             }
             existingInfos.add(tx);
-            source.put(txHash, existingInfos);
+            source.putToBatch(txHash, existingInfos);
 
             return true;
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    public void flushBatch(){
+        source.flushBatch();
     }
 
     public INFO get(byte[] txHash, byte[] blockHash) {

--- a/modMcf/src/org/aion/mcf/ds/ObjectDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/ObjectDataSource.java
@@ -63,6 +63,15 @@ public class ObjectDataSource<V> implements Flushable, Closeable {
         src.put(key, bytes);
     }
 
+    public void putToBatch(byte[] key, V value) {
+        byte[] bytes = serializer.serialize(value);
+        src.putToBatch(key, bytes);
+    }
+
+    public void flushBatch() {
+        src.commitBatch();
+    }
+
     public void delete(byte[] key) {
         src.delete(key);
     }

--- a/modMcf/src/org/aion/mcf/ds/XorDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/XorDataSource.java
@@ -110,4 +110,13 @@ public class XorDataSource implements IByteArrayKeyValueStore {
         return false;
     }
 
+    @Override
+    public void putToBatch(byte[] key, byte[] value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void commitBatch() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
+++ b/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
@@ -233,6 +233,16 @@ public class JournalPruneDataSource<BLK extends IBlock<?, ?>, BH extends IBlockH
     }
 
     @Override
+    public void putToBatch(byte[] key, byte[] value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void commitBatch() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void deleteBatch(Collection<byte[]> keys) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Followed the performance pre and post patch for blocks 0 to 18590 on the Q2 network:

Import block time in **ms** (not particularly informative due to many factors that can influence it):

| tx per block | number of blocks | pre patch | post patch |
| ---------------:| -----------------------:|--------------:|--------------:|
| any number | 18590 | 75.83 |  **74.65** |
|          >=100 | 773 | 1582.47 | **1572.58** |
| >=700 | 352 | 2547.70 | **2527.63** |

The average time per transaction put to database in **ns**:

| pre patch | post patch|
| -------------:|--------------:|
| 39303 | **22251** |

Before the current changes one `put(key,value)` was used per transaction:

|       operation       | count calls  |        avg  time      |
|----------------|-------:|--------------------:|
| put(key,value) | 447195 | 39303 |

After the current changes we call `putToBatch(key,value)` per transaction and `commitBatch()` once per block:

|          operation           | count calls  |         avg time         |
|-----------------------|--------:|--------------------:|
| commitBatch()         |  18590 | 208684 |
| putToBatch(key,value) | 447195 |  13575 |

