### PR TITLE
Heap caching for reads

### DIFF
--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -67,6 +67,22 @@
 		<block_size>16mB</block_size>
 		<write_buffer_size>64mB</write_buffer_size>
 		<cache_size>128mB</cache_size>
+		<block>
+			<enable_heap_cache>true</enable_heap_cache>
+			<heap_cache_type>light-read</heap_cache_type>
+			<max_heap_cache_size>30</max_heap_cache_size>
+		</block>
+		<index>
+			<enable_heap_cache>true</enable_heap_cache>
+			<heap_cache_type>light-read</heap_cache_type>
+			<max_heap_cache_size>30</max_heap_cache_size>
+		</index>
+		<details>
+			<enable_heap_cache>true</enable_heap_cache>
+			<heap_cache_type>lru-read</heap_cache_type>
+			<max_heap_cache_size>3000</max_heap_cache_size>
+		</details>
+
 	</db>
 	<log>
 		<GEN>INFO</GEN>

--- a/modDbImpl/src/org/aion/db/generic/LRUCachedReadsDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/LRUCachedReadsDatabase.java
@@ -1,0 +1,290 @@
+/*******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ *     <ether.camp> team through the ethereumJ library.
+ *     Ether.Camp Inc. (US) team through Ethereum Harmony.
+ *     John Tromp through the Equihash solver.
+ *     Samuel Neves through the BLAKE2 implementation.
+ *     Zcash project team.
+ *     Bitcoinj team.
+ ******************************************************************************/
+package org.aion.db.generic;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.aion.base.db.IByteArrayKeyValueDatabase;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * LRU map used for speeding up reads.
+ *
+ * @author Alexandra Roatis
+ */
+public class LRUCachedReadsDatabase implements IByteArrayKeyValueDatabase {
+
+    private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.DB.name());
+
+    /** Underlying database implementation. */
+    protected IByteArrayKeyValueDatabase database;
+
+    /** Keeps track of the entries that have been modified. */
+    private LoadingCache<ByteArrayWrapper, Optional<byte[]>> loadingCache = null;
+
+    /** The underlying cache maximum size. */
+    private int maxSize;
+
+    /** The flag to indicate if the stats are enabled or not. */
+    private boolean statsEnabled;
+
+    public LRUCachedReadsDatabase(IByteArrayKeyValueDatabase _database, int _maxSize, boolean _statsEnabled) {
+        database = _database;
+        maxSize = _maxSize;
+        statsEnabled = _statsEnabled;
+    }
+
+    /**
+     * Assists in setting up the underlying cache for the current instance.
+     *
+     * @param size
+     * @param enableStats
+     */
+    private void setupLoadingCache(final long size, final boolean enableStats) {
+        // Use CacheBuilder to create the cache.
+        CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+
+        // Set the size.
+        // Actually when size is 0, we make it unbounded
+        if (size != 0) {
+            builder.maximumSize(size);
+        }
+
+        // Enable stats if passed in.
+        if (enableStats) {
+            builder.recordStats();
+        }
+
+        // Utilize CacheBuilder and pass in the parameters to create the cache.
+        this.loadingCache = builder.build(new CacheLoader<ByteArrayWrapper, Optional<byte[]>>() {
+            @Override
+            public Optional<byte[]> load(ByteArrayWrapper keyToLoad) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(getName().get() + " -> value from READ CACHE with size = " + loadingCache.size());
+                }
+                // It is safe to say keyToLoad is not null or the data is null.
+                // Load from the data source.
+                return database.get(keyToLoad.getData());
+            }
+        });
+    }
+
+    /**
+     * For testing the lock functionality of public methods.
+     * Used to ensure that locks are released after normal or exceptional execution.
+     *
+     * @return {@code true} when the resource is locked,
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean isLocked() {
+        return database.isLocked();
+    }
+
+    // IDatabase functionality -----------------------------------------------------------------------------------------
+
+    @Override
+    public boolean open() {
+        if (isOpen()) {
+            return true;
+        }
+
+        boolean open = database.open();
+
+        // setup cache only id database was opened successfully
+        if (open) {
+            setupLoadingCache(maxSize, statsEnabled);
+        }
+
+        return open;
+    }
+
+    @Override
+    public void close() {
+        try {
+            // close database
+            database.close();
+        } finally {
+            // clear the cache
+            loadingCache.invalidateAll();
+        }
+    }
+
+    @Override
+    public boolean commit() {
+        loadingCache.invalidateAll();
+        return database.commit();
+    }
+
+    @Override
+    public void compact() {
+        database.compact();
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return database.getName();
+    }
+
+    @Override
+    public Optional<String> getPath() {
+        return database.getPath();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return database.isOpen();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return database.isClosed();
+    }
+
+    @Override
+    public boolean isAutoCommitEnabled() {
+        return database.isAutoCommitEnabled();
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return database.isPersistent();
+    }
+
+    @Override
+    public boolean isCreatedOnDisk() {
+        return database.isCreatedOnDisk();
+    }
+
+    @Override
+    public long approximateSize() {
+        return database.approximateSize();
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "<" + maxSize + ">" + " over " + this.database.toString();
+    }
+
+    // IKeyValueStore functionality ------------------------------------------------------------------------------------
+
+    @Override
+    public boolean isEmpty() {
+        if (loadingCache.size() > 0) {
+            return false;
+        } else {
+            return database.isEmpty();
+        }
+    }
+
+    @Override
+    public Set<byte[]> keys() {
+        return database.keys();
+    }
+
+    @Override
+    public Optional<byte[]> get(byte[] k) {
+        Optional<byte[]> val;
+
+        try {
+            val = loadingCache.get(ByteArrayWrapper.wrap(k));
+        } catch (ExecutionException e) {
+            LOG.error(this.toString() + " cannot load from cache. Loading directly from database.", e);
+            return database.get(k);
+        }
+
+        return val;
+    }
+
+    @Override
+    public void put(byte[] k, byte[] v) {
+        loadingCache.put(ByteArrayWrapper.wrap(k), Optional.of(v));
+        database.put(k, v);
+    }
+
+    @Override
+    public void delete(byte[] k) {
+        loadingCache.invalidate(ByteArrayWrapper.wrap(k));
+        database.delete(k);
+    }
+
+    @Override
+    public void putBatch(Map<byte[], byte[]> inputMap) {
+        if (statsEnabled && LOG.isDebugEnabled()) {
+            LOG.debug(getName().get() + " > " + loadingCache.stats().toString());
+        }
+        loadingCache.invalidateAll();
+        database.putBatch(inputMap);
+    }
+
+    @Override
+    public void putToBatch(byte[] k, byte[] v) {
+        database.putToBatch(k, v);
+    }
+
+    @Override
+    public void commitBatch() {
+        if (statsEnabled && LOG.isDebugEnabled()) {
+            LOG.debug(getName().get() + " > " + loadingCache.stats().toString());
+        }
+        loadingCache.invalidateAll();
+        database.commitBatch();
+    }
+
+    @Override
+    public void deleteBatch(Collection<byte[]> keys) {
+        if (statsEnabled && LOG.isDebugEnabled()) {
+            LOG.debug(getName().get() + " > " + loadingCache.stats().toString());
+        }
+        loadingCache.invalidateAll();
+        database.deleteBatch(keys);
+    }
+
+    @Override
+    public void drop() {
+        loadingCache.invalidateAll();
+        database.drop();
+    }
+}

--- a/modDbImpl/src/org/aion/db/generic/LightCachedReadsDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/LightCachedReadsDatabase.java
@@ -1,0 +1,243 @@
+/*******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ *     <ether.camp> team through the ethereumJ library.
+ *     Ether.Camp Inc. (US) team through Ethereum Harmony.
+ *     John Tromp through the Equihash solver.
+ *     Samuel Neves through the BLAKE2 implementation.
+ *     Zcash project team.
+ *     Bitcoinj team.
+ ******************************************************************************/
+package org.aion.db.generic;
+
+import org.aion.base.db.IByteArrayKeyValueDatabase;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.slf4j.Logger;
+
+import java.util.*;
+
+/**
+ * Used for block and index where entries are typically accessed in order.
+ *
+ * @author Alexandra Roatis
+ */
+public class LightCachedReadsDatabase implements IByteArrayKeyValueDatabase {
+
+    private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.DB.name());
+
+    /** Underlying database implementation. */
+    protected IByteArrayKeyValueDatabase database;
+
+    /** Keeps track of the entries that have been modified. */
+    private LinkedHashMap<ByteArrayWrapper, Optional<byte[]>> knownEntries;
+
+    /** The underlying cache maximum size. */
+    private int maxSize;
+
+    public LightCachedReadsDatabase(IByteArrayKeyValueDatabase _database, int _maxSize) {
+        database = _database;
+        knownEntries = new LinkedHashMap<>();
+        maxSize = _maxSize;
+    }
+
+    /**
+     * For testing the lock functionality of public methods.
+     * Used to ensure that locks are released after normal or exceptional execution.
+     *
+     * @return {@code true} when the resource is locked,
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean isLocked() {
+        return database.isLocked();
+    }
+
+    // IDatabase functionality -----------------------------------------------------------------------------------------
+
+    @Override
+    public boolean open() {
+        if (isOpen()) {
+            return true;
+        }
+        return database.open();
+    }
+
+    @Override
+    public void close() {
+        try {
+            // close database
+            database.close();
+        } finally {
+            knownEntries.clear();
+        }
+    }
+
+    @Override
+    public boolean commit() {
+        knownEntries.clear();
+        return database.commit();
+    }
+
+    @Override
+    public void compact() {
+        database.compact();
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return database.getName();
+    }
+
+    @Override
+    public Optional<String> getPath() {
+        return database.getPath();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return database.isOpen();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return database.isClosed();
+    }
+
+    @Override
+    public boolean isAutoCommitEnabled() {
+        return database.isAutoCommitEnabled();
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return database.isPersistent();
+    }
+
+    @Override
+    public boolean isCreatedOnDisk() {
+        return database.isCreatedOnDisk();
+    }
+
+    @Override
+    public long approximateSize() {
+        return database.approximateSize();
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "<" + maxSize + ">" + " over " + this.database.toString();
+    }
+
+    // IKeyValueStore functionality ------------------------------------------------------------------------------------
+
+    @Override
+    public boolean isEmpty() {
+        if (knownEntries.size() > 0) {
+            return false;
+        } else {
+            return database.isEmpty();
+        }
+    }
+
+    @Override
+    public Set<byte[]> keys() {
+        return database.keys();
+    }
+
+    @Override
+    public Optional<byte[]> get(byte[] k) {
+        ByteArrayWrapper key = ByteArrayWrapper.wrap(k);
+
+        if (knownEntries.size() > 0 && knownEntries.containsKey(key)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(getName().get() + " -> value from READ CACHE with size = " + knownEntries.size());
+            }
+            return knownEntries.get(key);
+        }
+
+        if (knownEntries.size() > maxSize) {
+            knownEntries.remove(knownEntries.keySet().iterator().next());
+        }
+
+        Optional<byte[]> value = database.get(k);
+        knownEntries.put(key, value);
+
+        return value;
+    }
+
+    @Override
+    public void put(byte[] k, byte[] v) {
+        ByteArrayWrapper key = ByteArrayWrapper.wrap(k);
+
+        knownEntries.remove(key);
+
+        if (knownEntries.size() > maxSize) {
+            knownEntries.remove(knownEntries.keySet().iterator().next());
+        }
+
+        knownEntries.put(key, Optional.of(v));
+
+        database.put(k, v);
+    }
+
+    @Override
+    public void delete(byte[] k) {
+        knownEntries.remove(ByteArrayWrapper.wrap(k));
+        database.delete(k);
+    }
+
+    @Override
+    public void putBatch(Map<byte[], byte[]> inputMap) {
+        knownEntries.clear();
+        database.putBatch(inputMap);
+    }
+
+    @Override
+    public void putToBatch(byte[] k, byte[] v) {
+        database.putToBatch(k, v);
+    }
+
+    @Override
+    public void commitBatch() {
+        knownEntries.clear();
+        database.commitBatch();
+    }
+
+    @Override
+    public void deleteBatch(Collection<byte[]> keys) {
+        knownEntries.clear();
+        database.deleteBatch(keys);
+    }
+
+    @Override
+    public void drop() {
+        knownEntries.clear();
+        database.drop();
+    }
+}

--- a/modMcf/src/org/aion/mcf/config/CfgDbDetails.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDbDetails.java
@@ -48,6 +48,7 @@ public class CfgDbDetails {
         this.enable_db_cache = true;
         this.enable_db_compression = true;
         this.enable_heap_cache = false;
+        this.heap_cache_type = "none";
         // size 0 means unbound
         this.max_heap_cache_size = "1024";
         this.enable_heap_cache_stats = false;
@@ -71,6 +72,7 @@ public class CfgDbDetails {
 
     public boolean enable_auto_commit;
     public boolean enable_heap_cache;
+    public String heap_cache_type;
     public String max_heap_cache_size;
     public boolean enable_heap_cache_stats;
 
@@ -139,6 +141,9 @@ public class CfgDbDetails {
                             break;
                         case Props.ENABLE_HEAP_CACHE:
                             this.enable_heap_cache = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
+                        case Props.HEAP_CACHE_TYPE:
+                            this.heap_cache_type = Cfg.readValue(sr);
                             break;
                         case Props.MAX_HEAP_CACHE_SIZE:
                             this.max_heap_cache_size = Cfg.readValue(sr);
@@ -246,6 +251,7 @@ public class CfgDbDetails {
 
         props.setProperty(Props.ENABLE_AUTO_COMMIT, String.valueOf(this.enable_auto_commit));
         props.setProperty(Props.ENABLE_HEAP_CACHE, String.valueOf(this.enable_heap_cache));
+        props.setProperty(Props.HEAP_CACHE_TYPE, this.heap_cache_type);
         props.setProperty(Props.MAX_HEAP_CACHE_SIZE, this.max_heap_cache_size);
         props.setProperty(Props.ENABLE_HEAP_CACHE_STATS, String.valueOf(this.enable_heap_cache_stats));
 

--- a/modMcf/src/org/aion/mcf/config/CfgDbDetails.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDbDetails.java
@@ -237,6 +237,31 @@ public class CfgDbDetails {
         xmlWriter.writeCharacters(String.valueOf(DEFAULT_CACHE_SIZE));
         xmlWriter.writeEndElement();
 
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement(Props.ENABLE_HEAP_CACHE);
+        xmlWriter.writeCharacters(String.valueOf(this.enable_heap_cache));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement(Props.ENABLE_AUTO_COMMIT);
+        xmlWriter.writeCharacters(String.valueOf(this.enable_auto_commit));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement(Props.HEAP_CACHE_TYPE);
+        xmlWriter.writeCharacters(String.valueOf(this.heap_cache_type));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement(Props.MAX_HEAP_CACHE_SIZE);
+        xmlWriter.writeCharacters(String.valueOf(this.max_heap_cache_size));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement(Props.ENABLE_HEAP_CACHE_STATS);
+        xmlWriter.writeCharacters(String.valueOf(this.enable_heap_cache_stats));
+        xmlWriter.writeEndElement();
+
         xmlWriter.writeCharacters("\r\n\t\t");
         xmlWriter.writeEndElement();
     }


### PR DESCRIPTION
Preliminary tests show that 99.99% of reads will be done from the light cache for **block** and **index** (tested with a sync from block 0 to 10000). 

For **details** 99.55% of reads should be from LRU cache (tested with a sync from block 0 to 24000).