### PR TITLE
Refactor and test journal pruning class

### DIFF
--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  *
  * Copyright (c) 2017, 2018 Aion foundation.
  *
@@ -18,9 +18,17 @@
  * Contributors:
  *     Aion foundation.
  *******************************************************************************/
-
 package org.aion.mcf.db;
 
+import static org.aion.db.impl.DatabaseFactory.Props;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.IRepository;
 import org.aion.base.db.IRepositoryConfig;
@@ -38,22 +46,13 @@ import org.aion.mcf.types.AbstractBlock;
 import org.aion.mcf.vm.types.DataWord;
 import org.slf4j.Logger;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+// import org.aion.dbmgr.exception.DriverManagerNoSuitableDriverRegisteredException;
 
-import static org.aion.db.impl.DatabaseFactory.Props;
-
-//import org.aion.dbmgr.exception.DriverManagerNoSuitableDriverRegisteredException;
-
-/**
- * Abstract Repository class.
- */
-public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends ITransaction>, BH extends IBlockHeader, BSB extends IBlockStoreBase<?, ?>>
+/** Abstract Repository class. */
+public abstract class AbstractRepository<
+                BLK extends AbstractBlock<BH, ? extends ITransaction>,
+                BH extends IBlockHeader,
+                BSB extends IBlockStoreBase<?, ?>>
         implements IRepository<AccountState, DataWord, BSB> {
 
     // Logger
@@ -63,9 +62,9 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
     // Configuration parameter
     protected IRepositoryConfig cfg;
 
-    /*********** Database Name Constants ***********/
-
+    /** ********* Database Name Constants ********** */
     protected static final String TRANSACTION_DB = CfgDb.Names.TRANSACTION;
+
     protected static final String INDEX_DB = CfgDb.Names.INDEX;
     protected static final String BLOCK_DB = CfgDb.Names.BLOCK;
     protected static final String DETAILS_DB = CfgDb.Names.DETAILS;
@@ -81,9 +80,9 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
     // protected final static String DB_PATH = new
     // File(System.getProperty("user.dir"), "database").getAbsolutePath();
 
-    /********** Database and Cache parameters **************/
-
+    /** ******** Database and Cache parameters ************* */
     protected IByteArrayKeyValueDatabase transactionDatabase;
+
     protected IByteArrayKeyValueDatabase detailsDatabase;
     protected IByteArrayKeyValueDatabase storageDatabase;
     protected IByteArrayKeyValueDatabase indexDatabase;
@@ -94,7 +93,7 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
 
     protected Collection<IByteArrayKeyValueDatabase> databaseGroup;
 
-    protected JournalPruneDataSource<BLK, BH> stateDSPrune;
+    protected JournalPruneDataSource stateDSPrune;
     protected DetailsDataStore<BLK, BH> detailsDS;
 
     // Read Write Lock
@@ -125,18 +124,18 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
          * on startup, enforce conditions here for safety
          */
         Objects.requireNonNull(this.cfg);
-//        Objects.requireNonNull(this.cfg.getVendorList());
-//        Objects.requireNonNull(this.cfg.getActiveVendor());
+        //        Objects.requireNonNull(this.cfg.getVendorList());
+        //        Objects.requireNonNull(this.cfg.getActiveVendor());
 
-//        /**
-//         * TODO: this is hack There should be some information on the
-//         * persistence of the DB so that we do not have to manually check.
-//         * Currently this information exists within
-//         * {@link DBVendor#getPersistence()}, but is not utilized.
-//         */
-//        if (this.cfg.getActiveVendor().equals(DBVendor.MOCKDB.toValue())) {
-//            LOG.warn("WARNING: Active vendor is set to MockDB, data will not persist");
-//        } else {
+        //        /**
+        //         * TODO: this is hack There should be some information on the
+        //         * persistence of the DB so that we do not have to manually check.
+        //         * Currently this information exists within
+        //         * {@link DBVendor#getPersistence()}, but is not utilized.
+        //         */
+        //        if (this.cfg.getActiveVendor().equals(DBVendor.MOCKDB.toValue())) {
+        //            LOG.warn("WARNING: Active vendor is set to MockDB, data will not persist");
+        //        } else {
         // verify user-provided path
         File f = new File(this.cfg.getDbPath());
         try {
@@ -148,22 +147,27 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
                 f.mkdirs();
             }
         } catch (Exception e) {
-            throw new InvalidFilePathException("Resolved file path \"" + this.cfg.getDbPath()
-                                                       + "\" not valid as reported by the OS or a read/write permissions error occurred. Please provide an alternative DB file path in /config/config.xml.");
+            throw new InvalidFilePathException(
+                    "Resolved file path \""
+                            + this.cfg.getDbPath()
+                            + "\" not valid as reported by the OS or a read/write permissions error occurred. Please provide an alternative DB file path in /config/config.xml.");
         }
-//        }
-//
-//        if (!Arrays.asList(this.cfg.getVendorList()).contains(this.cfg.getActiveVendor())) {
-//
-//            ArrayList<String> vendorListString = new ArrayList<>();
-//            for (String v : this.cfg.getVendorList()) {
-//                vendorListString.add("\"" + v + "\"");
-//            }
-//            throw new DriverManagerNoSuitableDriverRegisteredException(
-//                    "Please check the vendor name field in /config/config.xml.\n"
-//                            + "No suitable driver found with name \"" + this.cfg.getActiveVendor()
-//                            + "\".\nPlease select a driver from the following vendor list: " + vendorListString);
-//        }
+        //        }
+        //
+        //        if (!Arrays.asList(this.cfg.getVendorList()).contains(this.cfg.getActiveVendor()))
+        // {
+        //
+        //            ArrayList<String> vendorListString = new ArrayList<>();
+        //            for (String v : this.cfg.getVendorList()) {
+        //                vendorListString.add("\"" + v + "\"");
+        //            }
+        //            throw new DriverManagerNoSuitableDriverRegisteredException(
+        //                    "Please check the vendor name field in /config/config.xml.\n"
+        //                            + "No suitable driver found with name \"" +
+        // this.cfg.getActiveVendor()
+        //                            + "\".\nPlease select a driver from the following vendor list:
+        // " + vendorListString);
+        //        }
 
         Properties sharedProps;
 
@@ -171,8 +175,10 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
         try {
             databaseGroup = new ArrayList<>();
 
-            checkIntegrity = Boolean
-                    .valueOf(cfg.getDatabaseConfig(CfgDb.Names.DEFAULT).getProperty(Props.CHECK_INTEGRITY));
+            checkIntegrity =
+                    Boolean.valueOf(
+                            cfg.getDatabaseConfig(CfgDb.Names.DEFAULT)
+                                    .getProperty(Props.CHECK_INTEGRITY));
 
             // getting state specific properties
             sharedProps = cfg.getDatabaseConfig(STATE_DB);
@@ -241,7 +247,7 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
 
             // Setup the cache for transaction data source.
             this.detailsDS = new DetailsDataStore<>(detailsDatabase, storageDatabase, this.cfg);
-            stateDSPrune = new JournalPruneDataSource<>(stateDatabase);
+            stateDSPrune = new JournalPruneDataSource(stateDatabase);
             pruneBlockCount = pruneEnabled ? this.cfg.getPrune() : -1;
             if (pruneEnabled && pruneBlockCount > 0) {
                 LOGGEN.info("Pruning block count set to {}.", pruneBlockCount);
@@ -272,16 +278,18 @@ public abstract class AbstractRepository<BLK extends AbstractBlock<BH, ? extends
 
         // check object status
         if (db == null) {
-            LOG.error("Database <{}> connection could not be established for <{}>.",
-                      info.getProperty(Props.DB_TYPE),
-                      info.getProperty(Props.DB_NAME));
+            LOG.error(
+                    "Database <{}> connection could not be established for <{}>.",
+                    info.getProperty(Props.DB_TYPE),
+                    info.getProperty(Props.DB_NAME));
         }
 
         // check persistence status
         if (!db.isCreatedOnDisk()) {
-            LOG.error("Database <{}> cannot be saved to disk for <{}>.",
-                      info.getProperty(Props.DB_TYPE),
-                      info.getProperty(Props.DB_NAME));
+            LOG.error(
+                    "Database <{}> cannot be saved to disk for <{}>.",
+                    info.getProperty(Props.DB_TYPE),
+                    info.getProperty(Props.DB_NAME));
         }
 
         return db;

--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -182,8 +182,8 @@ public abstract class AbstractRepository<
 
             // getting state specific properties
             sharedProps = cfg.getDatabaseConfig(STATE_DB);
-            // locking enabled for state
-            sharedProps.setProperty(Props.ENABLE_LOCKING, "true");
+            // locking enabled for state when JournalPrune not used
+            sharedProps.setProperty(Props.ENABLE_LOCKING, "false");
             sharedProps.setProperty(Props.DB_PATH, cfg.getDbPath());
             sharedProps.setProperty(Props.DB_NAME, STATE_DB);
             this.stateDatabase = connectAndOpen(sharedProps);

--- a/modMcf/src/org/aion/mcf/db/DetailsDataStore.java
+++ b/modMcf/src/org/aion/mcf/db/DetailsDataStore.java
@@ -1,25 +1,42 @@
-/*******************************************************************************
+/* ******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
  *
- * Copyright (c) 2017, 2018 Aion foundation.
+ *     This file is part of the aion network project.
  *
- * 	This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
  *
  *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <https://www.gnu.org/licenses/>
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
  *
- * Contributors:
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
  *     Aion foundation.
- *******************************************************************************/
+ *     <ether.camp> team through the ethereumJ library.
+ *     Ether.Camp Inc. (US) team through Ethereum Harmony.
+ *     John Tromp through the Equihash solver.
+ *     Samuel Neves through the BLAKE2 implementation.
+ *     Zcash project team.
+ *     Bitcoinj team.
+ ******************************************************************************/
 package org.aion.mcf.db;
 
+import static org.aion.base.util.ByteArrayWrapper.wrap;
+
+import java.util.*;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.db.IRepositoryConfig;
@@ -31,43 +48,38 @@ import org.aion.mcf.trie.JournalPruneDataSource;
 import org.aion.mcf.types.AbstractBlock;
 import org.aion.mcf.vm.types.DataWord;
 
-import java.util.*;
+/** Detail data storage , */
+public class DetailsDataStore<
+        BLK extends AbstractBlock<BH, ? extends ITransaction>, BH extends IBlockHeader> {
 
-import static org.aion.base.util.ByteArrayWrapper.wrap;
-
-/**
- * Detail data storage ,
- */
-public class DetailsDataStore<BLK extends AbstractBlock<BH, ? extends ITransaction>, BH extends IBlockHeader> {
-
-    private JournalPruneDataSource<BLK, BH> storageDSPrune;
+    private JournalPruneDataSource storageDSPrune;
     private IRepositoryConfig repoConfig;
 
     private IByteArrayKeyValueDatabase detailsSrc;
     private IByteArrayKeyValueDatabase storageSrc;
     private Set<ByteArrayWrapper> removes = new HashSet<>();
 
-    public DetailsDataStore() {
-    }
+    public DetailsDataStore() {}
 
-    public DetailsDataStore(IByteArrayKeyValueDatabase detailsCache, IByteArrayKeyValueDatabase storageCache,
+    public DetailsDataStore(
+            IByteArrayKeyValueDatabase detailsCache,
+            IByteArrayKeyValueDatabase storageCache,
             IRepositoryConfig repoConfig) {
 
         this.repoConfig = repoConfig;
         withDb(detailsCache, storageCache);
     }
 
-    public DetailsDataStore<BLK, BH> withDb(IByteArrayKeyValueDatabase detailsSrc,
-            IByteArrayKeyValueDatabase storageSrc) {
+    public DetailsDataStore<BLK, BH> withDb(
+            IByteArrayKeyValueDatabase detailsSrc, IByteArrayKeyValueDatabase storageSrc) {
         this.detailsSrc = detailsSrc;
         this.storageSrc = storageSrc;
-        this.storageDSPrune = new JournalPruneDataSource<>(storageSrc);
+        this.storageDSPrune = new JournalPruneDataSource(storageSrc);
         return this;
     }
 
     /**
-     * Fetches the ContractDetails from the cache, and if it doesn't exist, add
-     * to the remove set.
+     * Fetches the ContractDetails from the cache, and if it doesn't exist, add to the remove set.
      *
      * @param key
      * @return
@@ -110,7 +122,6 @@ public class DetailsDataStore<BLK extends AbstractBlock<BH, ? extends ITransacti
 
         // Remove from the remove set.
         removes.remove(wrappedKey);
-
     }
 
     public synchronized void remove(byte[] key) {
@@ -170,7 +181,7 @@ public class DetailsDataStore<BLK extends AbstractBlock<BH, ? extends ITransacti
         }
     }
 
-    public JournalPruneDataSource<BLK, BH> getStorageDSPrune() {
+    public JournalPruneDataSource getStorageDSPrune() {
         return storageDSPrune;
     }
 

--- a/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
+++ b/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
@@ -35,9 +35,14 @@
 package org.aion.mcf.trie;
 
 import java.util.*;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.util.ByteArrayWrapper;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.slf4j.Logger;
 
 /**
  * The DataSource which doesn't immediately forward delete updates (unlike inserts) but collects
@@ -47,6 +52,9 @@ import org.aion.base.util.ByteArrayWrapper;
  * deleted at block N and then inserted at block N + 10 this delete is not passed.
  */
 public class JournalPruneDataSource implements IByteArrayKeyValueStore {
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.DB.name());
 
     private class Updates {
         ByteArrayWrapper blockHeader;
@@ -82,58 +90,99 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
     }
 
     public void setPruneEnabled(boolean e) {
+        lock.writeLock().lock();
+
         enabled = e;
+
+        lock.writeLock().unlock();
     }
 
-    public synchronized void put(byte[] key, byte[] value) {
-        ByteArrayWrapper keyW = new ByteArrayWrapper(key);
+    public void put(byte[] key, byte[] value) {
+        lock.writeLock().lock();
 
-        // Check to see the value exists.
-        if (value != null) {
+        try {
+            ByteArrayWrapper keyW = new ByteArrayWrapper(key);
 
-            // If it exists and pruning is enabled.
-            if (enabled) {
-                currentUpdates.insertedKeys.add(keyW);
-                incRef(keyW);
-            }
+            // Check to see the value exists.
+            if (value != null) {
 
-            // put to source database.
-            src.put(key, value);
-
-        } else {
-            // Value does not exist, so we delete from current updates
-            if (enabled) {
-                currentUpdates.deletedKeys.add(keyW);
-            }
-            // delete is not sent to source db
-        }
-    }
-
-    public synchronized void delete(byte[] key) {
-        if (!enabled) {
-            return;
-        }
-        currentUpdates.deletedKeys.add(new ByteArrayWrapper(key));
-        // delete is delayed
-    }
-
-    public synchronized void updateBatch(Map<byte[], byte[]> rows) {
-        Map<byte[], byte[]> insertsOnly = new HashMap<>();
-        for (Map.Entry<byte[], byte[]> entry : rows.entrySet()) {
-            ByteArrayWrapper keyW = new ByteArrayWrapper(entry.getKey());
-            if (entry.getValue() != null) {
+                // If it exists and pruning is enabled.
                 if (enabled) {
                     currentUpdates.insertedKeys.add(keyW);
                     incRef(keyW);
                 }
-                insertsOnly.put(entry.getKey(), entry.getValue());
+
+                // put to source database.
+                src.put(key, value);
+
             } else {
+                // Value does not exist, so we delete from current updates
                 if (enabled) {
                     currentUpdates.deletedKeys.add(keyW);
                 }
+                // delete is not sent to source db
             }
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                LOG.error("Could not put key-value pair due to ", e);
+            }
+        } finally {
+            lock.writeLock().unlock();
         }
-        src.putBatch(insertsOnly);
+    }
+
+    public void delete(byte[] key) {
+        lock.writeLock().lock();
+
+        try {
+            if (!enabled) {
+                return;
+            }
+            currentUpdates.deletedKeys.add(new ByteArrayWrapper(key));
+            // delete is delayed
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                LOG.error("Could not delete key due to ", e);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void putBatch(Map<byte[], byte[]> inputMap) {
+        lock.writeLock().lock();
+
+        try {
+            Map<byte[], byte[]> insertsOnly = new HashMap<>();
+            for (Map.Entry<byte[], byte[]> entry : inputMap.entrySet()) {
+                ByteArrayWrapper keyW = new ByteArrayWrapper(entry.getKey());
+                if (entry.getValue() != null) {
+                    if (enabled) {
+                        currentUpdates.insertedKeys.add(keyW);
+                        incRef(keyW);
+                    }
+                    insertsOnly.put(entry.getKey(), entry.getValue());
+                } else {
+                    if (enabled) {
+                        currentUpdates.deletedKeys.add(keyW);
+                    }
+                }
+            }
+            src.putBatch(insertsOnly);
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                LOG.error("Could not put batch due to ", e);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     private void incRef(ByteArrayWrapper keyW) {
@@ -154,40 +203,52 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
         return cnt;
     }
 
-    public synchronized void storeBlockChanges(byte[] blockHash, long blockNumber) {
-        if (!enabled) {
-            return;
+    public void storeBlockChanges(byte[] blockHash, long blockNumber) {
+        lock.writeLock().lock();
+
+        try {
+            if (!enabled) {
+                return;
+            }
+            ByteArrayWrapper hash = new ByteArrayWrapper(blockHash);
+            currentUpdates.blockHeader = hash;
+            currentUpdates.blockNumber = blockNumber;
+            blockUpdates.put(hash, currentUpdates);
+            currentUpdates = new Updates();
+        } finally {
+            lock.writeLock().unlock();
         }
-        ByteArrayWrapper hash = new ByteArrayWrapper(blockHash);
-        currentUpdates.blockHeader = hash;
-        currentUpdates.blockNumber = blockNumber;
-        blockUpdates.put(hash, currentUpdates);
-        currentUpdates = new Updates();
     }
 
-    public synchronized void prune(byte[] blockHash, long blockNumber) {
-        if (!enabled) {
-            return;
-        }
-        ByteArrayWrapper blockHashW = new ByteArrayWrapper(blockHash);
-        Updates updates = blockUpdates.remove(blockHashW);
-        if (updates != null) {
-            for (ByteArrayWrapper insertedKey : updates.insertedKeys) {
-                decRef(insertedKey).dbRef = true;
-            }
+    public void prune(byte[] blockHash, long blockNumber) {
+        lock.writeLock().lock();
 
-            List<byte[]> batchRemove = new ArrayList<>();
-            for (ByteArrayWrapper key : updates.deletedKeys) {
-                Ref ref = refCount.get(key);
-                if (ref == null || ref.journalRefs == 0) {
-                    batchRemove.add(key.getData());
-                } else if (ref != null) {
-                    ref.dbRef = false;
+        try {
+            if (!enabled) {
+                return;
+            }
+            ByteArrayWrapper blockHashW = new ByteArrayWrapper(blockHash);
+            Updates updates = blockUpdates.remove(blockHashW);
+            if (updates != null) {
+                for (ByteArrayWrapper insertedKey : updates.insertedKeys) {
+                    decRef(insertedKey).dbRef = true;
                 }
-            }
-            src.deleteBatch(batchRemove);
 
-            rollbackForkBlocks(blockNumber);
+                List<byte[]> batchRemove = new ArrayList<>();
+                for (ByteArrayWrapper key : updates.deletedKeys) {
+                    Ref ref = refCount.get(key);
+                    if (ref == null || ref.journalRefs == 0) {
+                        batchRemove.add(key.getData());
+                    } else if (ref != null) {
+                        ref.dbRef = false;
+                    }
+                }
+                src.deleteBatch(batchRemove);
+
+                rollbackForkBlocks(blockNumber);
+            }
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -199,7 +260,7 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
         }
     }
 
-    private synchronized void rollback(ByteArrayWrapper blockHashW) {
+    private void rollback(ByteArrayWrapper blockHashW) {
         Updates updates = blockUpdates.remove(blockHashW);
         Map<byte[], byte[]> batchRemove = new HashMap<>();
         for (ByteArrayWrapper insertedKey : updates.insertedKeys) {
@@ -220,29 +281,54 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
     }
 
     public int getDeletedKeysCount() {
-        return currentUpdates.deletedKeys.size();
+        lock.readLock().lock();
+        try {
+            return currentUpdates.deletedKeys.size();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     public int getInsertedKeysCount() {
-        return currentUpdates.insertedKeys.size();
+        lock.readLock().lock();
+        try {
+            return currentUpdates.insertedKeys.size();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     public Optional<byte[]> get(byte[] key) {
-        return src.get(key);
+        lock.readLock().lock();
+        try {
+            return src.get(key);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     public Set<byte[]> keys() {
-        return src.keys();
+        lock.readLock().lock();
+        try {
+            return src.keys();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
     public void close() {
-        src.close();
-    }
+        lock.writeLock().lock();
 
-    @Override
-    public void putBatch(Map<byte[], byte[]> inputMap) {
-        updateBatch(inputMap);
+        try {
+            src.close();
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
@@ -257,20 +343,38 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
 
     @Override
     public void deleteBatch(Collection<byte[]> keys) {
-        if (!enabled) {
-            return;
+        lock.writeLock().lock();
+        try {
+            if (!enabled) {
+                return;
+            }
+            // deletes are delayed
+            keys.forEach(key -> currentUpdates.deletedKeys.add(new ByteArrayWrapper(key)));
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                LOG.error("Could not delete batch due to ", e);
+            }
+        } finally {
+            lock.writeLock().unlock();
         }
-        // deletes are delayed
-        keys.forEach(key -> currentUpdates.deletedKeys.add(new ByteArrayWrapper(key)));
     }
 
     @Override
     public boolean isEmpty() {
-        // the delayed deletes are not considered by this check until applied to the db
-        if (!currentUpdates.insertedKeys.isEmpty()) {
-            return false;
-        } else {
-            return src.isEmpty();
+        lock.readLock().lock();
+        try {
+            // the delayed deletes are not considered by this check until applied to the db
+            if (!currentUpdates.insertedKeys.isEmpty()) {
+                return false;
+            } else {
+                return src.isEmpty();
+            }
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            lock.readLock().unlock();
         }
     }
 

--- a/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
+++ b/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
@@ -1430,12 +1430,12 @@ public class JournalPruneDataSourceTest {
         // also removed the updates for block b2
         assertThat(db.getBlockUpdates().size()).isEqualTo(0);
 
-        assertThat(source_db.keys().size()).isEqualTo(5);
+        assertThat(source_db.keys().size()).isEqualTo(4);
         assertThat(source_db.get(k1).get()).isEqualTo(v3);
         assertThat(source_db.get(k2).get()).isEqualTo(v4);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
         assertThat(source_db.get(k4).isPresent()).isFalse();
-        assertThat(source_db.get(k5).get()).isEqualTo(v5);
+        assertThat(source_db.get(k5).isPresent()).isFalse();
         assertThat(source_db.get(k6).get()).isEqualTo(v6);
     }
 
@@ -1485,7 +1485,6 @@ public class JournalPruneDataSourceTest {
 
         // block b3
         db.put(k6, v6);
-        db.delete(k4);
         db.put(k2, v4);
         db.put(k1, v3);
         db.storeBlockChanges(b3, 2);
@@ -1507,12 +1506,11 @@ public class JournalPruneDataSourceTest {
         // prune block b2 at level 1 : (should be called for main chain block)
         db.prune(b2, 1);
         assertThat(db.getBlockUpdates().size()).isEqualTo(1);
-        assertThat(source_db.keys().size()).isEqualTo(5);
+        assertThat(source_db.keys().size()).isEqualTo(4);
         assertThat(source_db.get(k1).get()).isEqualTo(v3);
         assertThat(source_db.get(k2).get()).isEqualTo(v4);
         assertThat(source_db.get(k3).isPresent()).isFalse();
-        // note: k4 must be explicitly deleted even if it was introduced in the discarded b1 block
-        assertThat(source_db.get(k4).get()).isEqualTo(v4);
+        assertThat(source_db.get(k4).isPresent()).isFalse();
         assertThat(source_db.get(k5).get()).isEqualTo(v5);
         assertThat(source_db.get(k6).get()).isEqualTo(v6);
 

--- a/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
+++ b/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
@@ -26,7 +26,7 @@
  * Contributors to the aion source files in decreasing order of code volume:
  *     Aion foundation.
  ******************************************************************************/
-package org.aion.trie;
+package org.aion.mcf.trie;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -36,7 +36,6 @@ import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.db.impl.DatabaseFactory;
 import org.aion.log.AionLoggerFactory;
-import org.aion.mcf.trie.JournalPruneDataSource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -441,7 +440,7 @@ public class JournalPruneDataSourceTest {
     }
 
     @Test
-    public void testDeleteBatchWithPrune() {
+    public void testDeleteBatch_wPrune() {
         // ensure existence
         Map<byte[], byte[]> map = new HashMap<>();
         map.put(k1, v1);
@@ -467,7 +466,7 @@ public class JournalPruneDataSourceTest {
     }
 
     @Test
-    public void testKeys() {
+    public void testKeys_wPrune() {
         db.setPruneEnabled(true);
 
         // keys shouldn't be null even when empty


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- made the `JournalPruneDataSource.java` independent of the block and block header classes
- improved and corrected synchronization
- removed locks from `stateDatabase` since the only class accessing it is the `JournalPruneDataSource`
- further unit tests for the journal prune functionality

Related to issues #54 and #298.

## Note: this PR builds on top of #478.  

The PR in #478 should be reviewed and merged first. After which this PR can be rebased to `master-pre-merge` branch.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [x] New feature.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- full test suite and unit tests submitted as part of this PR

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
