### PR TITLE
cors headers fix for json-rpc server

### DIFF
--- a/modApiServer/src/org/aion/api/server/nanohttpd/NanoHttpd.java
+++ b/modApiServer/src/org/aion/api/server/nanohttpd/NanoHttpd.java
@@ -29,8 +29,10 @@ public class NanoHttpd extends NanoHTTPD {
 
     protected Response addCORSHeaders(Response resp) {
         resp.addHeader("Access-Control-Allow-Origin", "*");
+        resp.addHeader("Access-Control-Allow-Headers", "origin,accept,content-type");
         resp.addHeader("Access-Control-Allow-Credentials", "true");
-        resp.addHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+        resp.addHeader("Access-Control-Allow-Methods", "POST");
+        resp.addHeader("Access-Control-Max-Age", "86400");
         return resp;
     }
 


### PR DESCRIPTION
correct headers to make rpc requests originating from browsers work correctly