### PR TITLE
Syncing progress enhancement

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -173,6 +173,8 @@ public class AionHub {
 		registerCallback();
 		this.p2pMgr.run();
 
+        ((AionPendingStateImpl)this.mempool).setP2pMgr(this.p2pMgr);
+
 		this.pow = new AionPoW();
 		this.pow.init(blockchain, mempool, eventMgr);
 

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -1036,16 +1036,21 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
 
         bestNetBlk.sort(Comparator.reverseOrder());
 
+        int position = bestNetBlk.size()/3;
+        if (position > 3) {
+            position -= 1;
+        }
+
         if (LOG.isDebugEnabled()) {
             StringBuilder blk = new StringBuilder();
             for (Long l : bestNetBlk) {
                 blk.append(l.toString()).append(" ");
             }
 
-            LOG.debug("getNetworkBestBlk13 {} NetworkBest:{}", bestNetBlk.get(bestNetBlk.size()/3), blk.toString());
+            LOG.debug("getNetworkBestBlk13 peers[{}] 1/3[{}] NetworkBest[{}]", bestNetBlk.size(), bestNetBlk.get(position), blk.toString());
         }
 
-        return bestNetBlk.get(bestNetBlk.size()/3);
+        return bestNetBlk.get(position);
     }
 
     private void recoverCache() {

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -726,7 +726,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
 
         best.set(newBlock);
 
-        if (best.get().getNumber() + 128 < getNetworkBestBlk13()) {
+        if (best.get().getNumber() + 128 < getPeersBestBlk13()) {
             closeToNetworkBest = false;
         } else {
             closeToNetworkBest = true;
@@ -1020,37 +1020,37 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
         }
     }
 
-    private long getNetworkBestBlk13() {
+    private long getPeersBestBlk13() {
         if (this.p2pMgr == null) {
             return 0;
         }
 
-        List<Long> bestNetBlk = new ArrayList<>();
+        List<Long> peersBest = new ArrayList<>();
         for (INode node : p2pMgr.getActiveNodes().values()) {
-            bestNetBlk.add(node.getBestBlockNumber());
+            peersBest.add(node.getBestBlockNumber());
         }
 
-        if (bestNetBlk.isEmpty()) {
+        if (peersBest.isEmpty()) {
             return 0;
         }
 
-        bestNetBlk.sort(Comparator.reverseOrder());
+        peersBest.sort(Comparator.reverseOrder());
 
-        int position = bestNetBlk.size()/3;
+        int position = peersBest.size()/3;
         if (position > 3) {
             position -= 1;
         }
 
         if (LOG.isDebugEnabled()) {
             StringBuilder blk = new StringBuilder();
-            for (Long l : bestNetBlk) {
+            for (Long l : peersBest) {
                 blk.append(l.toString()).append(" ");
             }
 
-            LOG.debug("getNetworkBestBlk13 peers[{}] 1/3[{}] NetworkBest[{}]", bestNetBlk.size(), bestNetBlk.get(position), blk.toString());
+            LOG.debug("getPeersBestBlk13 peers[{}] 1/3[{}] PeersBest[{}]", peersBest.size(), peersBest.get(position), blk.toString());
         }
 
-        return bestNetBlk.get(position);
+        return peersBest.get(position);
     }
 
     private void recoverCache() {

--- a/modMcf/src/org/aion/mcf/blockchain/IPendingState.java
+++ b/modMcf/src/org/aion/mcf/blockchain/IPendingState.java
@@ -23,13 +23,12 @@
  ******************************************************************************/
 package org.aion.mcf.blockchain;
 
-import java.math.BigInteger;
-import java.util.List;
-import java.util.Map;
-
 import org.aion.base.db.IRepositoryCache;
 import org.aion.base.type.Address;
 import org.aion.base.type.ITransaction;
+
+import java.math.BigInteger;
+import java.util.List;
 
 public interface IPendingState<TX extends ITransaction> {
 


### PR DESCRIPTION
1. this PR is trying to ease the kernel DB pressure. the transaction will go into the pendingPool when the node is syncing to the block high greater than top 1/3 of all connecting nodes. Otherwise just bypassing the txs and broadcast it out.