### PR TITLE
Fix sendTransaction error handling

### DIFF
--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -549,15 +549,9 @@ public abstract class ApiAion extends Api {
             throw new NullPointerException();
         }
 
-        try {
-            AionTransaction tx = new AionTransaction(signedTx);
-
-            pendingState.addPendingTransaction(tx);
-
-            return tx.getHash();
-        } catch (Exception ex) {
-            return ByteUtil.EMPTY_BYTE_ARRAY;
-        }
+        AionTransaction tx = new AionTransaction(signedTx);
+        pendingState.addPendingTransaction(tx);
+        return tx.getHash();
     }
 
     // --Commented out by Inspection START (02/02/18 6:58 PM):

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -665,6 +665,7 @@ public class ApiWeb3Aion extends ApiAion {
             byte[] transactionHash = sendTransaction(rawTransaction);
             return new RpcMsg(TypeConverter.toJsonHex(transactionHash));
         } catch (Exception e) {
+            LOG.error("<rpc-server - exception during response for eth_sendRawTransaction: ", e);
             return new RpcMsg(null, RpcError.INTERNAL_ERROR, e.getMessage());
         }
     }

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -661,13 +661,8 @@ public class ApiWeb3Aion extends ApiAion {
 
         byte[] rawTransaction = ByteUtil.hexStringToBytes(_rawTx);
 
-        try {
-            byte[] transactionHash = sendTransaction(rawTransaction);
-            return new RpcMsg(TypeConverter.toJsonHex(transactionHash));
-        } catch (Exception e) {
-            LOG.error("<rpc-server - exception during response for eth_sendRawTransaction: ", e);
-            return new RpcMsg(null, RpcError.INTERNAL_ERROR, e.getMessage());
-        }
+        byte[] transactionHash = sendTransaction(rawTransaction);
+        return new RpcMsg(TypeConverter.toJsonHex(transactionHash));
     }
 
     public RpcMsg eth_call(Object _params) {

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -660,9 +660,13 @@ public class ApiWeb3Aion extends ApiAion {
             return new RpcMsg(null, RpcError.INVALID_PARAMS, "Null raw transaction provided.");
 
         byte[] rawTransaction = ByteUtil.hexStringToBytes(_rawTx);
-        byte[] transactionHash = sendTransaction(rawTransaction);
 
-        return new RpcMsg(TypeConverter.toJsonHex(transactionHash));
+        try {
+            byte[] transactionHash = sendTransaction(rawTransaction);
+            return new RpcMsg(TypeConverter.toJsonHex(transactionHash));
+        } catch (Exception e) {
+            return new RpcMsg(null, RpcError.INTERNAL_ERROR, e.getMessage());
+        }
     }
 
     public RpcMsg eth_call(Object _params) {

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -302,13 +302,13 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
     public byte[] process(byte[] request, byte[] socketId) {
         if (request == null || (request.length < this.getApiHeaderLen())) {
-            return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_header_len_VALUE);
+            return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_header_len_VALUE);
         }
 
         byte[] msgHash = ApiUtil.getApiMsgHash(request);
         if (request[0] < this.getApiVersion()) {
-            return msgHash == null ? ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_api_version_VALUE)
-                    : ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_api_version_VALUE, msgHash);
+            return msgHash == null ? ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_api_version_VALUE)
+                    : ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_api_version_VALUE, msgHash);
         }
 
         short service = (short) request[1];
@@ -317,7 +317,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
         // General Module
         case Message.Funcs.f_protocolVersion_VALUE: {
             if (service != Message.Servs.s_net_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             // TODO : create query API for every module
@@ -328,32 +328,32 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     .setTxpool(this.ac.getAionHub().getPendingState().getVersion())
                     .setVm("0.1.0").build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
         case Message.Funcs.f_minerAddress_VALUE: {
 
             if (service != Message.Servs.s_wallet_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             String cb = this.getCoinbase();
             if (cb == null) {
                 LOG.debug("ApiAion0.process.coinbase - null coinbase");
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_wallet_nullcb_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_wallet_nullcb_VALUE);
             }
 
             Message.rsp_minerAddress rsp = Message.rsp_minerAddress.newBuilder()
                     .setMinerAddr(ByteString.copyFrom(TypeConverter.StringHexToByteArray(cb))).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
 
         case Message.Funcs.f_contractDeploy_VALUE: {
 
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE, msgHash);
             }
 
             Message.req_contractDeploy req;
@@ -365,7 +365,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 // instead of str format like "0xhex".!
                 byte[] bytes = req.getData().toByteArray();
                 if (bytes == null || bytes.length <= 4) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_ct_bytecode_VALUE, msgHash);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_ct_bytecode_VALUE, msgHash);
                 }
 
                 ArgTxCall params = new ArgTxCall(Address.wrap(req.getFrom().toByteArray()), null,
@@ -385,14 +385,14 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 }
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.ContractDeploy exception [{}] ", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE, msgHash);
             }
 
             Message.rsp_contractDeploy rsp = Message.rsp_contractDeploy.newBuilder()
                     .setContractAddress(ByteString.copyFrom(result != null ? result.address.toBytes() : EMPTY_BYTE_ARRAY))
                     .setTxHash(ByteString.copyFrom(result != null ? result.transId : EMPTY_BYTE_ARRAY)).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_tx_Recved_VALUE, msgHash);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_tx_Recved_VALUE, msgHash);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
 
@@ -400,7 +400,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
         case Message.Funcs.f_accounts_VALUE: {
 
             if (service != Message.Servs.s_wallet_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             // noinspection unchecked
@@ -411,24 +411,24 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             }
             Message.rsp_accounts rsp = Message.rsp_accounts.newBuilder().addAllAccout(al).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
         case Message.Funcs.f_blockNumber_VALUE: {
 
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             Message.rsp_blockNumber rsp = Message.rsp_blockNumber.newBuilder()
                     .setBlocknumber(this.getBestBlock().getNumber()).build();
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
         case Message.Funcs.f_unlockAccount_VALUE: {
 
             if (service != Message.Servs.s_wallet_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -439,10 +439,10 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         req.getDuration());
             } catch (InvalidProtocolBufferException e) {
                 LOG.error("ApiAion0.process.unlockAccount exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, (byte) (result ? 0x01 : 0x00));
         }
 
@@ -450,7 +450,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
         case Message.Funcs.f_getBalance_VALUE: {
 
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -463,19 +463,19 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 balance = this.getBalance(addr);
             } catch (InvalidProtocolBufferException e) {
                 LOG.error("ApiAion0.process.getbalance exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
 
             Message.rsp_getBalance rsp = Message.rsp_getBalance.newBuilder()
                     .setBalance(ByteString.copyFrom(balance.toByteArray())).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
         case Message.Funcs.f_compile_VALUE: {
 
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -483,7 +483,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 Message.req_compileSolidity req = Message.req_compileSolidity.parseFrom(data);
                 String source = req.getSource();
                 if (source == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_null_compile_source_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_null_compile_source_VALUE);
                 }
 
                 @SuppressWarnings("unchecked")
@@ -494,7 +494,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     for (Entry<String, CompiledContr> entry : _contrs.entrySet()) {
                         if (entry.getKey().contains("AionCompileError")) {
                             byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(),
-                                    Message.Retcode.r_fail_compile_contract_VALUE);
+                                    Retcode.r_fail_compile_contract_VALUE);
                             Message.t_Contract tc = Message.t_Contract.newBuilder().setError(entry.getValue().error)
                                     .build();
                             return ApiUtil.combineRetMsg(retHeader,
@@ -514,21 +514,21 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         b.putConstracts(entry.getKey(), tc);
                     }
                     Message.rsp_compile rsp = b.build();
-                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 } else {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
                 }
 
             } catch (InvalidProtocolBufferException e) {
                 LOG.error("ApiAion0.process.compile exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_sendTransaction_VALUE: {
 
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE, msgHash);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -545,11 +545,11 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 result = this.sendTransaction(params);
             } catch (InvalidProtocolBufferException e) {
                 LOG.error("ApiAion0.process.sendTransaction exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE, msgHash);
             }
 
             if (result == null) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_sendTx_null_rep_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_sendTx_null_rep_VALUE, msgHash);
             }
 
             getMsgIdMapping().put(ByteArrayWrapper.wrap(result), new AbstractMap.SimpleEntry<>(
@@ -562,12 +562,12 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             Message.rsp_sendTransaction rsp = Message.rsp_sendTransaction.newBuilder()
                     .setTxHash(ByteString.copyFrom(result)).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_tx_Recved_VALUE, msgHash);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_tx_Recved_VALUE, msgHash);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
         case Message.Funcs.f_getCode_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -578,21 +578,21 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 byte[] code = this.getCode(to);
                 if (code == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_null_rsp_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_null_rsp_VALUE);
                 }
 
                 Message.rsp_getCode rsp = Message.rsp_getCode.newBuilder().setCode(ByteString.copyFrom(code)).build();
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getCode exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getTransactionReceipt_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -602,7 +602,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 TxRecpt result = this.getTransactionReceipt(req.getTxHash().toByteArray());
                 if (result == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_getTxReceipt_null_recp_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_getTxReceipt_null_recp_VALUE);
                 }
 
                 List<Message.t_LgEle> logs = new ArrayList<>();
@@ -634,17 +634,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         .setNrgConsumed(result.nrgUsed).setCumulativeNrgUsed(result.cumulativeNrgUsed).addAllLogs(logs)
                         .build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getTransactionReceipt exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_call_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -663,17 +663,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 Message.rsp_call rsp = Message.rsp_call.newBuilder().setResult(ByteString.copyFrom(this.doCall(params)))
                         .build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.call exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockByNumber_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -687,12 +687,12 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return createBlockMsg(blk);
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockByNumber exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockByHash_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -703,19 +703,19 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] hash = req.getBlockHash().toByteArray();
 
                 if (hash == null || hash.length != Hash256.BYTES) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 AionBlock blk = this.getBlockByHash(hash);
                 return createBlockMsg(blk);
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockByHash exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getTransactionByBlockHashAndIndex_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -727,26 +727,26 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] hash = req.getBlockHash().toByteArray();
 
                 if (txIdx < -1 || hash == null || hash.length != Hash256.BYTES) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 AionTransaction tx = this.getTransactionByBlockHashAndIndex(hash, txIdx);
                 if (tx == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_call_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_call_VALUE);
                 }
 
                 Message.rsp_getTransaction rsp = getRsp_getTransaction(tx);
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getTransactionByBlockHashAndIndex exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getTransactionByBlockNumberAndIndex_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -758,26 +758,26 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 long txIdx = req.getTxIndex();
 
                 if (blkNr < -1 || txIdx < -1) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 AionTransaction tx = this.getTransactionByBlockNumberAndIndex(blkNr, txIdx);
                 if (tx == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_call_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_call_VALUE);
                 }
 
                 Message.rsp_getTransaction rsp = getRsp_getTransaction(tx);
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getTransactionByBlockNumberAndIndex exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockTransactionCountByNumber_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -788,27 +788,27 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 long blkNr = req.getBlockNumber();
 
                 if (blkNr < -1) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 long cnt = this.getBlockTransactionCountByNumber(blkNr);
                 if (cnt == -1) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_call_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_call_VALUE);
                 }
 
                 Message.rsp_getBlockTransactionCount rsp = Message.rsp_getBlockTransactionCount.newBuilder()
                         .setTxCount((int) cnt).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockTransactionCountByNumber exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getTransactionCount_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -820,28 +820,28 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 Address addr = Address.wrap(req.getAddress().toByteArray());
 
                 if (blkNr < -1) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 long cnt = this.getTransactionCount(addr, blkNr);
                 if (cnt == -1) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_call_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_call_VALUE);
                 }
 
                 Message.rsp_getTransactionCount rsp = Message.rsp_getTransactionCount.newBuilder().setTxCount((int) cnt)
                         .build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getTransactionCount exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockTransactionCountByHash_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -852,28 +852,28 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] hash = req.getTxHash().toByteArray();
 
                 if (hash == null || hash.length != Hash256.BYTES) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 long cnt = this.getTransactionCountByHash(hash);
                 if (cnt == -1) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_call_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_call_VALUE);
                 }
 
                 Message.rsp_getTransactionCount rsp = Message.rsp_getTransactionCount.newBuilder().setTxCount((int) cnt)
                         .build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getTransactionCount exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getTransactionByHash_VALUE: {
             if (service != Message.Servs.s_chain_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -884,28 +884,28 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] txHash = req.getTxHash().toByteArray();
 
                 if (txHash == null || txHash.length != this.getTxHashLen()) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 AionTransaction tx = this.getTransactionByHash(txHash);
                 if (tx == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_call_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_call_VALUE);
                 }
 
                 Message.rsp_getTransaction rsp = getRsp_getTransaction(tx);
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getTransactionCount exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
 
         case Message.Funcs.f_getActiveNodes_VALUE: {
             if (service != Message.Servs.s_net_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             List<INode> nodes = new ArrayList<>();
@@ -925,17 +925,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 }
 
                 Message.rsp_getActiveNodes rsp = Message.rsp_getActiveNodes.newBuilder().addAllNode(pl).build();
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getActiveNodes exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
 
         case Message.Funcs.f_getStaticNodes_VALUE: {
             if (service != Message.Servs.s_net_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
             List<String> al = Arrays.asList(this.getBootNodes());
             List<Message.t_Node> nl = new ArrayList<>();
@@ -948,16 +948,16 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             try {
                 Message.rsp_getStaticNodes rsp = Message.rsp_getStaticNodes.newBuilder().addAllNode(nl).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getStaticNodes exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getSolcVersion_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             String ver = this.solcVersion();
@@ -965,31 +965,31 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             try {
                 Message.rsp_getSolcVersion rsp = Message.rsp_getSolcVersion.newBuilder().setVer(ver).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getSolcVersion exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_isSyncing_VALUE: {
             if (service != Message.Servs.s_net_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             try {
                 Message.rsp_isSyncing rsp = Message.rsp_isSyncing.newBuilder().setSyncing(!this.getSync().done).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.syncing exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_syncInfo_VALUE: {
             if (service != Message.Servs.s_net_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             SyncInfo sync = this.getSync();
@@ -999,16 +999,16 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         .setNetworkBestBlock(sync.networkBestBlkNumber).setSyncing(!sync.done)
                         .setMaxImportBlocks(24).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.syncInfo exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_accountCreate_VALUE: {
             if (service != Message.Servs.s_account_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1038,24 +1038,24 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 Message.rsp_accountCreate rsp = Message.rsp_accountCreate.newBuilder().addAllAddress(addressList)
                         .addAllPrivateKey(pKeyList).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.accountCreate exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
 
         case Message.Funcs.f_accountLock_VALUE: {
             if (service != Message.Servs.s_wallet_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
 
             if (data == null) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
             }
 
             boolean result;
@@ -1064,35 +1064,35 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 result = this.lockAccount(Address.wrap(req.getAccount().toByteArray()), req.getPassword());
             } catch (InvalidProtocolBufferException e) {
                 LOG.error("ApiAion0.process.lockAccount exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, (byte) (result ? 0x01 : 0x00));
         }
 
         case Message.Funcs.f_userPrivilege_VALUE: {
 
             if (service != Message.Servs.s_privilege_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
-            return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_unsupport_api_VALUE);
+            return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_unsupport_api_VALUE);
         }
         case Message.Funcs.f_mining_VALUE: {
             if (service != Message.Servs.s_mine_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             Message.rsp_mining rsp = Message.rsp_mining.newBuilder().setMining(this.isMining()).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
 
         case Message.Funcs.f_estimateNrg_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE, msgHash);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1108,19 +1108,19 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 result = this.estimateNrg(params);
             } catch (InvalidProtocolBufferException e) {
                 LOG.error("ApiAion0.process.estimateNrg exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE, msgHash);
             }
 
             Message.rsp_estimateNrg rsp = Message.rsp_estimateNrg.newBuilder().setNrg(result).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
 
         case Message.Funcs.f_exportAccounts_VALUE:
         case Message.Funcs.f_backupAccounts_VALUE: {
             if (service != Message.Servs.s_account_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1130,7 +1130,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 req = Message.req_exportAccounts.parseFrom(data);
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.exportAccounts exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
 
             Map<Address, String> addrMap = new HashMap<>();
@@ -1153,13 +1153,13 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             Message.rsp_exportAccounts rsp = Message.rsp_exportAccounts.newBuilder().addAllKeyFile(keyBins)
                     .addAllFailedKey(invalidKey).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
         }
         case Message.Funcs.f_importAccounts_VALUE: {
             if (service != Message.Servs.s_account_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1169,7 +1169,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 req = Message.req_importAccounts.parseFrom(data);
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.importAccount exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
 
             Map<String, String> importKey = req.getPrivateKeyList().parallelStream()
@@ -1177,7 +1177,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
             if (importKey == null) {
                 LOG.error("ApiAion0.process.importAccount exception: [null importKey]");
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
 
             Set<String> res = Keystore.importAccount(importKey);
@@ -1187,13 +1187,13 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
             Message.rsp_importAccounts rsp = Message.rsp_importAccounts.newBuilder().addAllInvalidKey(res).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
         case Message.Funcs.f_signedTransaction_VALUE:
         case Message.Funcs.f_rawTransaction_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE, msgHash);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1204,7 +1204,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] encodedTx = req.getEncodedTx().toByteArray();
                 if (encodedTx == null) {
                     LOG.error("ApiAion0.process.rawTransaction exception: [null encodedTx]");
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 result = this.sendTransaction(encodedTx);
@@ -1214,7 +1214,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             }
 
             if (result == null) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_sendTx_null_rep_VALUE, msgHash);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_sendTx_null_rep_VALUE, msgHash);
             }
 
             getMsgIdMapping().put(ByteArrayWrapper.wrap(result), new AbstractMap.SimpleEntry<>(
@@ -1226,12 +1226,12 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             Message.rsp_sendTransaction rsp = Message.rsp_sendTransaction.newBuilder()
                     .setTxHash(ByteString.copyFrom(result)).build();
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_tx_Recved_VALUE, msgHash);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_tx_Recved_VALUE, msgHash);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
         case Message.Funcs.f_eventRegister_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1243,7 +1243,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 List<String> evtList = new ArrayList<>(req.getEventsList());
                 if (evtList.isEmpty()) {
                     LOG.error("ApiNucoNcp.process.eventRegister : [{}]", "empty event list");
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 Message.t_FilterCt fltr = req.getFilter();
@@ -1267,17 +1267,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 Message.rsp_eventRegister rsp = Message.rsp_eventRegister.newBuilder().setResult(true).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.eventRegister exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_eventDeregister_VALUE: {
             if (service != Message.Servs.s_tx_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1297,7 +1297,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 if (evtList.isEmpty()) {
                     LOG.error("ApiAion0.process.eventRegister : [{}]", "empty event list");
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 long lv = ByteUtil.byteArrayToLong(socketId);
@@ -1317,17 +1317,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 Message.rsp_eventRegister rsp = Message.rsp_eventRegister.newBuilder().setResult(changed).build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.eventDeregister exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockDetailsByNumber_VALUE: {
             if (service != Message.Servs.s_admin_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1352,7 +1352,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 List<Map.Entry<AionBlock, BigInteger>> blks = getBlkAndDifficultyForBlkNumList(blkNum);
 
                 if (blks == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 } else {
 
 
@@ -1361,17 +1361,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                             .addAllBlkDetails(bds)
                             .build();
 
-                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 }
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockSqlByRange_VALUE: {
             if (service != Message.Servs.s_admin_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1402,7 +1402,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     blkEnd = _blkEnd;
 
                 if (blkEnd < blkStart)
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
 
                 // truncate the thing
                 if (blkEnd - blkStart > 1000) {
@@ -1505,16 +1505,16 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         .addAllBlkSql(bds)
                         .build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockDetailsByRange_VALUE: {
             if (service != Message.Servs.s_admin_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1546,7 +1546,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                     .addAllBlkDetails(new ArrayList<>())
                                     .build();
 
-                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 }
 
@@ -1556,7 +1556,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     blkEnd = _blkEnd;
 
                 if (blkEnd < blkStart)
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
 
                 // truncate at the beginning of range
                 if (blkEnd - blkStart > 1000) {
@@ -1648,16 +1648,16 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                 .addAllBlkDetails(bds)
                                 .build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlockDetailsByLatest_VALUE: {
             if (service != Message.Servs.s_admin_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1682,24 +1682,24 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 List<Map.Entry<AionBlock, BigInteger>> blks = getBlkAndDifficultyForBlkNumList(blkNum);
 
                 if (blks == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 } else {
                     List<Message.t_BlockDetail> bds = getRsp_getBlockDetails(blks);
                     Message.rsp_getBlockDetailsByLatest rsp =  Message.rsp_getBlockDetailsByLatest.newBuilder()
                             .addAllBlkDetails(bds)
                             .build();
 
-                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 }
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockDetailsByLatest exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getBlocksByLatest_VALUE: {
             if (service != Message.Servs.s_admin_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1724,24 +1724,24 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 List<Map.Entry<AionBlock, BigInteger>> blks = getBlkAndDifficultyForBlkNumList(blkNum);
 
                 if (blks == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 } else {
                     List<Message.t_Block> bs = getRsp_getBlocks(blks);
                     Message.rsp_getBlocksByLatest rsp =  Message.rsp_getBlocksByLatest.newBuilder()
                             .addAllBlks(bs)
                             .build();
 
-                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                    byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 }
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlocksByLatest exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
         case Message.Funcs.f_getAccountDetailsByAddressList_VALUE: {
             if (service != Message.Servs.s_admin_VALUE) {
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_service_call_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_service_call_VALUE);
             }
 
             byte[] data = parseMsgReq(request, msgHash);
@@ -1769,19 +1769,19 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         ).collect(Collectors.toList());
 
                 if (accounts == null) {
-                    return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+                    return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 Message.rsp_getAccountDetailsByAddressList rsp =  Message.rsp_getAccountDetailsByAddressList.newBuilder()
                         .addAllAccounts(accounts)
                         .build();
 
-                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+                byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE);
             }
         }
 
@@ -1789,7 +1789,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
         // case Message.Funcs.f_submitWork_VALUE:
         // case Message.Funcs.f_getWork_VALUE:
         default:
-            return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_call_VALUE);
+            return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_call_VALUE);
         }
     }
 
@@ -1813,7 +1813,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
     private byte[] createBlockMsg(AionBlock blk) {
         if (blk == null) {
-            return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
+            return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_arguments_VALUE);
         } else {
 
             List<ByteString> al = new ArrayList<>();
@@ -1824,7 +1824,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             BigInteger td = this.ac.getBlockchain().getTotalDifficultyByHash(Hash256.wrap(blk.getHash()));
             Message.rsp_getBlock rsp = getRsp_getBlock(blk, al, td);
 
-            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
+            byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_success_VALUE);
             return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
         }
     }

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -1208,9 +1208,6 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 }
 
                 result = this.sendTransaction(encodedTx);
-            } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAion0.process.rawTransaction exception: [{}]", e.getMessage());
-                return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
             } catch (Exception e) {
                 LOG.error("ApiAion0.process.rawTransaction exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE, msgHash);

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -49,6 +49,7 @@ import java.util.stream.LongStream;
 import org.aion.api.server.ApiAion;
 import org.aion.api.server.ApiUtil;
 import org.aion.api.server.IApiAion;
+import org.aion.api.server.pb.Message.Retcode;
 import org.aion.api.server.types.ArgTxCall;
 import org.aion.api.server.types.CompiledContr;
 import org.aion.api.server.types.EvtContract;
@@ -175,18 +176,18 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 ((AionTxReceipt) _txRcpt).getTransaction().getHash());
 
         if (LOG.isTraceEnabled()) {
-            LOG.trace("ApiAionA0.onPendingTransactionUpdate - txHash: [{}], state: [{}]", txHashW.toString(), _state.getValue());
+            LOG.trace("ApiAion0.onPendingTransactionUpdate - txHash: [{}], state: [{}]", txHashW.toString(), _state.getValue());
         }
 
         if (getMsgIdMapping().get(txHashW) != null) {
             if (pendingStatus.remainingCapacity() == 0) {
                 pendingStatus.poll();
                 LOG.warn(
-                        "ApiAionA0.onPendingTransactionUpdate - txPend ingStatus queue full, drop the first message.");
+                        "ApiAion0.onPendingTransactionUpdate - txPend ingStatus queue full, drop the first message.");
             }
 
             if (LOG.isTraceEnabled()) {
-                LOG.trace("ApiAionA0.onPendingTransactionUpdate - the pending Tx state : [{}]", _state.getValue());
+                LOG.trace("ApiAion0.onPendingTransactionUpdate - the pending Tx state : [{}]", _state.getValue());
             }
 
             pendingStatus.add(new TxPendingStatus(txHashW,
@@ -208,7 +209,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             if (txWait.remainingCapacity() == 0) {
                 txWait.poll();
                 if (LOG.isTraceEnabled()) {
-                    LOG.trace("ApiAionA0.onPendingTransactionUpdate - txWait queue full, drop the first message.");
+                    LOG.trace("ApiAion0.onPendingTransactionUpdate - txWait queue full, drop the first message.");
                 }
             }
 
@@ -216,7 +217,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             try {
                 txWait.put(new TxWaitingMappingUpdate(txHashW, _state.getValue(), ((AionTxReceipt) _txRcpt)));
             } catch (InterruptedException e) {
-                LOG.error("ApiAionA0.onPendingTransactionUpdate txWait.put exception", e.getMessage());
+                LOG.error("ApiAion0.onPendingTransactionUpdate txWait.put exception", e.getMessage());
             }
         }
     }
@@ -338,7 +339,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
             String cb = this.getCoinbase();
             if (cb == null) {
-                LOG.debug("ApiAionA0.process.coinbase - null coinbase");
+                LOG.debug("ApiAion0.process.coinbase - null coinbase");
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_wallet_nullcb_VALUE);
             }
 
@@ -371,7 +372,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         Hex.decode(new String(bytes).substring(2)), BigInteger.ZERO, BigInteger.ZERO, req.getNrgLimit(),
                         req.getNrgPrice());
 
-                LOG.debug("ApiAionA0.process.ContractDeploy - ArgsTxCall: [{}] ", params.toString());
+                LOG.debug("ApiAion0.process.ContractDeploy - ArgsTxCall: [{}] ", params.toString());
 
                 result = this.createContract(params);
 
@@ -379,11 +380,11 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     getMsgIdMapping().put(ByteArrayWrapper.wrap(result.transId), new AbstractMap.SimpleEntry<>(
                             ByteArrayWrapper.wrap(msgHash), ByteArrayWrapper.wrap(socketId)));
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("ApiAionA0.process.ContractDeploy - msgIdMapping.put: [{}] ", ByteArrayWrapper.wrap(result.transId).toString());
+                        LOG.debug("ApiAion0.process.ContractDeploy - msgIdMapping.put: [{}] ", ByteArrayWrapper.wrap(result.transId).toString());
                     }
                 }
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.ContractDeploy exception [{}] ", e.getMessage());
+                LOG.error("ApiAion0.process.ContractDeploy exception [{}] ", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
             }
 
@@ -437,7 +438,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 result = this.unlockAccount(Address.wrap(req.getAccount().toByteArray()), req.getPassword(),
                         req.getDuration());
             } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAionA0.process.unlockAccount exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.unlockAccount exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
 
@@ -461,7 +462,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 balance = this.getBalance(addr);
             } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAionA0.process.getbalance exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getbalance exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
 
@@ -520,7 +521,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 }
 
             } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAionA0.process.compile exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.compile exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -543,7 +544,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 result = this.sendTransaction(params);
             } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAionA0.process.sendTransaction exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.sendTransaction exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
             }
 
@@ -554,7 +555,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             getMsgIdMapping().put(ByteArrayWrapper.wrap(result), new AbstractMap.SimpleEntry<>(
                     ByteArrayWrapper.wrap(msgHash), ByteArrayWrapper.wrap(socketId)));
             if (LOG.isDebugEnabled()) {
-                LOG.debug("ApiAionA0.process.sendTransaction - msgIdMapping.put: [{}]",
+                LOG.debug("ApiAion0.process.sendTransaction - msgIdMapping.put: [{}]",
                         ByteArrayWrapper.wrap(result).toString());
             }
 
@@ -585,7 +586,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getCode exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getCode exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -637,7 +638,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getTransactionReceipt exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getTransactionReceipt exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -666,7 +667,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.call exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.call exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -685,7 +686,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 return createBlockMsg(blk);
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockByNumber exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockByNumber exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -708,7 +709,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 AionBlock blk = this.getBlockByHash(hash);
                 return createBlockMsg(blk);
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockByHash exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockByHash exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -739,7 +740,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getTransactionByBlockHashAndIndex exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getTransactionByBlockHashAndIndex exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -770,7 +771,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getTransactionByBlockNumberAndIndex exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getTransactionByBlockNumberAndIndex exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -801,7 +802,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockTransactionCountByNumber exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockTransactionCountByNumber exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -834,7 +835,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getTransactionCount exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getTransactionCount exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -866,7 +867,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getTransactionCount exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getTransactionCount exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -897,7 +898,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getTransactionCount exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getTransactionCount exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -927,7 +928,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getActiveNodes exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getActiveNodes exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -950,7 +951,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getStaticNodes exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getStaticNodes exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -967,7 +968,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getSolcVersion exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getSolcVersion exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -982,7 +983,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.syncing exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.syncing exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1001,7 +1002,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.syncInfo exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.syncInfo exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1041,7 +1042,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.accountCreate exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.accountCreate exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1062,7 +1063,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 Message.req_accountlock req = Message.req_accountlock.parseFrom(data);
                 result = this.lockAccount(Address.wrap(req.getAccount().toByteArray()), req.getPassword());
             } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAionA0.process.lockAccount exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.lockAccount exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
 
@@ -1106,7 +1107,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                 result = this.estimateNrg(params);
             } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAionA0.process.estimateNrg exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.estimateNrg exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
             }
 
@@ -1128,7 +1129,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             try {
                 req = Message.req_exportAccounts.parseFrom(data);
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.exportAccounts exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.exportAccounts exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
 
@@ -1167,7 +1168,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             try {
                 req = Message.req_importAccounts.parseFrom(data);
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.importAccount exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.importAccount exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
 
@@ -1175,7 +1176,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     .collect(Collectors.toMap(Message.t_PrivateKey::getPrivateKey, Message.t_PrivateKey::getPassword));
 
             if (importKey == null) {
-                LOG.error("ApiAionA0.process.importAccount exception: [null importKey]");
+                LOG.error("ApiAion0.process.importAccount exception: [null importKey]");
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
 
@@ -1202,14 +1203,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 req = Message.req_rawTransaction.parseFrom(data);
                 byte[] encodedTx = req.getEncodedTx().toByteArray();
                 if (encodedTx == null) {
-                    LOG.error("ApiAionA0.process.signedTransaction exception: [null encodedTx]");
+                    LOG.error("ApiAion0.process.rawTransaction exception: [null encodedTx]");
                     return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
                 }
 
                 result = this.sendTransaction(encodedTx);
             } catch (InvalidProtocolBufferException e) {
-                LOG.error("ApiAionA0.process.sendTransaction exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.rawTransaction exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE, msgHash);
+            } catch (Exception e) {
+                LOG.error("ApiAion0.process.rawTransaction exception: [{}]", e.getMessage());
+                return ApiUtil.toReturnHeader(getApiVersion(), Retcode.r_fail_function_exception_VALUE, msgHash);
             }
 
             if (result == null) {
@@ -1219,7 +1223,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
             getMsgIdMapping().put(ByteArrayWrapper.wrap(result), new AbstractMap.SimpleEntry<>(
                     ByteArrayWrapper.wrap(msgHash), ByteArrayWrapper.wrap(socketId)));
             if (LOG.isDebugEnabled()) {
-                LOG.debug("ApiAionA0.process.sendTransaction - msgIdMapping.put: [{}]", ByteArrayWrapper.wrap(result).toString());
+                LOG.debug("ApiAion0.process.rawTransaction - msgIdMapping.put: [{}]", ByteArrayWrapper.wrap(result).toString());
             }
 
             Message.rsp_sendTransaction rsp = Message.rsp_sendTransaction.newBuilder()
@@ -1270,7 +1274,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.eventRegister exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.eventRegister exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1295,7 +1299,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 }
 
                 if (evtList.isEmpty()) {
-                    LOG.error("ApiAionA0.process.eventRegister : [{}]", "empty event list");
+                    LOG.error("ApiAion0.process.eventRegister : [{}]", "empty event list");
                     return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_arguments_VALUE);
                 }
 
@@ -1320,7 +1324,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.eventDeregister exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.eventDeregister exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1364,7 +1368,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 }
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1507,7 +1511,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1650,7 +1654,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 byte[] retHeader = ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_success_VALUE);
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1692,7 +1696,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 }
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockDetailsByLatest exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockDetailsByLatest exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1734,7 +1738,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                     return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
                 }
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlocksByLatest exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlocksByLatest exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }
@@ -1779,7 +1783,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                 return ApiUtil.combineRetMsg(retHeader, rsp.toByteArray());
 
             } catch (Exception e) {
-                LOG.error("ApiAionA0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
+                LOG.error("ApiAion0.process.getBlockDetailsByNumber exception: [{}]", e.getMessage());
                 return ApiUtil.toReturnHeader(getApiVersion(), Message.Retcode.r_fail_function_exception_VALUE);
             }
         }


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- modified ApiAion0 and ApiWeb3Aion so that they catch the exception that the sendTransaction method (in ApiAion) possibly throws (line 1211 of ApiAion0). Also modified ApiAion so that, when an exception occurs, instead of returning a 0 length byte array it propagates the exception up to the caller instead so that the exception info is not lost & masked by the byte array. Some minor typo fixes throughout ApiAion0.

Fixes Issue #176.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Instead of figuring out how to naturally trigger an exception in sendTransaction I simply explicitly threw some exceptions at the top of the method, made calls to the api and monitored the client and server behaviour to ensure the exceptions were caught and handled as expected.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
