### PR TITLE
fix null console bug and account exist checks

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -289,9 +289,8 @@ public class Cli {
 
         ECKey key = ECKeyFac.inst().fromPrivate(raw);
         if (key == null) {
-            System.out.println("Uable to recover private key."
-                    + "Are you sure you did not import a public key? The provided key was: "
-                    + privateKey);
+            System.out.println("Unable to recover private key."
+                    + "Are you sure you did not import a public key?");
             return false;
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -31,6 +31,9 @@
 
 package org.aion.zero.impl.cli;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import org.aion.base.util.Hex;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
@@ -196,11 +199,17 @@ public class Cli {
     /**
      * Creates a new account.
      *
-     * @return boolean
+     * @return true only if the new account was successfully created, otherwise false.
      */
     private boolean createAccount() {
-        String password = readPassword("Please enter a password: ");
-        String password2 = readPassword("Please re-enter your password: ");
+        String password = null, password2 = null;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            password = readPassword("Please enter a password: ", reader);
+            password2 = readPassword("Please re-enter your password: ", reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
 
         if (!password2.equals(password)) {
             System.out.println("Passwords do not match!");
@@ -244,7 +253,13 @@ public class Cli {
             return false;
         }
 
-        String password = readPassword("Please enter your password: ");
+        String password = null;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            password = readPassword("Please enter your password: ", reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
         ECKey key = Keystore.getKey(address, password);
 
         if (key != null) {
@@ -273,9 +288,22 @@ public class Cli {
         }
 
         ECKey key = ECKeyFac.inst().fromPrivate(raw);
+        if (key == null) {
+            System.out.println("Uable to recover private key."
+                    + "Are you sure you did not import a public key? The provided key was: "
+                    + privateKey);
+            return false;
+        }
 
-        String password = readPassword("Please enter a password: ");
-        String password2 = readPassword("Please re-enter your password: ");
+        String password = null, password2 = null;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            password = readPassword("Please enter a password: ", reader);
+            password2 = readPassword("Please re-enter your password: ", reader);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+
         if (!password2.equals(password)) {
             System.out.println("Passwords do not match!");
             return false;
@@ -292,14 +320,47 @@ public class Cli {
     }
 
     /**
-     * Reads a password from the console.
+     * Returns a password after prompting the user to enter it. This method attempts first to read
+     * user input from a console evironment and if one is not available it instead attempts to read
+     * from reader.
      *
-     * @param prompt String
-     * @return boolean
+     * @throws NullPointerException if prompt is null or if console unavailable and reader is null.
+     * @param prompt The read-password prompt to display to the user.
+     * @return The user-entered password.
      */
-    public String readPassword(String prompt) {
+    public String readPassword(String prompt, BufferedReader reader) {
+        if (prompt == null) {
+            throw new NullPointerException("readPassword given null prompt.");
+        }
+
         Console console = System.console();
+        if (console == null) {
+            return readPasswordFromReader(prompt, reader);
+        }
         return new String(console.readPassword(prompt));
+    }
+
+    /**
+     * Returns a password after prompting the user to enter it from reader.
+     *
+     * @throws NullPointerException if reader is null.
+     * @param prompt The read-password prompt to display to the user.
+     * @param reader The BufferedReader to read input from.
+     * @return The user-entered password.
+     */
+    private String readPasswordFromReader(String prompt, BufferedReader reader) {
+        if (reader == null) {
+            throw new NullPointerException("readPasswordFromReader given null reader.");
+        }
+        System.out.println(prompt);
+        try {
+            return reader.readLine();
+        } catch (IOException e) {
+            System.err.println("Error reading from BufferedReader: " + reader);
+            e.printStackTrace();
+            System.exit(1);
+        }
+        return null; // Make compiler happy; never get here.
     }
 
     private RecoveryUtils.Status revertTo(String blockNumber) {

--- a/modAionImpl/test/org/aion/cli/CliTest.java
+++ b/modAionImpl/test/org/aion/cli/CliTest.java
@@ -22,7 +22,7 @@ public class CliTest {
     @Before
     public void setup() {
         cli = Mockito.spy(new Cli());
-        doReturn("password").when(cli).readPassword(any());
+        doReturn("password").when(cli).readPassword(any(), any());
     }
 
     @Test

--- a/modAionImpl/test/org/aion/cli/CliTest.java
+++ b/modAionImpl/test/org/aion/cli/CliTest.java
@@ -1,6 +1,5 @@
 package org.aion.cli;
 
-import org.aion.base.type.Address;
 import org.aion.mcf.account.Keystore;
 import org.aion.base.util.Hex;
 import org.aion.crypto.ECKey;
@@ -13,36 +12,51 @@ import org.mockito.Mockito;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import org.aion.zero.impl.cli.Cli;;
+import org.aion.zero.impl.cli.Cli;
 
 public class CliTest {
 
-    private Cli cli;
+    private static final Cli cli = Mockito.spy(new Cli());
 
+    /**
+     * Sets up a spy Cli class that returns the String "password" when the cli.readPassword()
+     * is called using any two params.
+     */
     @Before
     public void setup() {
-        cli = Mockito.spy(new Cli());
         doReturn("password").when(cli).readPassword(any(), any());
     }
 
+    /**
+     * Tests the -h argument does not fail.
+     */
     @Test
     public void testHelp() {
         String args[] = {"-h"};
         assertEquals(0, cli.call(args, CfgAion.inst()));
     }
 
+    /**
+     * Tests the -a create arguments do not fail.
+     */
     @Test
     public void testCreateAccount() {
         String args[] = {"-a", "create"};
         assertEquals(0, cli.call(args, CfgAion.inst()));
     }
 
+    /**
+     * Tests the -a list arguments do not fail.
+     */
     @Test
     public void testListAccounts() {
         String args[] = {"-a", "list"};
         assertEquals(0, cli.call(args, CfgAion.inst()));
     }
 
+    /**
+     * Tests the -a export arguments do not fail on a valid account.
+     */
     @Test
     public void testExportPrivateKey() {
         String account = Keystore.create("password");
@@ -51,6 +65,22 @@ public class CliTest {
         assertEquals(0, cli.call(args, CfgAion.inst()));
     }
 
+    /**
+     * Tests the -a export arguments fail when the suupplied account is a proper substring of a
+     * valid account.
+     */
+    @Test
+    public void testExportSubstringOfAccount() {
+        String account = Keystore.create("password");
+        String substrAcc = account.substring(1);
+
+        String[] args = {"-a", "export", substrAcc};
+        assertEquals(1, cli.call(args, CfgAion.inst()));
+    }
+
+    /**
+     * Tests the -a import arguments do not fail on a fail import key.
+     */
     @Test
     public void testImportPrivateKey() {
         ECKey key = ECKeyFac.inst().create();
@@ -59,6 +89,20 @@ public class CliTest {
         assertEquals(0, cli.call(args, CfgAion.inst()));
     }
 
+    /**
+     * Tests the -a import arguments fail when a non-private key is supplied.
+     */
+    @Test
+    public void testImportNonPrivateKey() {
+        String account = Keystore.create("password");
+
+        String[] args = {"-a", "import", account};
+        assertEquals(1, cli.call(args, CfgAion.inst()));
+    }
+
+    /**
+     * Tests the -a import arguments do not fail when a valid private key is supplied.
+     */
     @Test
     public void testImportPrivateKey2() {
         ECKey key = ECKeyFac.inst().create();
@@ -75,6 +119,9 @@ public class CliTest {
         System.out.println("Imported private key: " + Hex.toHexString(key2.getPrivKeyBytes()));
     }
 
+    /**
+     * Tests the -a import arguments fail given an invalid private key.
+     */
     @Test
     public void testImportPrivateKeyWrong() {
         String[] args = {"-a", "import", "hello"};

--- a/modMcf/src/org/aion/mcf/account/Keystore.java
+++ b/modMcf/src/org/aion/mcf/account/Keystore.java
@@ -67,6 +67,7 @@ public class Keystore {
     private static final String KEYSTORE_PATH = System.getProperty("user.dir") + "/keystore";
     private static final Path PATH = Paths.get(KEYSTORE_PATH);
     private static final FileDateTimeComparator COMPARE = new FileDateTimeComparator();
+    private static final Pattern HEX_64 = Pattern.compile("^[\\p{XDigit}]{64}$");
     private static final String ADDR_PREFIX = "0x";
     private static final String AION_PREFIX = "a0";
     private static final int IMPORT_LIMIT = 100;
@@ -230,11 +231,10 @@ public class Keystore {
         }
 
         ECKey key = null;
-        Pattern hex64 = Pattern.compile("^[\\p{XDigit}]{64}$");
         if (_address.startsWith(AION_PREFIX)) {
             List<File> files = getFiles();
             for (File file : files) {
-                if (hex64.matcher(_address).find() && file.getName().contains(_address)) {
+                if (HEX_64.matcher(_address).find() && file.getName().contains(_address)) {
                     try {
                         byte[] content = Files.readAllBytes(file.toPath());
                         key = KeystoreFormat.fromKeystore(content, _password);
@@ -261,11 +261,10 @@ public class Keystore {
         }
 
         boolean flag = false;
-        Pattern hex64 = Pattern.compile("^[\\p{XDigit}]{64}$");
         if (_address.startsWith(AION_PREFIX)) {
             List<File> files = getFiles();
             for (File file : files) {
-                if (hex64.matcher(_address).find() && file.getName().contains(_address)) {
+                if (HEX_64.matcher(_address).find() && file.getName().contains(_address)) {
                     flag = true;
                     break;
                 }

--- a/modMcf/src/org/aion/mcf/account/Keystore.java
+++ b/modMcf/src/org/aion/mcf/account/Keystore.java
@@ -231,7 +231,7 @@ public class Keystore {
         if (_address.startsWith(AION_PREFIX)) {
             List<File> files = getFiles();
             for (File file : files) {
-                if (file.getName().contains(_address)) {
+                if (file.getName().split("--")[2].equals(_address)) {
                     try {
                         byte[] content = Files.readAllBytes(file.toPath());
                         key = KeystoreFormat.fromKeystore(content, _password);
@@ -255,7 +255,7 @@ public class Keystore {
         if (_address.startsWith(AION_PREFIX)) {
             List<File> files = getFiles();
             for (File file : files) {
-                if (file.getName().contains(_address)) {
+                if (file.getName().split("--")[2].equals(_address)) {
                     flag = true;
                     break;
                 }

--- a/modMcf/src/org/aion/mcf/account/Keystore.java
+++ b/modMcf/src/org/aion/mcf/account/Keystore.java
@@ -49,6 +49,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.aion.base.type.Address;
 import org.aion.base.util.*;
@@ -228,10 +230,11 @@ public class Keystore {
         }
 
         ECKey key = null;
+        Pattern hex64 = Pattern.compile("^[\\p{XDigit}]{64}$");
         if (_address.startsWith(AION_PREFIX)) {
             List<File> files = getFiles();
             for (File file : files) {
-                if (file.getName().split("--")[2].equals(_address)) {
+                if (hex64.matcher(_address).find() && file.getName().contains(_address)) {
                     try {
                         byte[] content = Files.readAllBytes(file.toPath());
                         key = KeystoreFormat.fromKeystore(content, _password);
@@ -246,16 +249,23 @@ public class Keystore {
         return key;
     }
 
+    /**
+     * Returns true if the address _address exists, false otherwise.
+     *
+     * @param _address the address whose existence is to be tested.
+     * @return true only if _address exists.
+     */
     public static boolean exist(String _address) {
         if (_address.startsWith(ADDR_PREFIX)) {
             _address = _address.substring(2);
         }
 
         boolean flag = false;
+        Pattern hex64 = Pattern.compile("^[\\p{XDigit}]{64}$");
         if (_address.startsWith(AION_PREFIX)) {
             List<File> files = getFiles();
             for (File file : files) {
-                if (file.getName().split("--")[2].equals(_address)) {
+                if (hex64.matcher(_address).find() && file.getName().contains(_address)) {
                     flag = true;
                     break;
                 }


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- If aion is run outside of a console environment we get a NPE. Fixes this by catching the null and recovers by prompting the user from stdin instead. Also fixed two minor instances of the same bug in Keystore, where an account address qualified as existing as long as it was a substring of a genuinely existing address.

Fixes Issue #493 .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Can't be tested in console. Best way to test is to open debugger in IDEA with correct arguments. The affected methods in Cli class are: createAccount, exportPrivateKey, importPrivateKey. I've stepped through the debugger on all three under various circumstances.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
