### PR TITLE
Fix silent fail when in no-console environment

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -301,8 +301,10 @@ public class Cli {
 
         ECKey key = ECKeyFac.inst().fromPrivate(raw);
         if (key == null) {
-            System.out.println("Uable to recover private key." +
-                "Are you sure you did not import a public key? The provided key was: " + privateKey);
+            System.out.println(
+                    "Uable to recover private key."
+                            + "Are you sure you did not import a public key? The provided key was: "
+                            + privateKey);
             return false;
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -31,6 +31,9 @@
 
 package org.aion.zero.impl.cli;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import org.aion.base.util.Hex;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
@@ -41,6 +44,7 @@ import org.aion.zero.impl.db.RecoveryUtils;
 
 import java.io.Console;
 import java.util.UUID;
+import org.aion.zero.impl.db.RecoveryUtils.Status;
 
 /**
  * Command line interface.
@@ -196,11 +200,17 @@ public class Cli {
     /**
      * Creates a new account.
      *
-     * @return boolean
+     * @return true only if the new account was successfully created, otherwise false.
      */
     private boolean createAccount() {
-        String password = readPassword("Please enter a password: ");
-        String password2 = readPassword("Please re-enter your password: ");
+        String password = null, password2 = null;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            password = readPassword("Please enter a password: ", reader);
+            password2 = readPassword("Please re-enter your password: ", reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
 
         if (!password2.equals(password)) {
             System.out.println("Passwords do not match!");
@@ -244,7 +254,13 @@ public class Cli {
             return false;
         }
 
-        String password = readPassword("Please enter your password: ");
+        String password = null;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            password = readPassword("Please enter your password: ", reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
         ECKey key = Keystore.getKey(address, password);
 
         if (key != null) {
@@ -274,8 +290,15 @@ public class Cli {
 
         ECKey key = ECKeyFac.inst().fromPrivate(raw);
 
-        String password = readPassword("Please enter a password: ");
-        String password2 = readPassword("Please re-enter your password: ");
+        String password = null, password2 = null;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            password = readPassword("Please enter a password: ", reader);
+            password2 = readPassword("Please re-enter your password: ", reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+
         if (!password2.equals(password)) {
             System.out.println("Passwords do not match!");
             return false;
@@ -292,14 +315,47 @@ public class Cli {
     }
 
     /**
-     * Reads a password from the console.
+     * Returns a password after prompting the user to enter it. This method attempts first to read
+     * user input from a console evironment and if one is not available it instead attempts to read
+     * from reader.
      *
-     * @param prompt String
-     * @return boolean
+     * @throws NullPointerException if prompt is null or if console unavailable and reader is null.
+     * @param prompt The read-password prompt to display to the user.
+     * @return The user-entered password.
      */
-    public String readPassword(String prompt) {
+    public String readPassword(String prompt, BufferedReader reader) {
+        if (prompt == null) {
+            throw new NullPointerException("readPassword given null prompt.");
+        }
+
         Console console = System.console();
+        if (console == null) {
+            return readPasswordFromReader(prompt, reader);
+        }
         return new String(console.readPassword(prompt));
+    }
+
+    /**
+     * Returns a password after prompting the user to enter it from reader.
+     *
+     * @throws NullPointerException if reader is null.
+     * @param prompt The read-password prompt to display to the user.
+     * @param reader The BufferedReader to read input from.
+     * @return The user-entered password.
+     */
+    private String readPasswordFromReader(String prompt, BufferedReader reader) {
+        if (reader == null) {
+            throw new NullPointerException("readPasswordFromReader given null reader.");
+        }
+        System.out.println(prompt);
+        try {
+            return reader.readLine();
+        } catch (IOException e) {
+            System.err.println("Error reading from BufferedReader: " + reader);
+            e.printStackTrace();
+            System.exit(1);
+        }
+        return null;    // Make compiler happy; never get here.
     }
 
     private RecoveryUtils.Status revertTo(String blockNumber) {

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -28,12 +28,13 @@
  *
  */
 
-
 package org.aion.zero.impl.cli;
 
 import java.io.BufferedReader;
+import java.io.Console;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.UUID;
 import org.aion.base.util.Hex;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
@@ -41,10 +42,6 @@ import org.aion.mcf.account.Keystore;
 import org.aion.mcf.config.Cfg;
 import org.aion.zero.impl.Version;
 import org.aion.zero.impl.db.RecoveryUtils;
-
-import java.io.Console;
-import java.util.UUID;
-import org.aion.zero.impl.db.RecoveryUtils.Status;
 
 /**
  * Command line interface.
@@ -90,7 +87,7 @@ public class Cli {
                         default:
                             printHelp();
                             return 1;
-                        }
+                    }
                     break;
                 case "-c":
                     cfg.fromXML();
@@ -102,7 +99,13 @@ public class Cli {
                     cfg.fromXML();
                     System.out.println("\nInformation");
                     System.out.println("--------------------------------------------");
-                    System.out.println("current: p2p://" + cfg.getId() + "@" + cfg.getNet().getP2p().getIp() + ":" + cfg.getNet().getP2p().getPort());
+                    System.out.println(
+                            "current: p2p://"
+                                    + cfg.getId()
+                                    + "@"
+                                    + cfg.getNet().getP2p().getIp()
+                                    + ":"
+                                    + cfg.getNet().getP2p().getPort());
                     String[] nodes = cfg.getNet().getNodes();
                     if (nodes != null && nodes.length > 0) {
                         System.out.println("boot nodes list:");
@@ -112,7 +115,11 @@ public class Cli {
                     } else {
                         System.out.println("boot nodes list: 0");
                     }
-                    System.out.println("p2p: " + cfg.getNet().getP2p().getIp() + ":" + cfg.getNet().getP2p().getPort());
+                    System.out.println(
+                            "p2p: "
+                                    + cfg.getNet().getP2p().getIp()
+                                    + ":"
+                                    + cfg.getNet().getP2p().getPort());
                     break;
                 case "-r":
                     if (args.length < 2) {
@@ -121,15 +128,19 @@ public class Cli {
                         System.out.println("Finished database clean-up.");
                     } else {
                         switch (revertTo(args[1])) {
-                        case SUCCESS:
-                            System.out.println("Blockchain successfully reverted to block number " + args[1] + ".");
-                            break;
-                        case FAILURE:
-                            System.out.println("Unable to revert to block number " + args[1] + ".");
-                            return 1;
-                        case ILLEGAL_ARGUMENT:
-                        default:
-                            return 1;
+                            case SUCCESS:
+                                System.out.println(
+                                        "Blockchain successfully reverted to block number "
+                                                + args[1]
+                                                + ".");
+                                break;
+                            case FAILURE:
+                                System.out.println(
+                                        "Unable to revert to block number " + args[1] + ".");
+                                return 1;
+                            case ILLEGAL_ARGUMENT:
+                            default:
+                                return 1;
                         }
                     }
                     break;
@@ -146,7 +157,10 @@ public class Cli {
                         try {
                             count = Long.parseLong(args[1]);
                         } catch (NumberFormatException e) {
-                            System.out.println("The given argument <" + args[1] + "> cannot be converted to a number.");
+                            System.out.println(
+                                    "The given argument <"
+                                            + args[1]
+                                            + "> cannot be converted to a number.");
                         }
                         System.out.println("Printing top " + count + " blocks from database.");
                         RecoveryUtils.dumpBlocks(count);
@@ -174,9 +188,7 @@ public class Cli {
         return 0;
     }
 
-    /**
-     * Print the CLI help info.
-     */
+    /** Print the CLI help info. */
     private void printHelp() {
         System.out.println("Usage: ./aion.sh [options] [arguments]");
         System.out.println();
@@ -191,7 +203,8 @@ public class Cli {
         System.out.println();
         System.out.println("  -i                           show information");
         System.out.println();
-        System.out.println("  -r                           remove blocks on side chains and correct block info");
+        System.out.println(
+                "  -r                           remove blocks on side chains and correct block info");
         System.out.println("  -r [block_number]            revert db up to specific block number");
         System.out.println();
         System.out.println("  -v                           show version");
@@ -244,8 +257,7 @@ public class Cli {
     /**
      * Dumps the private of the given account.
      *
-     * @param address
-     *            address of the account
+     * @param address address of the account
      * @return boolean
      */
     private boolean exportPrivateKey(String address) {
@@ -275,8 +287,7 @@ public class Cli {
     /**
      * Imports a private key.
      *
-     * @param privateKey
-     *            private key in hex string
+     * @param privateKey private key in hex string
      * @return boolean
      */
     private boolean importPrivateKey(String privateKey) {
@@ -289,6 +300,11 @@ public class Cli {
         }
 
         ECKey key = ECKeyFac.inst().fromPrivate(raw);
+        if (key == null) {
+            System.out.println("Uable to recover private key." +
+                "Are you sure you did not import a public key? The provided key was: " + privateKey);
+            return false;
+        }
 
         String password = null, password2 = null;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
@@ -355,7 +371,7 @@ public class Cli {
             e.printStackTrace();
             System.exit(1);
         }
-        return null;    // Make compiler happy; never get here.
+        return null; // Make compiler happy; never get here.
     }
 
     private RecoveryUtils.Status revertTo(String blockNumber) {
@@ -365,11 +381,11 @@ public class Cli {
         try {
             block = Long.parseLong(blockNumber);
         } catch (NumberFormatException e) {
-            System.out.println("The given argument <" + blockNumber + "> cannot be converted to a number.");
+            System.out.println(
+                    "The given argument <" + blockNumber + "> cannot be converted to a number.");
             return RecoveryUtils.Status.ILLEGAL_ARGUMENT;
         }
 
         return RecoveryUtils.revertTo(block);
     }
-
 }

--- a/modAionImpl/test/org/aion/cli/CliTest.java
+++ b/modAionImpl/test/org/aion/cli/CliTest.java
@@ -1,23 +1,21 @@
 package org.aion.cli;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Scanner;
-import org.aion.base.type.Address;
-import org.aion.mcf.account.Keystore;
 import org.aion.base.util.Hex;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
+import org.aion.mcf.account.Keystore;
+import org.aion.zero.impl.cli.Cli;
 import org.aion.zero.impl.config.CfgAion;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import org.aion.zero.impl.cli.Cli;;
 
 public class CliTest {
 

--- a/modAionImpl/test/org/aion/cli/CliTest.java
+++ b/modAionImpl/test/org/aion/cli/CliTest.java
@@ -2,6 +2,7 @@ package org.aion.cli;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 
 import java.io.BufferedReader;
@@ -26,7 +27,7 @@ public class CliTest {
         cli = Mockito.spy(new Cli());
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
-            doReturn("password").when(cli).readPassword(any(), reader);
+            doReturn("password").when(cli).readPassword(any(), eq(reader));
         } catch (IOException e) {
             System.err.println("Error reading user input.");
             e.printStackTrace();

--- a/modAionImpl/test/org/aion/cli/CliTest.java
+++ b/modAionImpl/test/org/aion/cli/CliTest.java
@@ -25,13 +25,7 @@ public class CliTest {
     @Before
     public void setup() {
         cli = Mockito.spy(new Cli());
-
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
-            doReturn("password").when(cli).readPassword(any(), eq(reader));
-        } catch (IOException e) {
-            System.err.println("Error reading user input.");
-            e.printStackTrace();
-        }
+        doReturn("password").when(cli).readPassword(any(), any());
     }
 
     @Test

--- a/modAionImpl/test/org/aion/cli/CliTest.java
+++ b/modAionImpl/test/org/aion/cli/CliTest.java
@@ -1,5 +1,9 @@
 package org.aion.cli;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Scanner;
 import org.aion.base.type.Address;
 import org.aion.mcf.account.Keystore;
 import org.aion.base.util.Hex;
@@ -22,7 +26,13 @@ public class CliTest {
     @Before
     public void setup() {
         cli = Mockito.spy(new Cli());
-        doReturn("password").when(cli).readPassword(any());
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            doReturn("password").when(cli).readPassword(any(), reader);
+        } catch (IOException e) {
+            System.err.println("Error reading user input.");
+            e.printStackTrace();
+        }
     }
 
     @Test

--- a/modMcf/src/org/aion/mcf/account/Keystore.java
+++ b/modMcf/src/org/aion/mcf/account/Keystore.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  *
  * Copyright (c) 2017, 2018 Aion foundation.
  *
@@ -34,7 +34,6 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.HashMap;
 import java.util.stream.Collectors;
-
 import org.aion.base.type.Address;
 import org.aion.base.util.*;
 import org.aion.crypto.ECKey;
@@ -43,9 +42,7 @@ import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.slf4j.Logger;
 
-/**
- *  key store class.
- */
+/** key store class. */
 public class Keystore {
 
     private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
@@ -89,8 +86,7 @@ public class Keystore {
             String fileName = "UTC--" + iso_date + "--" + address;
             try {
                 Path keyFile = PATH.resolve(fileName);
-                if (!Files.exists(keyFile))
-                    keyFile = Files.createFile(keyFile, attr);
+                if (!Files.exists(keyFile)) keyFile = Files.createFile(keyFile, attr);
                 String path = keyFile.toString();
                 FileOutputStream fos = new FileOutputStream(path);
                 fos.write(content);
@@ -132,9 +128,21 @@ public class Keystore {
             return new java.util.HashMap<>();
         }
 
-        List<File> matchedFile = files.parallelStream().filter(file -> account.entrySet().parallelStream()
-                .filter(ac -> file.getName().contains(ac.getKey().toString())).findFirst().isPresent())
-                .collect(Collectors.toList());
+        List<File> matchedFile =
+                files.parallelStream()
+                        .filter(
+                                file ->
+                                        account.entrySet()
+                                                .parallelStream()
+                                                .filter(
+                                                        ac ->
+                                                                file.getName()
+                                                                        .contains(
+                                                                                ac.getKey()
+                                                                                        .toString()))
+                                                .findFirst()
+                                                .isPresent())
+                        .collect(Collectors.toList());
 
         Map<Address, ByteArrayWrapper> res = new HashMap<>();
         for (File file : matchedFile) {
@@ -164,12 +172,13 @@ public class Keystore {
         List<String> addresses = new ArrayList<>();
         List<File> files = getFiles();
 
-        files.forEach((file) -> {
-            String[] frags = file.getName().split("--");
-            if (frags.length == 3) {
-                addresses.add(TypeConverter.toJsonHex(frags[2]));
-            }
-        });
+        files.forEach(
+                (file) -> {
+                    String[] frags = file.getName().split("--");
+                    if (frags.length == 3) {
+                        addresses.add(TypeConverter.toJsonHex(frags[2]));
+                    }
+                });
         return addresses.toArray(new String[addresses.size()]);
     }
 
@@ -184,12 +193,13 @@ public class Keystore {
 
         files.sort(COMPARE);
 
-        files.forEach((file) -> {
-            String[] frags = file.getName().split("--");
-            if (frags.length == 3) {
-                addresses.add(TypeConverter.toJsonHex(frags[2]));
-            }
-        });
+        files.forEach(
+                (file) -> {
+                    String[] frags = file.getName().split("--");
+                    if (frags.length == 3) {
+                        addresses.add(TypeConverter.toJsonHex(frags[2]));
+                    }
+                });
         return addresses;
     }
 
@@ -221,7 +231,6 @@ public class Keystore {
         List<File> files = getFiles();
         boolean flag = false;
         for (File file : files) {
-            String s = file.getName().split("--")[2];
             if (file.getName().split("--")[2].equals(_address)) {
                 flag = true;
                 break;
@@ -239,8 +248,11 @@ public class Keystore {
         int count = 0;
         for (Map.Entry<String, String> keySet : importKey.entrySet()) {
             if (count < 100) {
-                byte[] raw = Hex
-                        .decode(keySet.getKey().startsWith("0x") ? keySet.getKey().substring(2) : keySet.getKey());
+                byte[] raw =
+                        Hex.decode(
+                                keySet.getKey().startsWith("0x")
+                                        ? keySet.getKey().substring(2)
+                                        : keySet.getKey());
                 ECKey key = KeystoreFormat.fromKeystore(raw, keySet.getValue());
                 String address = Keystore.create(keySet.getValue(), key);
                 if (!address.equals("0x")) {

--- a/modMcf/src/org/aion/mcf/account/Keystore.java
+++ b/modMcf/src/org/aion/mcf/account/Keystore.java
@@ -200,7 +200,7 @@ public class Keystore {
         ECKey key = null;
         List<File> files = getFiles();
         for (File file : files) {
-            if (file.getName().contains(_address)) {
+            if (file.getName().split("--")[2].equals(_address)) {
                 try {
                     byte[] content = Files.readAllBytes(file.toPath());
                     key = KeystoreFormat.fromKeystore(content, _password);
@@ -221,7 +221,8 @@ public class Keystore {
         List<File> files = getFiles();
         boolean flag = false;
         for (File file : files) {
-            if (file.getName().contains(_address)) {
+            String s = file.getName().split("--")[2];
+            if (file.getName().split("--")[2].equals(_address)) {
                 flag = true;
                 break;
             }


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Aion would silently fail with NPE when user was not using console. I've caught when we have no console and instead we read the user's password from stdin now so that we can continue to function. Also caught a bug in the exist and getKey methods of Keystore, where an account address was verified as existing as long as it was a substring of an existing address. Now the two addresses must perfectly match. The core of the fix is readPassword and readPasswordFromReader, both in Cli class.

Fixes Issue #486.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- This feature can't be tested in console. Easiest to test it in IDEA by using debugger with appropriate arguments. I walked through a number of cases to test the functionality on all affected methods: createAccount, exportPrivateKey, importPrivateKey.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
