### PR TITLE
Archive states at runtime

### DIFF
--- a/modAionBase/src/org/aion/base/db/IKeyValueStore.java
+++ b/modAionBase/src/org/aion/base/db/IKeyValueStore.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -42,14 +42,11 @@ import java.util.Set;
 /**
  * Functionality for a key-value cache allowing itemized updates.
  *
- * @param <K>
- *            the data type of the keys
- * @param <V>
- *            the data type of the values
+ * @param <K> the data type of the keys
+ * @param <V> the data type of the values
  * @author Alexandra Roatis
- * @implNote For the underlying DB connection, if [isClosed() == true], then all
- *           function calls which are documented to throw RuntimeException, will
- *           throw a RuntimeException.
+ * @implNote For the underlying DB connection, if [isClosed() == true], then all function calls
+ *     which are documented to throw RuntimeException, will throw a RuntimeException.
  */
 public interface IKeyValueStore<K, V> extends AutoCloseable {
 
@@ -60,8 +57,7 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
      * Returns if the DB is empty or not.
      *
      * @return True if number of keys > 0, false otherwise
-     * @throws RuntimeException
-     *             if the data store is closed
+     * @throws RuntimeException if the data store is closed
      */
     boolean isEmpty();
 
@@ -69,23 +65,18 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
      * Returns the set of keys for the database.
      *
      * @return Set of keys
-     * @throws RuntimeException
-     *             if the data store is closed
-     * @apiNote Returns an empty set if the database keys could not be
-     *          retrieved.
+     * @throws RuntimeException if the data store is closed
+     * @apiNote Returns an empty set if the database keys could not be retrieved.
      */
     Set<K> keys();
 
     /**
-     * get retrieves a value from the database, returning an optional, it is
-     * fulfilled if a value was able to be retrieved from the DB, otherwise the
-     * optional is empty
+     * get retrieves a value from the database, returning an optional, it is fulfilled if a value
+     * was able to be retrieved from the DB, otherwise the optional is empty
      *
      * @param k
-     * @throws RuntimeException
-     *             if the data store is closed
-     * @throws IllegalArgumentException
-     *             if the key is null
+     * @throws RuntimeException if the data store is closed
+     * @throws IllegalArgumentException if the key is null
      */
     Optional<V> get(K k);
 
@@ -93,44 +84,34 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
     // -------------------------------------------------------------------------------------
 
     /**
-     * Places or updates a value into the cache at the corresponding key. Makes
-     * no guarantees about when the value is actually inserted into the
-     * underlying data store.
+     * Places or updates a value into the cache at the corresponding key. Makes no guarantees about
+     * when the value is actually inserted into the underlying data store.
      *
-     * @param k
-     *            the key for the new entry
-     * @param v
-     *            the value for the new entry
-     * @throws RuntimeException
-     *             if the underlying data store is closed
-     * @throws IllegalArgumentException
-     *             if the key is null
-     * @implNote The choice of when to push the changes to the data store is
-     *           left up to the implementation.
+     * @param k the key for the new entry
+     * @param v the value for the new entry
+     * @throws RuntimeException if the underlying data store is closed
+     * @throws IllegalArgumentException if the key is null
+     * @implNote The choice of when to push the changes to the data store is left up to the
+     *     implementation.
      * @apiNote Put must have the following properties:
-     *          <ol>
-     *          <li>Creates a new entry in the cache, if the key-value pair does
-     *          not exist in the cache or underlying data store.</li>
-     *          <li>Updates the entry in the cache when the key-value pair
-     *          already exists.
-     *          <li>Deletes the entry when given a {@code null} value.</li>
-     *          </ol>
+     *     <ol>
+     *       <li>Creates a new entry in the cache, if the key-value pair does not exist in the cache
+     *           or underlying data store.
+     *       <li>Updates the entry in the cache when the key-value pair already exists.
+     *       <li>Deletes the entry when given a {@code null} value.
+     *     </ol>
      */
     void put(K k, V v);
 
     /**
-     * Delete an entry from the cache, marking it for deletion inside the data
-     * store. Makes no guarantees about when the value is actually deleted from
-     * the underlying data store.
+     * Delete an entry from the cache, marking it for deletion inside the data store. Makes no
+     * guarantees about when the value is actually deleted from the underlying data store.
      *
-     * @param k
-     *            the key of the entry to be deleted
-     * @throws RuntimeException
-     *             if the underlying data store is closed
-     * @throws IllegalArgumentException
-     *             if the key is null
-     * @implNote The choice of when to push the changes to the data store is
-     *           left up to the implementation.
+     * @param k the key of the entry to be deleted
+     * @throws RuntimeException if the underlying data store is closed
+     * @throws IllegalArgumentException if the key is null
+     * @implNote The choice of when to push the changes to the data store is left up to the
+     *     implementation.
      */
     void delete(K k);
 
@@ -138,37 +119,32 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
     // ---------------------------------------------------------------------------------------------------
 
     /**
-     * Puts or updates the data store with the given <i>key-value</i> pairs, as
-     * follows:
+     * Puts or updates the data store with the given <i>key-value</i> pairs, as follows:
+     *
      * <ul>
-     * <li>if the <i>key</i> is present in the data store, the stored
-     * <i>value</i> is overwritten</li>
-     * <li>if the <i>key</i> is not present in the data store, the new
-     * <i>key-value</i> pair is stored</li>
-     * <li>if the <i>value</i> is null, the matching stored <i>key</i> will be
-     * deleted from the data store, or</li>
+     *   <li>if the <i>key</i> is present in the data store, the stored <i>value</i> is overwritten
+     *   <li>if the <i>key</i> is not present in the data store, the new <i>key-value</i> pair is
+     *       stored
+     *   <li>if the <i>value</i> is null, the matching stored <i>key</i> will be deleted from the
+     *       data store, or
      * </ul>
      *
-     * @param inputMap
-     *            a {@link Map} of key-value pairs to be updated in the database
-     * @throws RuntimeException
-     *             if the data store is closed
-     * @throws IllegalArgumentException
-     *             if the map contains a null key
+     * @param inputMap a {@link Map} of key-value pairs to be updated in the database
+     * @throws RuntimeException if the data store is closed
+     * @throws IllegalArgumentException if the map contains a null key
      */
     void putBatch(Map<K, V> inputMap);
 
-    void putToBatch(byte[] key, byte[] value);
+    void putToBatch(K key, V value);
+
     void commitBatch();
 
     /**
      * Similar to delete, except operates on a list of keys
      *
      * @param keys
-     * @throws RuntimeException
-     *             if the data store is closed
-     * @throws IllegalArgumentException
-     *             if the collection contains a null key
+     * @throws RuntimeException if the data store is closed
+     * @throws IllegalArgumentException if the collection contains a null key
      */
     void deleteBatch(Collection<K> keys);
 }

--- a/modAionBase/src/org/aion/base/db/IKeyValueStore.java
+++ b/modAionBase/src/org/aion/base/db/IKeyValueStore.java
@@ -147,4 +147,13 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
      * @throws IllegalArgumentException if the collection contains a null key
      */
     void deleteBatch(Collection<K> keys);
+
+    /**
+     * Checks that the data store connection is open. Throws a {@link RuntimeException} if the data
+     * store connection is closed.
+     *
+     * @implNote Always do this check after acquiring a lock on the class/data. Otherwise it might
+     *     produce inconsistent results due to lack of synchronization.
+     */
+    void check();
 }

--- a/modAionBase/src/org/aion/base/db/IPruneConfig.java
+++ b/modAionBase/src/org/aion/base/db/IPruneConfig.java
@@ -1,0 +1,30 @@
+package org.aion.base.db;
+
+/**
+ * Interface for pruning configuration parameters.
+ *
+ * @author Alexandra Roatis
+ */
+public interface IPruneConfig {
+
+    /**
+     * Indicates if pruning should be enabled or disabled.
+     *
+     * @return {@code true} when pruning enabled, {@code false} when pruning disabled.
+     */
+    boolean isEnabled();
+
+    /**
+     * @return the number of topmost blocks for which the full data should be maintained on disk.
+     */
+    int getCurrentCount();
+
+    /**
+     * Gets the rate at which blocks should be archived (for which the full data should be
+     * maintained on disk). Blocks that are exact multiples of the returned value should be
+     * persisted on disk, regardless of other pruning.
+     *
+     * @return integer value representing the archive rate
+     */
+    int getArchiveRate();
+}

--- a/modAionBase/src/org/aion/base/db/IPruneConfig.java
+++ b/modAionBase/src/org/aion/base/db/IPruneConfig.java
@@ -15,6 +15,13 @@ public interface IPruneConfig {
     boolean isEnabled();
 
     /**
+     * Indicates if archiving should be enabled or disabled.
+     *
+     * @return {@code true} when archiving enabled, {@code false} when archiving disabled.
+     */
+    boolean isArchived();
+
+    /**
      * @return the number of topmost blocks for which the full data should be maintained on disk.
      */
     int getCurrentCount();

--- a/modAionBase/src/org/aion/base/db/IRepositoryConfig.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryConfig.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -37,19 +37,17 @@ package org.aion.base.db;
 import java.util.Properties;
 
 /**
- * Represents a configuration interface accepted that should be accepted by the
- * repository to implement necessary configs
+ * Represents a configuration interface accepted that should be accepted by the repository to
+ * implement necessary configs
  *
  * @author yao
  */
 public interface IRepositoryConfig {
 
-    /**
-     * @return absolute path to the DB folder containing files
-     */
+    /** @return absolute path to the DB folder containing files */
     String getDbPath();
 
-    int getPrune();
+    IPruneConfig getPruneConfig();
 
     IContractDetails contractDetailsImpl();
 

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -1356,6 +1356,9 @@ public class AionBlockchainImpl implements IAionBlockchain {
 
         AionRepositoryImpl repo = (AionRepositoryImpl) repository;
 
+        // keeping track of the original root
+        byte[] originalRoot = repo.getRoot();
+
         Deque<AionBlock> dirtyBlocks = new ArrayDeque<>();
         // already known to be missing the state
         dirtyBlocks.push(block);
@@ -1396,6 +1399,9 @@ public class AionBlockchainImpl implements IAionBlockchain {
 
         // update the repository
         repo.flush();
+
+        // setting the root back to its correct value
+        repo.syncToRoot(originalRoot);
 
         // return a flag indicating if the recovery worked
         return repo.isValidRoot(block.getStateRoot());

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -1351,7 +1351,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
         }
 
         long blockNumber = block.getNumber();
-        LOG.info("Corrupt world state at block hash: {}, number: {}."
+        LOG.info("Pruned or corrupt world state at block hash: {}, number: {}."
                          + " Looking for ancestor block with valid world state ...", block.getShortHash(), blockNumber);
 
         AionRepositoryImpl repo = (AionRepositoryImpl) repository;

--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -282,9 +282,13 @@ public class AionHub {
                         "Corrupt world state for genesis block hash: " + genesis.getShortHash() + ", number: " + genesis
                                 .getNumber() + ".");
 
-                buildGenesis(genesis);
+                AionHubUtils.buildGenesis(genesis, repository);
 
-                LOG.info("Rebuilding genesis block SUCCEEDED.");
+                if (repository.isValidRoot(genesis.getStateRoot())) {
+                    LOG.info("Rebuilding genesis block SUCCEEDED.");
+                } else {
+                    LOG.info("Rebuilding genesis block FAILED.");
+                }
             }
 
             recovered = this.blockchain.recoverWorldState(this.repository, bestBlock);
@@ -335,7 +339,7 @@ public class AionHub {
 
             AionGenesis genesis = cfg.getGenesis();
 
-            buildGenesis(genesis);
+            AionHubUtils.buildGenesis(genesis, repository);
 
             blockchain.setBestBlock(genesis);
             blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());
@@ -389,30 +393,6 @@ public class AionHub {
         }
 
 //        this.repository.getBlockStore().load();
-    }
-
-    private void buildGenesis(AionGenesis genesis) {
-        // initialization section for network balance contract
-        IRepositoryCache track = repository.startTracking();
-
-        Address networkBalanceAddress = PrecompiledContracts.totalCurrencyAddress;
-        track.createAccount(networkBalanceAddress);
-
-        for (Map.Entry<Integer, BigInteger> addr : genesis.getNetworkBalances().entrySet()) {
-            track.addStorageRow(
-                    networkBalanceAddress,
-                    new DataWord(addr.getKey()),
-                    new DataWord(addr.getValue()));
-        }
-
-        for (Address addr : genesis.getPremine().keySet()) {
-            track.createAccount(addr);
-            track.addBalance(addr, genesis.getPremine().get(addr).getBalance());
-        }
-        track.flush();
-
-        this.repository.commitBlock(genesis.getHeader());
-        this.repository.getBlockStore().saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
     }
 
     public void close() {

--- a/modAionImpl/src/org/aion/zero/impl/AionHubUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHubUtils.java
@@ -1,0 +1,65 @@
+/* ******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ ******************************************************************************/
+package org.aion.zero.impl;
+
+import java.math.BigInteger;
+import java.util.Map;
+import org.aion.base.db.IRepositoryCache;
+import org.aion.base.type.Address;
+import org.aion.mcf.vm.types.DataWord;
+import org.aion.vm.PrecompiledContracts;
+import org.aion.zero.impl.db.AionRepositoryImpl;
+
+/** {@link AionHub} functionality where a full instantiation of the class is not desirable. */
+public class AionHubUtils {
+
+    public static void buildGenesis(AionGenesis genesis, AionRepositoryImpl repository) {
+        // initialization section for network balance contract
+        IRepositoryCache track = repository.startTracking();
+
+        Address networkBalanceAddress = PrecompiledContracts.totalCurrencyAddress;
+        track.createAccount(networkBalanceAddress);
+
+        for (Map.Entry<Integer, BigInteger> addr : genesis.getNetworkBalances().entrySet()) {
+            track.addStorageRow(
+                    networkBalanceAddress,
+                    new DataWord(addr.getKey()),
+                    new DataWord(addr.getValue()));
+        }
+
+        for (Address addr : genesis.getPremine().keySet()) {
+            track.createAccount(addr);
+            track.addBalance(addr, genesis.getPremine().get(addr).getBalance());
+        }
+        track.flush();
+
+        repository.commitBlock(genesis.getHeader());
+        repository.getBlockStore().saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
+    }
+}

--- a/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -19,22 +19,27 @@
  *
  * Contributors:
  *     Aion foundation.
- *     
+ *
  ******************************************************************************/
 
 package org.aion.zero.impl;
 
+import java.math.BigInteger;
+import java.util.*;
 import org.aion.base.db.IContractDetails;
+import org.aion.base.db.IPruneConfig;
 import org.aion.base.db.IRepositoryCache;
 import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteArrayWrapper;
-import org.aion.db.impl.DatabaseFactory;
-import org.aion.mcf.core.AccountState;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
 import org.aion.db.impl.DBVendor;
+import org.aion.db.impl.DatabaseFactory;
+import org.aion.mcf.config.CfgPrune;
+import org.aion.mcf.core.AccountState;
 import org.aion.mcf.valid.BlockHeaderValidator;
+import org.aion.mcf.vm.types.DataWord;
 import org.aion.vm.PrecompiledContracts;
 import org.aion.zero.exceptions.HeaderStructureException;
 import org.aion.zero.impl.blockchain.ChainConfiguration;
@@ -47,50 +52,49 @@ import org.aion.zero.impl.valid.AionExtraDataRule;
 import org.aion.zero.impl.valid.AionHeaderVersionRule;
 import org.aion.zero.impl.valid.EnergyConsumedRule;
 import org.aion.zero.types.A0BlockHeader;
-import org.aion.mcf.vm.types.DataWord;
-
-import java.math.BigInteger;
-import java.util.*;
 
 /**
- * Used mainly for debugging and testing purposes, provides codepaths for easy
- * setup, into standard configurations that a user might expected, and handles
- * any non-intuitive setup that the blockchain may require.
+ * Used mainly for debugging and testing purposes, provides codepaths for easy setup, into standard
+ * configurations that a user might expected, and handles any non-intuitive setup that the
+ * blockchain may require.
  */
 public class StandaloneBlockchain extends AionBlockchainImpl {
 
     public AionGenesis genesis;
 
-    private static IRepositoryConfig repoConfig = new IRepositoryConfig() {
-        @Override
-        public String getDbPath() {
-            return "";
-        }
+    private static IRepositoryConfig repoConfig =
+            new IRepositoryConfig() {
+                @Override
+                public String getDbPath() {
+                    return "";
+                }
 
-        @Override
-        public int getPrune() {
-            return -1;
-        }
+                @Override
+                public IPruneConfig getPruneConfig() {
+                    return new CfgPrune(false);
+                }
 
-        @Override
-        public IContractDetails contractDetailsImpl() {
-            return ContractDetailsAion.createForTesting(0, 1000000).getDetails();
-        }
+                @Override
+                public IContractDetails contractDetailsImpl() {
+                    return ContractDetailsAion.createForTesting(0, 1000000).getDetails();
+                }
 
-        @Override
-        public Properties getDatabaseConfig(String db_name) {
-            Properties props = new Properties();
-            props.setProperty(DatabaseFactory.Props.DB_TYPE, DBVendor.MOCKDB.toValue());
-            props.setProperty(DatabaseFactory.Props.ENABLE_HEAP_CACHE, "false");
-            return props;
-        }
-    };
+                @Override
+                public Properties getDatabaseConfig(String db_name) {
+                    Properties props = new Properties();
+                    props.setProperty(DatabaseFactory.Props.DB_TYPE, DBVendor.MOCKDB.toValue());
+                    props.setProperty(DatabaseFactory.Props.ENABLE_HEAP_CACHE, "false");
+                    return props;
+                }
+            };
 
     protected StandaloneBlockchain(final A0BCConfig config, final ChainConfiguration chainConfig) {
         super(config, AionRepositoryImpl.createForTesting(repoConfig), chainConfig);
     }
 
-    protected StandaloneBlockchain(final A0BCConfig config, final ChainConfiguration chainConfig,
+    protected StandaloneBlockchain(
+            final A0BCConfig config,
+            final ChainConfiguration chainConfig,
             IRepositoryConfig repoConfig) {
         super(config, AionRepositoryImpl.createForTesting(repoConfig), chainConfig);
     }
@@ -103,9 +107,7 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
         return this.genesis;
     }
 
-    public void loadJSON(String json) {
-
-    }
+    public void loadJSON(String json) {}
 
     public BlockHeaderValidator getBlockHeaderValidator() {
         return this.chainConfiguration.createBlockHeaderValidator();
@@ -133,15 +135,15 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
         private IRepositoryConfig repoConfig;
 
         public static final int INITIAL_ACC_LEN = 10;
-        public static final BigInteger DEFAULT_BALANCE = new BigInteger("1000000000000000000000000");
+        public static final BigInteger DEFAULT_BALANCE =
+                new BigInteger("1000000000000000000000000");
 
         /**
-         * The type of validator selected for the blockchain, a "full" validator
-         * validates blocks as if they were broadcasted from the network.
-         * Therefore the header validator will require a valid equiHash
-         * solution.
+         * The type of validator selected for the blockchain, a "full" validator validates blocks as
+         * if they were broadcasted from the network. Therefore the header validator will require a
+         * valid equiHash solution.
          *
-         * {@code validatorType -> (full|simple)}
+         * <p>{@code validatorType -> (full|simple)}
          */
         String validatorType;
 
@@ -154,7 +156,8 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
             for (int i = 0; i < INITIAL_ACC_LEN; i++) {
                 ECKey pk = ECKeyFac.inst().create();
                 this.defaultKeys.add(pk);
-                initialState.put(new ByteArrayWrapper(pk.getAddress()),
+                initialState.put(
+                        new ByteArrayWrapper(pk.getAddress()),
                         new AccountState(BigInteger.ZERO, DEFAULT_BALANCE));
             }
             return this;
@@ -162,8 +165,11 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
 
         public Builder withDefaultAccounts(List<ECKey> defaultAccounts) {
             this.defaultKeys.addAll(defaultAccounts);
-            this.defaultKeys.forEach(k -> initialState.put(new ByteArrayWrapper(k.getAddress()),
-                    new AccountState(BigInteger.ZERO, DEFAULT_BALANCE)));
+            this.defaultKeys.forEach(
+                    k ->
+                            initialState.put(
+                                    new ByteArrayWrapper(k.getAddress()),
+                                    new AccountState(BigInteger.ZERO, DEFAULT_BALANCE)));
             return this;
         }
 
@@ -199,8 +205,8 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
                 }
 
                 @Override
-                public int getPrune() {
-                    return -1;
+                public IPruneConfig getPruneConfig() {
+                    return new CfgPrune(false);
                 }
 
                 @Override
@@ -219,41 +225,45 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
         }
 
         public Bundle build() {
-            this.a0Config = this.a0Config == null ? new A0BCConfig() {
-                @Override
-                public Address getCoinbase() {
-                    return Address.ZERO_ADDRESS();
-                }
+            this.a0Config =
+                    this.a0Config == null
+                            ? new A0BCConfig() {
+                                @Override
+                                public Address getCoinbase() {
+                                    return Address.ZERO_ADDRESS();
+                                }
 
-                @Override
-                public byte[] getExtraData() {
-                    return new byte[32];
-                }
+                                @Override
+                                public byte[] getExtraData() {
+                                    return new byte[32];
+                                }
 
-                @Override
-                public boolean getExitOnBlockConflict() {
-                    return false;
-                }
+                                @Override
+                                public boolean getExitOnBlockConflict() {
+                                    return false;
+                                }
 
-                @Override
-                public Address getMinerCoinbase() {
-                    return Address.ZERO_ADDRESS();
-                }
+                                @Override
+                                public Address getMinerCoinbase() {
+                                    return Address.ZERO_ADDRESS();
+                                }
 
-                @Override
-                public int getFlushInterval() {
-                    return 1;
-                }
+                                @Override
+                                public int getFlushInterval() {
+                                    return 1;
+                                }
 
-                @Override
-                public AbstractEnergyStrategyLimit getEnergyLimitStrategy() {
-                    return new TargetStrategy(
-                            configuration.getConstants().getEnergyLowerBoundLong(),
-                            configuration.getConstants().getEnergyDivisorLimitLong(),
-                            10_000_000L);
-                }
-
-            } : this.a0Config;
+                                @Override
+                                public AbstractEnergyStrategyLimit getEnergyLimitStrategy() {
+                                    return new TargetStrategy(
+                                            configuration.getConstants().getEnergyLowerBoundLong(),
+                                            configuration
+                                                    .getConstants()
+                                                    .getEnergyDivisorLimitLong(),
+                                            10_000_000L);
+                                }
+                            }
+                            : this.a0Config;
 
             if (this.configuration == null) {
                 if (this.validatorType == null) {
@@ -261,34 +271,38 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
                 } else if (this.validatorType.equals("full")) {
                     this.configuration = new ChainConfiguration();
                 } else if (this.validatorType.equals("simple")) {
-                    this.configuration = new ChainConfiguration() {
-                        /*
-                         * Remove the equiHash solution for the simplified
-                         * validator this gives us the ability to connect new
-                         * blocks without validating the solution and POW.
-                         *
-                         * This is good for transaction testing, but another set
-                         * of tests need to ensure that the equihash and POW
-                         * generated are valid.
-                         */
-                        @Override
-                        public BlockHeaderValidator<A0BlockHeader> createBlockHeaderValidator() {
-                            return new BlockHeaderValidator<A0BlockHeader>(
-                                    Arrays.asList(
-                                            new AionExtraDataRule(this.constants.getMaximumExtraDataSize()),
-                                            new EnergyConsumedRule(),
-                                            new AionHeaderVersionRule()));
-                        }
-                    };
+                    this.configuration =
+                            new ChainConfiguration() {
+                                /*
+                                 * Remove the equiHash solution for the simplified
+                                 * validator this gives us the ability to connect new
+                                 * blocks without validating the solution and POW.
+                                 *
+                                 * This is good for transaction testing, but another set
+                                 * of tests need to ensure that the equihash and POW
+                                 * generated are valid.
+                                 */
+                                @Override
+                                public BlockHeaderValidator<A0BlockHeader>
+                                        createBlockHeaderValidator() {
+                                    return new BlockHeaderValidator<A0BlockHeader>(
+                                            Arrays.asList(
+                                                    new AionExtraDataRule(
+                                                            this.constants
+                                                                    .getMaximumExtraDataSize()),
+                                                    new EnergyConsumedRule(),
+                                                    new AionHeaderVersionRule()));
+                                }
+                            };
                 } else {
                     throw new IllegalArgumentException("validatorType != (full|simple)");
                 }
             }
 
-            if (this.repoConfig == null)
-                this.repoConfig = generateRepositoryConfig();
+            if (this.repoConfig == null) this.repoConfig = generateRepositoryConfig();
 
-            StandaloneBlockchain bc = new StandaloneBlockchain(this.a0Config, this.configuration, this.repoConfig);
+            StandaloneBlockchain bc =
+                    new StandaloneBlockchain(this.a0Config, this.configuration, this.repoConfig);
 
             AionGenesis.Builder genesisBuilder = new AionGenesis.Builder();
             for (Map.Entry<ByteArrayWrapper, AccountState> acc : this.initialState.entrySet()) {
@@ -307,7 +321,9 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
             track.createAccount(PrecompiledContracts.totalCurrencyAddress);
 
             for (Map.Entry<Integer, BigInteger> key : genesis.getNetworkBalances().entrySet()) {
-                track.addStorageRow(PrecompiledContracts.totalCurrencyAddress, new DataWord(key.getKey()),
+                track.addStorageRow(
+                        PrecompiledContracts.totalCurrencyAddress,
+                        new DataWord(key.getKey()),
                         new DataWord(key.getValue()));
             }
 
@@ -320,8 +336,8 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
             // TODO: violates abstraction, consider adding to interface after
             // stable
             ((AionRepositoryImpl) bc.getRepository()).commitBlock(genesis.getHeader());
-            ((AionBlockStore) bc.getRepository().getBlockStore()).saveBlock(genesis, genesis.getCumulativeDifficulty(),
-                    true);
+            ((AionBlockStore) bc.getRepository().getBlockStore())
+                    .saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
             bc.setBestBlock(genesis);
             bc.setTotalDifficulty(genesis.getCumulativeDifficulty());
 

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -129,6 +129,20 @@ public class Cli {
                         }
                     }
                     break;
+                case "--state": {
+                    String pruning_type = "full";
+                    if (args.length >= 2) {
+                        pruning_type = args[1];
+                    }
+                    try {
+                        RecoveryUtils.pruneOrRecoverState(pruning_type);
+                    } catch (Throwable t) {
+                        System.out.println("Reorganizing the state storage FAILED due to:");
+                        t.printStackTrace();
+                        return 1;
+                    }
+                    break;
+                }
                 case "--dump-state-size":
                     long block_count = 2L;
 

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -502,6 +502,11 @@ public class AionRepositoryImpl
             detailsDS.syncLargeStorage();
 
             if (pruneEnabled) {
+                if (blockHeader.getNumber() % archiveRate == 0 && stateDSPrune.isArchiveEnabled()) {
+                    // archive block
+                    worldState.saveDiffStateToDatabase(
+                            blockHeader.getStateRoot(), stateDSPrune.getArchiveSource());
+                }
                 stateDSPrune.storeBlockChanges(blockHeader.getHash(), blockHeader.getNumber());
                 detailsDS
                         .getStorageDSPrune()

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -698,6 +698,10 @@ public class AionRepositoryImpl
         return this.stateDatabase;
     }
 
+    public IByteArrayKeyValueDatabase getStateArchiveDatabase() {
+        return this.stateArchiveDatabase;
+    }
+
     /**
      * Retrieves the underlying details database that sits below all caches. This is usually
      * provided by {@link org.aion.db.impl.mockdb.MockDB} or {@link org.aion.db.impl.mockdb.MockDB}.

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -74,17 +74,6 @@ public class AionRepositoryImpl
                         new RepositoryConfig(
                                 new File(config.getBasePath(), config.getDb().getPath())
                                         .getAbsolutePath(),
-                                config.getDb().getPrune() > 0
-                                        ?
-                                        // if the value is smaller than backward step
-                                        // there is the risk of importing state-less blocks after
-                                        // reboot
-                                        (128 > config.getDb().getPrune()
-                                                ? 128
-                                                : config.getDb().getPrune())
-                                        :
-                                        // negative value => pruning disabled
-                                        config.getDb().getPrune(),
                                 ContractDetailsAion.getInstance(),
                                 config.getDb()));
     }
@@ -122,7 +111,7 @@ public class AionRepositoryImpl
     }
 
     private Trie createStateTrie() {
-        return new SecureTrie(stateDSPrune).withPruningEnabled(pruneBlockCount > 0);
+        return new SecureTrie(stateDSPrune).withPruningEnabled(pruneEnabled);
     }
 
     @Override
@@ -512,7 +501,7 @@ public class AionRepositoryImpl
             worldState.sync();
             detailsDS.syncLargeStorage();
 
-            if (pruneBlockCount > 0) {
+            if (pruneEnabled) {
                 stateDSPrune.storeBlockChanges(blockHeader.getHash(), blockHeader.getNumber());
                 detailsDS
                         .getStorageDSPrune()
@@ -554,7 +543,12 @@ public class AionRepositoryImpl
             repo.cfg = cfg;
             repo.stateDatabase = this.stateDatabase;
             repo.stateDSPrune = this.stateDSPrune;
+
+            // pruning config
+            repo.pruneEnabled = this.pruneEnabled;
             repo.pruneBlockCount = this.pruneBlockCount;
+            repo.archiveRate = this.archiveRate;
+
             repo.detailsDS = this.detailsDS;
             repo.isSnapshot = true;
 

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -542,6 +542,7 @@ public class AionRepositoryImpl
             repo.blockStore = blockStore;
             repo.cfg = cfg;
             repo.stateDatabase = this.stateDatabase;
+            repo.stateWithArchive = this.stateWithArchive;
             repo.stateDSPrune = this.stateDSPrune;
 
             // pruning config
@@ -622,6 +623,16 @@ public class AionRepositoryImpl
                 }
             } catch (Exception e) {
                 LOGGEN.error("Exception occurred while closing the state database.", e);
+            }
+
+            try {
+                if (stateArchiveDatabase != null) {
+                    stateArchiveDatabase.close();
+                    LOGGEN.info("State archive database closed.");
+                    stateArchiveDatabase = null;
+                }
+            } catch (Exception e) {
+                LOGGEN.error("Exception occurred while closing the state archive database.", e);
             }
 
             try {

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -485,13 +485,8 @@ public class AionRepositoryImpl
         }
     }
 
-    public void setPruneBlockCount(long pruneBlockCount) {
-        rwLock.writeLock().lock();
-        try {
-            this.pruneBlockCount = pruneBlockCount;
-        } finally {
-            rwLock.writeLock().unlock();
-        }
+    public long getPruneBlockCount() {
+        return this.pruneBlockCount;
     }
 
     public void commitBlock(A0BlockHeader blockHeader) {
@@ -532,6 +527,14 @@ public class AionRepositoryImpl
             }
         }
         bestBlockNumber = curBlock.getNumber();
+    }
+
+    /**
+     * @return {@code true} when pruning is enabled and archiving is disabled, {@code false}
+     *     otherwise
+     */
+    public boolean usesTopPruning() {
+        return pruneEnabled && !stateDSPrune.isArchiveEnabled();
     }
 
     public Trie getWorldState() {

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -368,6 +368,19 @@ public class RecoveryUtils {
                 "Rebuilding the main chain "
                         + block.getNumber()
                         + " blocks (may take a while) ...");
+
+        long topBlockNumber = block.getNumber();
+        long blockNumber = 1000;
+
+        // recover in increments of 1k blocks
+        while (blockNumber < topBlockNumber) {
+            block = store.getChainBlockByNumber(blockNumber);
+            chain.recoverWorldState(repo, block);
+            System.out.println("Finished with blocks up to " + blockNumber + ".");
+            blockNumber += 1000;
+        }
+
+        block = store.getBestBlock();
         chain.recoverWorldState(repo, block);
 
         repo.close();

--- a/modAionImpl/src/org/aion/zero/impl/db/RepositoryConfig.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RepositoryConfig.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -19,23 +19,21 @@
  *
  * Contributors:
  *     Aion foundation.
- *
  ******************************************************************************/
-
 package org.aion.zero.impl.db;
-
-import org.aion.base.db.DetailsProvider;
-import org.aion.base.db.IContractDetails;
-import org.aion.base.db.IRepositoryConfig;
-import org.aion.mcf.config.CfgDb;
 
 import java.util.Map;
 import java.util.Properties;
+import org.aion.base.db.DetailsProvider;
+import org.aion.base.db.IContractDetails;
+import org.aion.base.db.IPruneConfig;
+import org.aion.base.db.IRepositoryConfig;
+import org.aion.mcf.config.CfgDb;
 
 public class RepositoryConfig implements IRepositoryConfig {
 
     private final String dbPath;
-    private final int prune;
+    private final IPruneConfig cfgPrune;
     private final DetailsProvider detailsProvider;
     private final Map<String, Properties> cfg;
 
@@ -45,8 +43,8 @@ public class RepositoryConfig implements IRepositoryConfig {
     }
 
     @Override
-    public int getPrune() {
-        return prune;
+    public IPruneConfig getPruneConfig() {
+        return cfgPrune;
     }
 
     @Override
@@ -63,13 +61,11 @@ public class RepositoryConfig implements IRepositoryConfig {
         return new Properties(prop);
     }
 
-    public RepositoryConfig(final String dbPath,
-                            final int prune,
-                            final DetailsProvider detailsProvider,
-                            final CfgDb cfgDb) {
+    public RepositoryConfig(
+            final String dbPath, final DetailsProvider detailsProvider, final CfgDb cfgDb) {
         this.dbPath = dbPath;
-        this.prune = prune;
         this.detailsProvider = detailsProvider;
         this.cfg = cfgDb.asProperties();
+        this.cfgPrune = cfgDb.getPrune();
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/PeerState.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/PeerState.java
@@ -3,48 +3,39 @@ package org.aion.zero.impl.sync;
 public class PeerState {
 
     public enum Mode {
-        /**
-         * The peer is in main-chain; use normal syncing strategy.
-         */
+        /** The peer is in main-chain; use normal syncing strategy. */
         NORMAL,
 
-        /**
-         * The peer is in side-chain; sync backward to find the fork point.
-         */
+        /** The peer is in side-chain; sync backward to find the fork point. */
         BACKWARD,
 
-        /**
-         * The peer is in side-chain; sync forward to catch up.
-         */
+        /** The peer is in side-chain; sync forward to catch up. */
         FORWARD
     }
 
     // TODO: enforce rules on this
     public enum State {
-        /**
-         * The initial state.
-         */
+        /** The initial state. */
         INITIAL,
 
-        /**
-         * Status request, waiting for response.
-         */
+        /** Status request, waiting for response. */
         STATUS_REQUESTED,
 
-        /**
-         * Block headers request, waiting for response.
-         */
+        /** Block headers request, waiting for response. */
         HEADERS_REQUESTED,
 
-        /**
-         * Block bodies request, waiting for response.
-         */
+        /** Block bodies request, waiting for response. */
         BODIES_REQUESTED,
     }
 
     // The syncing mode and the base block number
     private Mode mode;
     private long base;
+
+    // used in FORWARD mode to prevent endlessly importing EXISTing blocks
+    // compute how many times to go forward without importing a new block
+    private int repeated;
+    private int maxRepeats;
 
     // The syncing status
     private State state;
@@ -97,5 +88,34 @@ public class PeerState {
 
     public void resetLastHeaderRequest() {
         this.lastHeaderRequest = 0;
+    }
+
+    public int getRepeated() {
+        return repeated;
+    }
+
+    public void resetRepeated() {
+        this.repeated = 0;
+    }
+
+    public void incRepeated() {
+        this.repeated++;
+    }
+
+    /**
+     * This number is set based on the BACKWARD step size and the size of each requested batch in
+     * FORWARD mode. Passing the number of repeats allowed means that we have entered in the
+     * previous BACKWARD step. If that step would have been viable, we never would have made another
+     * step back, so it effectively ends the FORWARD pass.
+     *
+     * @return The number of times that a node in FORWARD mode can import only blocks that already
+     *     EXIST.
+     */
+    public int getMaxRepeats() {
+        return maxRepeats;
+    }
+
+    public void setMaxRepeats(int maxRepeats) {
+        this.maxRepeats = maxRepeats;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
@@ -40,6 +40,8 @@ import org.aion.p2p.IP2pMgr;
 import org.aion.zero.impl.sync.msg.ReqBlocksHeaders;
 import org.slf4j.Logger;
 
+import static org.aion.p2p.P2pConstant.BACKWARD_SYNC_STEP;
+
 /** @author chris */
 final class TaskGetHeaders implements Runnable {
 
@@ -99,7 +101,7 @@ final class TaskGetHeaders implements Runnable {
         int size = 24;
 
         // depends on the number of blocks going BACKWARD
-        state.setMaxRepeats(128 / size + 1);
+        state.setMaxRepeats(BACKWARD_SYNC_STEP / size + 1);
 
         switch (state.getMode()) {
             case NORMAL:
@@ -109,9 +111,9 @@ final class TaskGetHeaders implements Runnable {
 
                     // normal mode
                     long nodeNumber = node.getBestBlockNumber();
-                    if (nodeNumber >= selfNumber + 128) {
+                    if (nodeNumber >= selfNumber + BACKWARD_SYNC_STEP) {
                         from = Math.max(1, selfNumber + 1 - 4);
-                    } else if (nodeNumber >= selfNumber - 128) {
+                    } else if (nodeNumber >= selfNumber - BACKWARD_SYNC_STEP) {
                         from = Math.max(1, selfNumber + 1 - 16);
                     } else {
                         // no need to request from this node. His TD is probably corrupted.
@@ -123,7 +125,7 @@ final class TaskGetHeaders implements Runnable {
             case BACKWARD:
                 {
                     // step back by 128 blocks
-                    from = Math.max(1, state.getBase() - 128);
+                    from = Math.max(1, state.getBase() - BACKWARD_SYNC_STEP);
                     break;
                 }
             case FORWARD:

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
@@ -29,21 +29,18 @@
 
 package org.aion.zero.impl.sync;
 
-import org.aion.p2p.INode;
-import org.aion.p2p.IP2pMgr;
-import org.aion.zero.impl.sync.msg.ReqBlocksHeaders;
-import org.slf4j.Logger;
-
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
+import org.aion.p2p.INode;
+import org.aion.p2p.IP2pMgr;
+import org.aion.zero.impl.sync.msg.ReqBlocksHeaders;
+import org.slf4j.Logger;
 
-/**
- * @author chris
- */
+/** @author chris */
 final class TaskGetHeaders implements Runnable {
 
     private final IP2pMgr p2p;
@@ -58,7 +55,12 @@ final class TaskGetHeaders implements Runnable {
 
     private final Random random = new Random(System.currentTimeMillis());
 
-    TaskGetHeaders(IP2pMgr p2p, long selfNumber, BigInteger selfTd, Map<Integer, PeerState> peerStates, Logger log) {
+    TaskGetHeaders(
+            IP2pMgr p2p,
+            long selfNumber,
+            BigInteger selfTd,
+            Map<Integer, PeerState> peerStates,
+            Logger log) {
         this.p2p = p2p;
         this.selfNumber = selfNumber;
         this.selfTd = selfTd;
@@ -78,8 +80,9 @@ final class TaskGetHeaders implements Runnable {
                         // higher td
                         n.getTotalDifficulty() != null && n.getTotalDifficulty().compareTo(this.selfTd) >= 0
                                 // not recently requested
-                                && (now - 5000) > peerStates.computeIfAbsent(n.getIdHash(), k -> new PeerState(PeerState.Mode.NORMAL, selfNumber)).getLastHeaderRequest()
-                )
+                                && (now - 5000) > peerStates
+                                .computeIfAbsent(n.getIdHash(), k -> new PeerState(PeerState.Mode.NORMAL, selfNumber))
+                                .getLastHeaderRequest())
                 .collect(Collectors.toList());
         if (nodesFiltered.isEmpty()) {
             return;
@@ -94,39 +97,51 @@ final class TaskGetHeaders implements Runnable {
         // decide the start block number
         long from = 0;
         int size = 24;
+
+        // depends on the number of blocks going BACKWARD
+        state.setMaxRepeats(128 / size + 1);
+
         switch (state.getMode()) {
-            case NORMAL: {
-                // update base block
-                state.setBase(selfNumber);
+            case NORMAL:
+                {
+                    // update base block
+                    state.setBase(selfNumber);
 
-                // normal mode
-                long nodeNumber = node.getBestBlockNumber();
-                if (nodeNumber >= selfNumber + 128) {
-                    from = Math.max(1, selfNumber + 1 - 4);
-                } else if (nodeNumber >= selfNumber - 128) {
-                    from = Math.max(1, selfNumber + 1 - 16);
-                } else {
-                    // no need to request from this node. His TD is probably corrupted.
-                    return;
+                    // normal mode
+                    long nodeNumber = node.getBestBlockNumber();
+                    if (nodeNumber >= selfNumber + 128) {
+                        from = Math.max(1, selfNumber + 1 - 4);
+                    } else if (nodeNumber >= selfNumber - 128) {
+                        from = Math.max(1, selfNumber + 1 - 16);
+                    } else {
+                        // no need to request from this node. His TD is probably corrupted.
+                        return;
+                    }
+
+                    break;
                 }
-
-                break;
-            }
-            case BACKWARD: {
-                // step back by 128 blocks
-                from = Math.max(1, state.getBase() - 128);
-                break;
-            }
-            case FORWARD: {
-                // start from base block
-                from = state.getBase() + 1;
-                break;
-            }
+            case BACKWARD:
+                {
+                    // step back by 128 blocks
+                    from = Math.max(1, state.getBase() - 128);
+                    break;
+                }
+            case FORWARD:
+                {
+                    // start from base block
+                    from = state.getBase() + 1;
+                    break;
+                }
         }
 
         // send request
         if (log.isDebugEnabled()) {
-            log.debug("<get-headers mode={} from-num={} size={} node={}>", state.getMode(), from, size, node.getIdShort());
+            log.debug(
+                    "<get-headers mode={} from-num={} size={} node={}>",
+                    state.getMode(),
+                    from,
+                    size,
+                    node.getIdShort());
         }
         ReqBlocksHeaders rbh = new ReqBlocksHeaders(from, size);
         this.p2p.send(node.getIdHash(), node.getIdShort(), rbh);

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -107,6 +107,19 @@ final class TaskImportBlocks implements Runnable {
                         "This is not supposed to happen, but the peer is sending us blocks without ask");
             }
 
+            // checking if there are restrictions due to pruning
+            if (batch.size() > 0 && chain.isPruneRestricted(batch.get(0).getNumber())) {
+                // reset status if possible
+                if (state != null) {
+                    state.setMode(PeerState.Mode.NORMAL);
+                    state.setBase(chain.getBestBlock().getNumber());
+                    state.resetLastHeaderRequest();
+                }
+                // will not import this batch because it will fail due to TOP mode pruning
+                batch.clear();
+                continue;
+            }
+
             ImportResult importResult = ImportResult.IMPORTED_NOT_BEST;
 
             // importing last block in batch to see if we can skip batch

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -99,25 +99,13 @@ final class TaskImportBlocks implements Runnable {
 
             List<AionBlock> batch = bw.getBlocks().stream()
                     .filter(b -> importedBlockHashes.get(ByteArrayWrapper.wrap(b.getHash())) == null)
+                    .filter(b -> chain.isPruneRestricted(b.getNumber()) == false)
                     .collect(Collectors.toList());
 
             PeerState state = peerStates.get(bw.getNodeIdHash());
             if (state == null) {
                 log.warn(
                         "This is not supposed to happen, but the peer is sending us blocks without ask");
-            }
-
-            // checking if there are restrictions due to pruning
-            if (batch.size() > 0 && chain.isPruneRestricted(batch.get(0).getNumber())) {
-                // reset status if possible
-                if (state != null) {
-                    state.setMode(PeerState.Mode.NORMAL);
-                    state.setBase(chain.getBestBlock().getNumber());
-                    state.resetLastHeaderRequest();
-                }
-                // will not import this batch because it will fail due to TOP mode pruning
-                batch.clear();
-                continue;
             }
 
             ImportResult importResult = ImportResult.IMPORTED_NOT_BEST;

--- a/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
+++ b/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -34,59 +34,61 @@
  ******************************************************************************/
 package org.aion.db;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.IContractDetails;
+import org.aion.base.db.IPruneConfig;
 import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteUtil;
 import org.aion.db.impl.DBVendor;
 import org.aion.db.impl.DatabaseFactory;
-import org.aion.db.impl.leveldb.LevelDBConstants;
+import org.aion.mcf.config.CfgPrune;
 import org.aion.mcf.vm.types.DataWord;
 import org.aion.zero.db.AionContractDetailsImpl;
 import org.aion.zero.impl.db.AionRepositoryImpl;
 import org.aion.zero.impl.db.ContractDetailsAion;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class AionContractDetailsTest {
 
-    private static final int IN_MEMORY_STORAGE_LIMIT = 1000000; // CfgAion.inst().getDb().getDetailsInMemoryStorageLimit();
+    private static final int IN_MEMORY_STORAGE_LIMIT =
+            1000000; // CfgAion.inst().getDb().getDetailsInMemoryStorageLimit();
 
-    protected IRepositoryConfig repoConfig = new IRepositoryConfig() {
-        @Override
-        public String getDbPath() {
-            return "";
-        }
+    protected IRepositoryConfig repoConfig =
+            new IRepositoryConfig() {
+                @Override
+                public String getDbPath() {
+                    return "";
+                }
 
-        @Override
-        public int getPrune() {
-            return 0;
-        }
+                @Override
+                public IPruneConfig getPruneConfig() {
+                    return new CfgPrune(false);
+                }
 
-        @Override
-        public IContractDetails contractDetailsImpl() {
-            return ContractDetailsAion.createForTesting(0, 1000000).getDetails();
-        }
+                @Override
+                public IContractDetails contractDetailsImpl() {
+                    return ContractDetailsAion.createForTesting(0, 1000000).getDetails();
+                }
 
-        @Override
-        public Properties getDatabaseConfig(String db_name) {
-            Properties props = new Properties();
-            props.setProperty(DatabaseFactory.Props.DB_TYPE, DBVendor.MOCKDB.toValue());
-            props.setProperty(DatabaseFactory.Props.ENABLE_HEAP_CACHE, "false");
-            return props;
-        }
-    };
+                @Override
+                public Properties getDatabaseConfig(String db_name) {
+                    Properties props = new Properties();
+                    props.setProperty(DatabaseFactory.Props.DB_TYPE, DBVendor.MOCKDB.toValue());
+                    props.setProperty(DatabaseFactory.Props.ENABLE_HEAP_CACHE, "false");
+                    return props;
+                }
+            };
 
-    private static IContractDetails deserialize(byte[] rlp, IByteArrayKeyValueDatabase externalStorage) {
+    private static IContractDetails deserialize(
+            byte[] rlp, IByteArrayKeyValueDatabase externalStorage) {
         AionContractDetailsImpl result = new AionContractDetailsImpl();
         result.setExternalStorageDataSource(externalStorage);
         result.decode(rlp);
@@ -105,10 +107,11 @@ public class AionContractDetailsTest {
         byte[] key_2 = ByteUtil.hexStringToBytes("222222");
         byte[] val_2 = ByteUtil.hexStringToBytes("bbbbbb");
 
-        AionContractDetailsImpl contractDetails = new AionContractDetailsImpl(
-                -1, //CfgAion.inst().getDb().getPrune(),
-                1000000 //CfgAion.inst().getDb().getDetailsInMemoryStorageLimit()
-        );
+        AionContractDetailsImpl contractDetails =
+                new AionContractDetailsImpl(
+                        -1, // CfgAion.inst().getDb().getPrune(),
+                        1000000 // CfgAion.inst().getDb().getDetailsInMemoryStorageLimit()
+                        );
         contractDetails.setCode(code);
         contractDetails.put(new DataWord(key_1), new DataWord(val_1));
         contractDetails.put(new DataWord(key_2), new DataWord(val_2));
@@ -117,20 +120,25 @@ public class AionContractDetailsTest {
 
         AionContractDetailsImpl contractDetails_ = new AionContractDetailsImpl(data);
 
-        assertEquals(ByteUtil.toHexString(code),
-                ByteUtil.toHexString(contractDetails_.getCode()));
+        assertEquals(ByteUtil.toHexString(code), ByteUtil.toHexString(contractDetails_.getCode()));
 
-        assertEquals(ByteUtil.toHexString(val_1),
-                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_1)).getNoLeadZeroesData()));
+        assertEquals(
+                ByteUtil.toHexString(val_1),
+                ByteUtil.toHexString(
+                        contractDetails_.get(new DataWord(key_1)).getNoLeadZeroesData()));
 
-        assertEquals(ByteUtil.toHexString(val_2),
-                ByteUtil.toHexString(contractDetails_.get(new DataWord(key_2)).getNoLeadZeroesData()));
+        assertEquals(
+                ByteUtil.toHexString(val_2),
+                ByteUtil.toHexString(
+                        contractDetails_.get(new DataWord(key_2)).getNoLeadZeroesData()));
     }
 
     @Test
     public void test_2() throws Exception {
 
-        byte[] code = ByteUtil.hexStringToBytes("7c0100000000000000000000000000000000000000000000000000000000600035046333d546748114610065578063430fe5f01461007c5780634d432c1d1461008d578063501385b2146100b857806357eb3b30146100e9578063dbc7df61146100fb57005b6100766004356024356044356102f0565b60006000f35b61008760043561039e565b60006000f35b610098600435610178565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100c96004356024356044356101a0565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100f1610171565b8060005260206000f35b610106600435610133565b8360005282602052816040528073ffffffffffffffffffffffffffffffffffffffff1660605260806000f35b5b60006020819052908152604090208054600182015460028301546003909301549192909173ffffffffffffffffffffffffffffffffffffffff1684565b5b60015481565b5b60026020526000908152604090205473ffffffffffffffffffffffffffffffffffffffff1681565b73ffffffffffffffffffffffffffffffffffffffff831660009081526020819052604081206002015481908302341080156101fe575073ffffffffffffffffffffffffffffffffffffffff8516600090815260208190526040812054145b8015610232575073ffffffffffffffffffffffffffffffffffffffff85166000908152602081905260409020600101548390105b61023b57610243565b3391506102e8565b6101966103ca60003973ffffffffffffffffffffffffffffffffffffffff3381166101965285166101b68190526000908152602081905260408120600201546101d6526101f68490526102169080f073ffffffffffffffffffffffffffffffffffffffff8616600090815260208190526040902060030180547fffffffffffffffffffffffff0000000000000000000000000000000000000000168217905591508190505b509392505050565b73ffffffffffffffffffffffffffffffffffffffff33166000908152602081905260408120548190821461032357610364565b60018054808201909155600090815260026020526040902080547fffffffffffffffffffffffff000000000000000000000000000000000000000016331790555b50503373ffffffffffffffffffffffffffffffffffffffff1660009081526020819052604090209081556001810192909255600290910155565b3373ffffffffffffffffffffffffffffffffffffffff166000908152602081905260409020600201555600608061019660043960048051602451604451606451600080547fffffffffffffffffffffffff0000000000000000000000000000000000000000908116909517815560018054909516909317909355600355915561013390819061006390396000f3007c0100000000000000000000000000000000000000000000000000000000600035046347810fe381146100445780637e4a1aa81461005557806383d2421b1461006957005b61004f6004356100ab565b60006000f35b6100636004356024356100fc565b60006000f35b61007460043561007a565b60006000f35b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146100a2576100a8565b60078190555b50565b73ffffffffffffffffffffffffffffffffffffffff8116600090815260026020526040902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117905550565b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146101245761012f565b600582905560068190555b505056");
+        byte[] code =
+                ByteUtil.hexStringToBytes(
+                        "7c0100000000000000000000000000000000000000000000000000000000600035046333d546748114610065578063430fe5f01461007c5780634d432c1d1461008d578063501385b2146100b857806357eb3b30146100e9578063dbc7df61146100fb57005b6100766004356024356044356102f0565b60006000f35b61008760043561039e565b60006000f35b610098600435610178565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100c96004356024356044356101a0565b8073ffffffffffffffffffffffffffffffffffffffff1660005260206000f35b6100f1610171565b8060005260206000f35b610106600435610133565b8360005282602052816040528073ffffffffffffffffffffffffffffffffffffffff1660605260806000f35b5b60006020819052908152604090208054600182015460028301546003909301549192909173ffffffffffffffffffffffffffffffffffffffff1684565b5b60015481565b5b60026020526000908152604090205473ffffffffffffffffffffffffffffffffffffffff1681565b73ffffffffffffffffffffffffffffffffffffffff831660009081526020819052604081206002015481908302341080156101fe575073ffffffffffffffffffffffffffffffffffffffff8516600090815260208190526040812054145b8015610232575073ffffffffffffffffffffffffffffffffffffffff85166000908152602081905260409020600101548390105b61023b57610243565b3391506102e8565b6101966103ca60003973ffffffffffffffffffffffffffffffffffffffff3381166101965285166101b68190526000908152602081905260408120600201546101d6526101f68490526102169080f073ffffffffffffffffffffffffffffffffffffffff8616600090815260208190526040902060030180547fffffffffffffffffffffffff0000000000000000000000000000000000000000168217905591508190505b509392505050565b73ffffffffffffffffffffffffffffffffffffffff33166000908152602081905260408120548190821461032357610364565b60018054808201909155600090815260026020526040902080547fffffffffffffffffffffffff000000000000000000000000000000000000000016331790555b50503373ffffffffffffffffffffffffffffffffffffffff1660009081526020819052604090209081556001810192909255600290910155565b3373ffffffffffffffffffffffffffffffffffffffff166000908152602081905260409020600201555600608061019660043960048051602451604451606451600080547fffffffffffffffffffffffff0000000000000000000000000000000000000000908116909517815560018054909516909317909355600355915561013390819061006390396000f3007c0100000000000000000000000000000000000000000000000000000000600035046347810fe381146100445780637e4a1aa81461005557806383d2421b1461006957005b61004f6004356100ab565b60006000f35b6100636004356024356100fc565b60006000f35b61007460043561007a565b60006000f35b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146100a2576100a8565b60078190555b50565b73ffffffffffffffffffffffffffffffffffffffff8116600090815260026020526040902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117905550565b6001543373ffffffffffffffffffffffffffffffffffffffff9081169116146101245761012f565b600582905560068190555b505056");
         Address address = Address.wrap(RandomUtils.nextBytes(Address.ADDRESS_LEN));
 
         byte[] key_0 = ByteUtil.hexStringToBytes("18d63b70aa690ad37cb50908746c9a55");
@@ -197,48 +205,60 @@ public class AionContractDetailsTest {
 
         AionContractDetailsImpl contractDetails_ = new AionContractDetailsImpl(data);
 
-        assertEquals(ByteUtil.toHexString(code),
-                ByteUtil.toHexString(contractDetails_.getCode()));
+        assertEquals(ByteUtil.toHexString(code), ByteUtil.toHexString(contractDetails_.getCode()));
 
         assertTrue(address.equals(contractDetails_.getAddress()));
 
-        assertEquals(ByteUtil.toHexString(val_1),
+        assertEquals(
+                ByteUtil.toHexString(val_1),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_1)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_2),
+        assertEquals(
+                ByteUtil.toHexString(val_2),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_2)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_3),
+        assertEquals(
+                ByteUtil.toHexString(val_3),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_3)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_4),
+        assertEquals(
+                ByteUtil.toHexString(val_4),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_4)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_5),
+        assertEquals(
+                ByteUtil.toHexString(val_5),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_5)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_6),
+        assertEquals(
+                ByteUtil.toHexString(val_6),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_6)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_7),
+        assertEquals(
+                ByteUtil.toHexString(val_7),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_7)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_8),
+        assertEquals(
+                ByteUtil.toHexString(val_8),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_8)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_9),
+        assertEquals(
+                ByteUtil.toHexString(val_9),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_9)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_10),
+        assertEquals(
+                ByteUtil.toHexString(val_10),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_10)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_11),
+        assertEquals(
+                ByteUtil.toHexString(val_11),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_11)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_12),
+        assertEquals(
+                ByteUtil.toHexString(val_12),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_12)).getData()));
 
-        assertEquals(ByteUtil.toHexString(val_13),
+        assertEquals(
+                ByteUtil.toHexString(val_13),
                 ByteUtil.toHexString(contractDetails_.get(new DataWord(key_13)).getData()));
     }
 
@@ -309,7 +329,6 @@ public class AionContractDetailsTest {
             elements.put(key, value);
             original.put(key, value);
         }
-
 
         original.syncStorage();
         assertTrue(!externalStorage.isEmpty());

--- a/modAionImpl/test/org/aion/zero/impl/MockRepositoryConfig.java
+++ b/modAionImpl/test/org/aion/zero/impl/MockRepositoryConfig.java
@@ -1,12 +1,13 @@
 package org.aion.zero.impl;
 
+import java.util.Properties;
 import org.aion.base.db.IContractDetails;
+import org.aion.base.db.IPruneConfig;
 import org.aion.base.db.IRepositoryConfig;
 import org.aion.db.impl.DBVendor;
 import org.aion.db.impl.DatabaseFactory;
+import org.aion.mcf.config.CfgPrune;
 import org.aion.zero.impl.db.ContractDetailsAion;
-
-import java.util.Properties;
 
 public class MockRepositoryConfig implements IRepositoryConfig {
     private DBVendor vendor = DBVendor.MOCKDB;
@@ -17,8 +18,8 @@ public class MockRepositoryConfig implements IRepositoryConfig {
     }
 
     @Override
-    public int getPrune() {
-        return 0;
+    public IPruneConfig getPruneConfig() {
+        return new CfgPrune(false);
     }
 
     @Override

--- a/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
@@ -39,15 +39,13 @@ import static com.google.common.truth.Truth.assertThat;
 import java.math.BigInteger;
 import java.util.Optional;
 import java.util.Properties;
-import org.aion.base.db.IByteArrayKeyValueDatabase;
-import org.aion.base.db.IContractDetails;
-import org.aion.base.db.IRepositoryCache;
-import org.aion.base.db.IRepositoryConfig;
+import org.aion.base.db.*;
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteUtil;
 import org.aion.crypto.HashUtil;
 import org.aion.db.impl.DBVendor;
 import org.aion.db.impl.DatabaseFactory;
+import org.aion.mcf.config.CfgPrune;
 import org.aion.mcf.core.AccountState;
 import org.aion.mcf.db.IBlockStoreBase;
 import org.aion.mcf.vm.types.DataWord;
@@ -67,8 +65,8 @@ public class AionRepositoryImplTest {
                 }
 
                 @Override
-                public int getPrune() {
-                    return 0;
+                public IPruneConfig getPruneConfig() {
+                    return new CfgPrune(false);
                 }
 
                 @Override

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -64,6 +64,15 @@
 		<path>database</path>
 		<!--Boolean value. Enable/disable database integrity check run at startup.-->
 		<check_integrity>true</check_integrity>
+		<!--Configuration for data pruning behavior.-->
+		<prune>
+			<!--Boolean value. Enable/disable database pruning.-->
+			<enabled>true</enabled>
+			<!--Integer value with minimum set to 128. Only blocks older than best block level minus this number are candidates for pruning.-->
+			<current_count>128</current_count>
+			<!--Integer value with minimum set to 1000. States for blocks that are exact multiples of this number will not be pruned.-->
+			<archive_rate>10000</archive_rate>
+		</prune>
 		<!--Integer value. Number of blocks after which to prune. Pruning disabled when negative.-->
 		<prune>1000</prune>
 		<!--Database implementation used to store data; supported options: leveldb, h2, rocksdb.-->

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -73,8 +73,6 @@
 			<!--Integer value with minimum set to 1000. States for blocks that are exact multiples of this number will not be pruned.-->
 			<archive_rate>10000</archive_rate>
 		</prune>
-		<!--Integer value. Number of blocks after which to prune. Pruning disabled when negative.-->
-		<prune>1000</prune>
 		<!--Database implementation used to store data; supported options: leveldb, h2, rocksdb.-->
 		<!--Caution: changing implementation requires re-syncing from genesis!-->
 		<vendor>leveldb</vendor>

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -64,15 +64,11 @@
 		<path>database</path>
 		<!--Boolean value. Enable/disable database integrity check run at startup.-->
 		<check_integrity>true</check_integrity>
-		<!--Configuration for data pruning behavior.-->
-		<prune>
-			<!--Boolean value. Enable/disable database pruning.-->
-			<enabled>true</enabled>
-			<!--Integer value with minimum set to 128. Only blocks older than best block level minus this number are candidates for pruning.-->
-			<current_count>128</current_count>
-			<!--Integer value with minimum set to 1000. States for blocks that are exact multiples of this number will not be pruned.-->
-			<archive_rate>10000</archive_rate>
-		</prune>
+		<!--Data pruning behavior for the state database. Options: FULL, TOP, SPREAD.-->
+		<!--FULL: the state is not pruned-->
+		<!--TOP: the state is kept only for the top K blocks; limits sync to branching only within the stored blocks-->
+		<!--SPREAD: the state is kept for the top K blocks and at regular block intervals-->
+		<state-storage>FULL</state-storage>
 		<!--Database implementation used to store data; supported options: leveldb, h2, rocksdb.-->
 		<!--Caution: changing implementation requires re-syncing from genesis!-->
 		<vendor>leveldb</vendor>

--- a/modDbImpl/src/org/aion/db/generic/DatabaseWithCache.java
+++ b/modDbImpl/src/org/aion/db/generic/DatabaseWithCache.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -163,14 +163,8 @@ public class DatabaseWithCache implements IByteArrayKeyValueDatabase {
         return this.loadingCache.stats();
     }
 
-    /**
-     * Checks that the database connection is open.
-     * Throws a {@link RuntimeException} if the database connection is closed.
-     *
-     * @implNote Always do this check after acquiring a lock on the class/data.
-     *         Otherwise it might produce inconsistent results due to lack of synchronization.
-     */
-    private void check() {
+    @Override
+    public void check() {
         if (!database.isOpen()) {
             throw new RuntimeException("Database is not opened: " + this);
         }

--- a/modDbImpl/src/org/aion/db/generic/LockedDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/LockedDatabase.java
@@ -367,6 +367,19 @@ public class LockedDatabase implements IByteArrayKeyValueDatabase {
     }
 
     @Override
+    public void check() {
+        // acquire read lock
+        lock.readLock().lock();
+
+        try {
+            database.check();
+        } finally {
+            // releasing read lock
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
     public void drop() {
         // acquire write lock
         lock.writeLock().lock();

--- a/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -28,16 +28,15 @@
  ******************************************************************************/
 package org.aion.db.generic;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.util.Hex;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.slf4j.Logger;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Times different database operations and logs the time.
@@ -48,6 +47,7 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
 
     /** Unlocked database. */
     protected final IByteArrayKeyValueDatabase database;
+
     protected static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.DB.name());
 
     public TimedDatabase(IByteArrayKeyValueDatabase _database) {
@@ -59,7 +59,8 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         return this.getClass().getSimpleName() + " over " + database.toString();
     }
 
-    // IDatabase functionality -----------------------------------------------------------------------------------------
+    // IDatabase functionality
+    // -----------------------------------------------------------------------------------------
 
     @Override
     public boolean open() {
@@ -164,7 +165,8 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         return result;
     }
 
-    // IKeyValueStore functionality ------------------------------------------------------------------------------------
+    // IKeyValueStore functionality
+    // ------------------------------------------------------------------------------------
 
     @Override
     public boolean isEmpty() {
@@ -192,7 +194,13 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         Optional<byte[]> value = database.get(key);
         long t2 = System.nanoTime();
 
-        LOG.debug(database.toString() + " get(key) in " + (t2 - t1) + " ns." + "\n\t\t\t\t\tkey = " + Hex.toHexString(key));
+        LOG.debug(
+                database.toString()
+                        + " get(key) in "
+                        + (t2 - t1)
+                        + " ns."
+                        + "\n\t\t\t\t\tkey = "
+                        + (key != null ? Hex.toHexString(key) : "null"));
         return value;
     }
 
@@ -202,8 +210,15 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         database.put(key, value);
         long t2 = System.nanoTime();
 
-        LOG.debug(database.toString() + " put(key,value) in " + (t2 - t1) + " ns." + "\n\t\t\t\t\tkey = " + Hex.toHexString(key)
-                          + "\n\t\t\t\t\tvalue = " + Hex.toHexString(value));
+        LOG.debug(
+                database.toString()
+                        + " put(key,value) in "
+                        + (t2 - t1)
+                        + " ns."
+                        + "\n\t\t\t\t\tkey = "
+                        + (key != null ? Hex.toHexString(key) : "null")
+                        + "\n\t\t\t\t\tvalue = "
+                        + (value != null ? Hex.toHexString(value) : "null"));
     }
 
     @Override
@@ -212,7 +227,13 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         database.delete(key);
         long t2 = System.nanoTime();
 
-        LOG.debug(database.toString() + " delete(key) in " + (t2 - t1) + " ns." + "\n\t\t\t\t\tkey = " + Hex.toHexString(key));
+        LOG.debug(
+                database.toString()
+                        + " delete(key) in "
+                        + (t2 - t1)
+                        + " ns."
+                        + "\n\t\t\t\t\tkey = "
+                        + (key != null ? Hex.toHexString(key) : "null"));
     }
 
     @Override
@@ -221,7 +242,13 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         database.putBatch(keyValuePairs);
         long t2 = System.nanoTime();
 
-        LOG.debug(database.toString() + " putBatch(" + keyValuePairs.size() + ") in " + (t2 - t1) + " ns.");
+        LOG.debug(
+                database.toString()
+                        + " putBatch("
+                        + (keyValuePairs != null ? keyValuePairs.size() : "null")
+                        + ") in "
+                        + (t2 - t1)
+                        + " ns.");
     }
 
     @Override
@@ -230,8 +257,15 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         database.putToBatch(key, value);
         long t2 = System.nanoTime();
 
-        LOG.debug(database.toString() + " putToBatch(key,value) in " + (t2 - t1) + " ns." + "\n\t\t\t\t\tkey = " + Hex
-                .toHexString(key) + "\n\t\t\t\t\tvalue = " + Hex.toHexString(value));
+        LOG.debug(
+                database.toString()
+                        + " putToBatch(key,value) in "
+                        + (t2 - t1)
+                        + " ns."
+                        + "\n\t\t\t\t\tkey = "
+                        + Hex.toHexString(key)
+                        + "\n\t\t\t\t\tvalue = "
+                        + (value != null ? Hex.toHexString(value) : "null"));
     }
 
     @Override
@@ -249,7 +283,13 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
         database.deleteBatch(keys);
         long t2 = System.nanoTime();
 
-        LOG.debug(database.toString() + " deleteBatch(" + keys.size() + ") in " + (t2 - t1) + " ns.");
+        LOG.debug(
+                database.toString()
+                        + " deleteBatch("
+                        + (keys != null ? keys.size() : "null")
+                        + ") in "
+                        + (t2 - t1)
+                        + " ns.");
     }
 
     @Override

--- a/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
@@ -253,6 +253,15 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
     }
 
     @Override
+    public void check() {
+        long t1 = System.nanoTime();
+        database.check();
+        long t2 = System.nanoTime();
+
+        LOG.debug(database.toString() + " check() in " + (t2 - t1) + " ns.");
+    }
+
+    @Override
     public void drop() {
         long t1 = System.nanoTime();
         database.drop();

--- a/modDbImpl/src/org/aion/db/impl/AbstractDB.java
+++ b/modDbImpl/src/org/aion/db/impl/AbstractDB.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -34,18 +34,16 @@
  ******************************************************************************/
 package org.aion.db.impl;
 
-import org.aion.base.db.IByteArrayKeyValueDatabase;
-import org.aion.base.util.ByteArrayWrapper;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.h2.store.fs.FileUtils;
-import org.slf4j.Logger;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Stream;
+import org.aion.base.db.IByteArrayKeyValueDatabase;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.slf4j.Logger;
 
 /**
  * Common functionality for database implementations.
@@ -70,7 +68,8 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
         this.name = name;
     }
 
-    protected AbstractDB(String name, String path, boolean enableDbCache, boolean enableDbCompression) {
+    protected AbstractDB(
+            String name, String path, boolean enableDbCache, boolean enableDbCompression) {
         this(name);
 
         Objects.requireNonNull(path, "The database path cannot be null.");
@@ -81,14 +80,22 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
     }
 
     protected String propertiesInfo() {
-        return "<name=" + name + ",autocommit=ON,cache=" + (enableDbCache ? "ON" : "OFF") + //
-                ",compression=" + (enableDbCompression ? "ON" : "OFF") + ">"; //
+        return "<name="
+                + name
+                + ",autocommit=ON,cache="
+                + (enableDbCache ? "ON" : "OFF")
+                + //
+                ",compression="
+                + (enableDbCompression ? "ON" : "OFF")
+                + ">"; //
     }
 
     @Override
     public boolean commit() {
-        // not implemented since we always commit the changes to the database for this implementation
-        throw new UnsupportedOperationException("Only automatic commits are supported by " + this.toString());
+        // not implemented since we always commit the changes to the database for this
+        // implementation
+        throw new UnsupportedOperationException(
+                "Only automatic commits are supported by " + this.toString());
     }
 
     @Override
@@ -119,22 +126,16 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
         return Optional.ofNullable(this.path);
     }
 
-    /**
-     * Checks that the database connection is open.
-     * Throws a {@link RuntimeException} if the database connection is closed.
-     *
-     * @implNote Always do this check after acquiring a lock on the class/data.
-     *         Otherwise it might produce inconsistent results due to lack of synchronization.
-     */
-    protected void check() {
+    @Override
+    public void check() {
         if (!isOpen()) {
             throw new RuntimeException("Database is not opened: " + this);
         }
     }
 
     /**
-     * Checks that the given key is not null.
-     * Throws a {@link IllegalArgumentException} if the key is null.
+     * Checks that the given key is not null. Throws a {@link IllegalArgumentException} if the key
+     * is null.
      */
     public static void check(byte[] k) {
         if (k == null) {
@@ -143,8 +144,8 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
     }
 
     /**
-     * Checks that the given collection of keys does not contain null values.
-     * Throws a {@link IllegalArgumentException} if a null key is present.
+     * Checks that the given collection of keys does not contain null values. Throws a {@link
+     * IllegalArgumentException} if a null key is present.
      */
     public static void check(Collection<byte[]> keys) {
         if (keys.contains(null)) {
@@ -170,23 +171,21 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
     }
 
     /**
-     * For testing the lock functionality of public methods.
-     * Helps ensure that locks are released after normal or exceptional execution.
+     * For testing the lock functionality of public methods. Helps ensure that locks are released
+     * after normal or exceptional execution.
      *
-     * @return {@code true} when the resource is locked,
-     *         {@code false} otherwise
+     * @return {@code true} when the resource is locked, {@code false} otherwise
      */
     @Override
     public boolean isLocked() {
         return false;
     }
 
-    /**
-     * Functionality for directly interacting with the heap cache.
-     */
+    /** Functionality for directly interacting with the heap cache. */
     public abstract boolean commitCache(Map<ByteArrayWrapper, byte[]> cache);
 
-    // IKeyValueStore functionality ------------------------------------------------------------------------------------
+    // IKeyValueStore functionality
+    // ------------------------------------------------------------------------------------
 
     @Override
     public Optional<byte[]> get(byte[] k) {
@@ -200,12 +199,11 @@ public abstract class AbstractDB implements IByteArrayKeyValueDatabase {
     }
 
     /**
-     * Database specific get functionality, without locking required. Locking is applied in {@link #get(byte[])}.
+     * Database specific get functionality, without locking required. Locking is applied in {@link
+     * #get(byte[])}.
      *
-     * @param k
-     *         the key for which the method must return the associated value
+     * @param k the key for which the method must return the associated value
      * @return the value stored in the database for the give key.
      */
     protected abstract byte[] getInternal(byte[] k);
-
 }

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -22,25 +22,22 @@
  ******************************************************************************/
 package org.aion.mcf.config;
 
-import org.aion.base.util.Utils;
-import org.aion.db.impl.DBVendor;
+import static org.aion.db.impl.DatabaseFactory.Props;
 
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import org.aion.base.util.Utils;
+import org.aion.db.impl.DBVendor;
 
-import static org.aion.db.impl.DatabaseFactory.Props;
-
-/**
- * @author chris
- */
+/** @author chris */
 public class CfgDb {
 
     public static class Names {
@@ -63,7 +60,7 @@ public class CfgDb {
     private String vendor;
     private boolean compression;
     private boolean check_integrity;
-    private int prune;
+    private CfgPrune prune;
 
     /**
      * Enabling expert mode allows more detailed database configurations.
@@ -80,7 +77,7 @@ public class CfgDb {
         this.vendor = DBVendor.LEVELDB.toValue();
         this.compression = false;
         this.check_integrity = true;
-        this.prune = -1;
+        this.prune = new CfgPrune();
 
         if (expert) {
             this.specificConfig = new HashMap<>();
@@ -103,79 +100,88 @@ public class CfgDb {
                             this.check_integrity = Boolean.parseBoolean(Cfg.readValue(sr));
                             break;
                         case "prune":
-                            this.prune = Integer.parseInt(Cfg.readValue(sr));
+                            this.prune.fromXML(sr);
                             break;
-                        // parameter considered only when expert==false
+                            // parameter considered only when expert==false
                         case "vendor":
                             this.vendor = Cfg.readValue(sr);
                             break;
-                        // parameter considered only when expert==false
+                            // parameter considered only when expert==false
                         case Props.ENABLE_DB_COMPRESSION:
                             this.compression = Boolean.parseBoolean(Cfg.readValue(sr));
                             break;
-                        // parameter considered only when expert==true
-                        case Names.DEFAULT: {
-                            CfgDbDetails dbConfig = this.specificConfig.get(Names.DEFAULT);
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.DEFAULT, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.BLOCK: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.BLOCK, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.INDEX: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.INDEX, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.DETAILS: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.DETAILS, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.STORAGE: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.STORAGE, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.STATE: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.STATE, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.TRANSACTION: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.TRANSACTION, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.TX_POOL: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.TX_POOL, dbConfig);
-                            break;
-                        }
-                        // parameter considered only when expert==true
-                        case Names.TX_CACHE: {
-                            CfgDbDetails dbConfig = new CfgDbDetails();
-                            dbConfig.fromXML(sr);
-                            this.specificConfig.put(Names.TX_CACHE, dbConfig);
-                            break;
-                        }
+                            // parameter considered only when expert==true
+                        case Names.DEFAULT:
+                            {
+                                CfgDbDetails dbConfig = this.specificConfig.get(Names.DEFAULT);
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.DEFAULT, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.BLOCK:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.BLOCK, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.INDEX:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.INDEX, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.DETAILS:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.DETAILS, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.STORAGE:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.STORAGE, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.STATE:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.STATE, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.TRANSACTION:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.TRANSACTION, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.TX_POOL:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.TX_POOL, dbConfig);
+                                break;
+                            }
+                            // parameter considered only when expert==true
+                        case Names.TX_CACHE:
+                            {
+                                CfgDbDetails dbConfig = new CfgDbDetails();
+                                dbConfig.fromXML(sr);
+                                this.specificConfig.put(Names.TX_CACHE, dbConfig);
+                                break;
+                            }
                         default:
                             Cfg.skipElement(sr);
                             break;
@@ -205,25 +211,24 @@ public class CfgDb {
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeComment("Boolean value. Enable/disable database integrity check run at startup.");
+            xmlWriter.writeComment(
+                    "Boolean value. Enable/disable database integrity check run at startup.");
             xmlWriter.writeCharacters("\r\n\t\t");
             xmlWriter.writeStartElement("check_integrity");
             xmlWriter.writeCharacters(String.valueOf(this.check_integrity));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeComment("Integer value. Number of blocks after which to prune. Pruning disabled when negative.");
-            xmlWriter.writeCharacters("\r\n\t\t");
-            xmlWriter.writeStartElement("prune");
-            xmlWriter.writeCharacters(String.valueOf(this.prune));
-            xmlWriter.writeEndElement();
+            xmlWriter.writeComment("Configuration for data pruning behavior.");
+            this.prune.toXML(xmlWriter);
 
             if (!expert) {
                 xmlWriter.writeCharacters("\r\n\t\t");
                 xmlWriter.writeComment(
                         "Database implementation used to store data; supported options: leveldb, h2, rocksdb.");
                 xmlWriter.writeCharacters("\r\n\t\t");
-                xmlWriter.writeComment("Caution: changing implementation requires re-syncing from genesis!");
+                xmlWriter.writeComment(
+                        "Caution: changing implementation requires re-syncing from genesis!");
                 xmlWriter.writeCharacters("\r\n\t\t");
                 xmlWriter.writeStartElement("vendor");
                 xmlWriter.writeCharacters(this.vendor);
@@ -260,7 +265,7 @@ public class CfgDb {
         return this.path;
     }
 
-    public int getPrune() {
+    public CfgPrune getPrune() {
         return this.prune;
     }
 

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -284,6 +284,19 @@ public class CfgDb {
         return this.prune;
     }
 
+    /**
+     * Number of topmost blocks present in the database in TOP pruning mode. Information about these
+     * blocks is also kept in memory for later pruning.
+     */
+    public static final int TOP_PRUNE_BLOCK_COUNT = 256;
+    /**
+     * Number of topmost blocks present in the database in SPREAD pruning mode. Information about
+     * these blocks is also kept in memory for later pruning.
+     */
+    public static final int SPREAD_PRUNE_BLOCK_COUNT = 128;
+    /** At what frequency block states are being archived. */
+    public static final int SPREAD_PRUNE_ARCHIVE_RATE = 10000;
+
     public enum PruneOption {
         FULL,
         TOP,
@@ -320,11 +333,11 @@ public class CfgDb {
         switch (prune_option) {
             case TOP:
                 // journal prune only
-                this.prune = new CfgPrune(128);
+                this.prune = new CfgPrune(TOP_PRUNE_BLOCK_COUNT);
                 break;
             case SPREAD:
                 // journal prune with archived states
-                this.prune = new CfgPrune(128, 10000);
+                this.prune = new CfgPrune(SPREAD_PRUNE_BLOCK_COUNT, SPREAD_PRUNE_ARCHIVE_RATE);
                 break;
             case FULL:
             default:

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -50,6 +50,7 @@ public class CfgDb {
         public static final String STORAGE = "storage";
 
         public static final String STATE = "state";
+        public static final String STATE_ARCHIVE = "stateArchive";
         public static final String TRANSACTION = "transaction";
 
         public static final String TX_CACHE = "pendingtxCache";

--- a/modMcf/src/org/aion/mcf/config/CfgPrune.java
+++ b/modMcf/src/org/aion/mcf/config/CfgPrune.java
@@ -1,0 +1,139 @@
+/* ******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ ******************************************************************************/
+package org.aion.mcf.config;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import org.aion.base.db.IPruneConfig;
+
+/**
+ * Configuration for data pruning behavior.
+ *
+ * @author Alexandra Roatis
+ */
+public class CfgPrune implements IPruneConfig {
+
+    private boolean enabled;
+    private int current;
+    private int archive;
+
+    public CfgPrune() {
+        this.enabled = true;
+        this.current = 128;
+        this.archive = 10000;
+    }
+
+    public CfgPrune(boolean _enabled) {
+        this.enabled = _enabled;
+        this.current = 128;
+        this.archive = 10000;
+    }
+
+    public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
+        loop:
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            switch (eventType) {
+                case XMLStreamReader.START_ELEMENT:
+                    String elementName = sr.getLocalName().toLowerCase();
+                    switch (elementName) {
+                        case "enabled":
+                            this.enabled = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
+                        case "current_count":
+                            this.current = Integer.parseInt(Cfg.readValue(sr));
+                            // must be at least 128
+                            if (this.current < 128) {
+                                this.current = 128;
+                            }
+                            break;
+                        case "archive_rate":
+                            this.archive = Integer.parseInt(Cfg.readValue(sr));
+                            // must be at least 1000
+                            if (this.current < 1000) {
+                                this.current = 1000;
+                            }
+                            break;
+                        default:
+                            Cfg.skipElement(sr);
+                            break;
+                    }
+                    break;
+                case XMLStreamReader.END_ELEMENT:
+                    break loop;
+            }
+        }
+    }
+
+    public void toXML(XMLStreamWriter xmlWriter) throws XMLStreamException {
+        xmlWriter.writeCharacters("\r\n\t\t");
+        xmlWriter.writeStartElement("prune");
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeComment("Boolean value. Enable/disable database pruning.");
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement("enabled");
+        xmlWriter.writeCharacters(String.valueOf(this.enabled));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeComment(
+                "Integer value with minimum set to 128. Only blocks older than best block level minus this number are candidates for pruning.");
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement("current_count");
+        xmlWriter.writeCharacters(String.valueOf(this.current));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeComment(
+                "Integer value with minimum set to 1000. States for blocks that are exact multiples of this number will not be pruned.");
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement("archive_rate");
+        xmlWriter.writeCharacters(String.valueOf(this.archive));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t");
+        xmlWriter.writeEndElement();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public int getCurrentCount() {
+        return current;
+    }
+
+    @Override
+    public int getArchiveRate() {
+        return archive;
+    }
+}

--- a/modMcf/src/org/aion/mcf/config/CfgPrune.java
+++ b/modMcf/src/org/aion/mcf/config/CfgPrune.java
@@ -44,16 +44,19 @@ public class CfgPrune implements IPruneConfig {
     private int current;
     private int archive;
 
+    private static final int MINIMUM_CURRENT_COUNT = 128;
+    private static final int MINIMUM_ARCHIVE_RATE = 1000;
+
     public CfgPrune() {
         this.enabled = true;
-        this.current = 128;
-        this.archive = 10000;
+        this.current = MINIMUM_CURRENT_COUNT;
+        this.archive = MINIMUM_ARCHIVE_RATE;
     }
 
     public CfgPrune(boolean _enabled) {
         this.enabled = _enabled;
-        this.current = 128;
-        this.archive = 10000;
+        this.current = MINIMUM_CURRENT_COUNT;
+        this.archive = MINIMUM_ARCHIVE_RATE;
     }
 
     public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
@@ -69,16 +72,16 @@ public class CfgPrune implements IPruneConfig {
                             break;
                         case "current_count":
                             this.current = Integer.parseInt(Cfg.readValue(sr));
-                            // must be at least 128
-                            if (this.current < 128) {
-                                this.current = 128;
+                            // must be at least MINIMUM_CURRENT_COUNT
+                            if (this.current < MINIMUM_CURRENT_COUNT) {
+                                this.current = MINIMUM_CURRENT_COUNT;
                             }
                             break;
                         case "archive_rate":
                             this.archive = Integer.parseInt(Cfg.readValue(sr));
-                            // must be at least 1000
-                            if (this.current < 1000) {
-                                this.current = 1000;
+                            // must be at least MINIMUM_ARCHIVE_RATE
+                            if (this.archive < MINIMUM_ARCHIVE_RATE) {
+                                this.archive = MINIMUM_ARCHIVE_RATE;
                             }
                             break;
                         default:

--- a/modMcf/src/org/aion/mcf/config/CfgPrune.java
+++ b/modMcf/src/org/aion/mcf/config/CfgPrune.java
@@ -41,22 +41,36 @@ import org.aion.base.db.IPruneConfig;
 public class CfgPrune implements IPruneConfig {
 
     private boolean enabled;
-    private int current;
-    private int archive;
+    private boolean archived;
+    private int current_count = MINIMUM_CURRENT_COUNT;
+    private int archive_rate = MINIMUM_ARCHIVE_RATE;
 
     private static final int MINIMUM_CURRENT_COUNT = 128;
     private static final int MINIMUM_ARCHIVE_RATE = 1000;
 
-    public CfgPrune() {
-        this.enabled = true;
-        this.current = MINIMUM_CURRENT_COUNT;
-        this.archive = MINIMUM_ARCHIVE_RATE;
-    }
-
     public CfgPrune(boolean _enabled) {
         this.enabled = _enabled;
-        this.current = MINIMUM_CURRENT_COUNT;
-        this.archive = MINIMUM_ARCHIVE_RATE;
+        this.archived = _enabled;
+    }
+
+    public CfgPrune(int _current_count) {
+        // enable journal pruning
+        this.enabled = true;
+        this.current_count =
+                _current_count > MINIMUM_CURRENT_COUNT ? _current_count : MINIMUM_CURRENT_COUNT;
+        // disable archiving
+        this.archived = false;
+    }
+
+    public CfgPrune(int _current_count, int _archive_rate) {
+        // enable journal pruning
+        this.enabled = true;
+        this.current_count =
+                _current_count > MINIMUM_CURRENT_COUNT ? _current_count : MINIMUM_CURRENT_COUNT;
+        // enable archiving
+        this.archived = true;
+        this.archive_rate =
+                _archive_rate > MINIMUM_ARCHIVE_RATE ? _archive_rate : MINIMUM_ARCHIVE_RATE;
     }
 
     public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
@@ -70,18 +84,21 @@ public class CfgPrune implements IPruneConfig {
                         case "enabled":
                             this.enabled = Boolean.parseBoolean(Cfg.readValue(sr));
                             break;
+                        case "archived":
+                            this.archived = Boolean.parseBoolean(Cfg.readValue(sr));
+                            break;
                         case "current_count":
-                            this.current = Integer.parseInt(Cfg.readValue(sr));
+                            this.current_count = Integer.parseInt(Cfg.readValue(sr));
                             // must be at least MINIMUM_CURRENT_COUNT
-                            if (this.current < MINIMUM_CURRENT_COUNT) {
-                                this.current = MINIMUM_CURRENT_COUNT;
+                            if (this.current_count < MINIMUM_CURRENT_COUNT) {
+                                this.current_count = MINIMUM_CURRENT_COUNT;
                             }
                             break;
                         case "archive_rate":
-                            this.archive = Integer.parseInt(Cfg.readValue(sr));
+                            this.archive_rate = Integer.parseInt(Cfg.readValue(sr));
                             // must be at least MINIMUM_ARCHIVE_RATE
-                            if (this.archive < MINIMUM_ARCHIVE_RATE) {
-                                this.archive = MINIMUM_ARCHIVE_RATE;
+                            if (this.archive_rate < MINIMUM_ARCHIVE_RATE) {
+                                this.archive_rate = MINIMUM_ARCHIVE_RATE;
                             }
                             break;
                         default:
@@ -107,11 +124,18 @@ public class CfgPrune implements IPruneConfig {
         xmlWriter.writeEndElement();
 
         xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeComment("Boolean value. Enable/disable database archiving.");
+        xmlWriter.writeCharacters("\r\n\t\t\t");
+        xmlWriter.writeStartElement("archived");
+        xmlWriter.writeCharacters(String.valueOf(this.archived));
+        xmlWriter.writeEndElement();
+
+        xmlWriter.writeCharacters("\r\n\t\t\t");
         xmlWriter.writeComment(
                 "Integer value with minimum set to 128. Only blocks older than best block level minus this number are candidates for pruning.");
         xmlWriter.writeCharacters("\r\n\t\t\t");
         xmlWriter.writeStartElement("current_count");
-        xmlWriter.writeCharacters(String.valueOf(this.current));
+        xmlWriter.writeCharacters(String.valueOf(this.current_count));
         xmlWriter.writeEndElement();
 
         xmlWriter.writeCharacters("\r\n\t\t\t");
@@ -119,24 +143,30 @@ public class CfgPrune implements IPruneConfig {
                 "Integer value with minimum set to 1000. States for blocks that are exact multiples of this number will not be pruned.");
         xmlWriter.writeCharacters("\r\n\t\t\t");
         xmlWriter.writeStartElement("archive_rate");
-        xmlWriter.writeCharacters(String.valueOf(this.archive));
+        xmlWriter.writeCharacters(String.valueOf(this.archive_rate));
         xmlWriter.writeEndElement();
 
         xmlWriter.writeCharacters("\r\n\t\t");
         xmlWriter.writeEndElement();
     }
 
+    @Override
     public boolean isEnabled() {
         return enabled;
     }
 
     @Override
+    public boolean isArchived() {
+        return archived;
+    }
+
+    @Override
     public int getCurrentCount() {
-        return current;
+        return current_count;
     }
 
     @Override
     public int getArchiveRate() {
-        return archive;
+        return archive_rate;
     }
 }

--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -102,6 +102,7 @@ public abstract class AbstractRepository<
     // Block related parameters.
     protected long bestBlockNumber = 0;
     protected long pruneBlockCount;
+    protected long archiveRate;
     protected boolean pruneEnabled = true;
 
     // Current blockstore.
@@ -248,9 +249,17 @@ public abstract class AbstractRepository<
             // Setup the cache for transaction data source.
             this.detailsDS = new DetailsDataStore<>(detailsDatabase, storageDatabase, this.cfg);
             stateDSPrune = new JournalPruneDataSource(stateDatabase);
-            pruneBlockCount = pruneEnabled ? this.cfg.getPrune() : -1;
-            if (pruneEnabled && pruneBlockCount > 0) {
-                LOGGEN.info("Pruning block count set to {}.", pruneBlockCount);
+
+            // pruning config
+            pruneEnabled = this.cfg.getPruneConfig().isEnabled();
+            pruneBlockCount = this.cfg.getPruneConfig().getCurrentCount();
+            archiveRate = this.cfg.getPruneConfig().getArchiveRate();
+
+            if (pruneEnabled) {
+                LOGGEN.info(
+                        "Pruning ENABLED. Block count set to {} and archive rate set to {}.",
+                        pruneBlockCount,
+                        archiveRate);
             } else {
                 stateDSPrune.setPruneEnabled(false);
             }

--- a/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
@@ -1,0 +1,125 @@
+/* ******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ ******************************************************************************/
+package org.aion.mcf.ds;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.aion.base.db.IByteArrayKeyValueDatabase;
+import org.aion.base.db.IByteArrayKeyValueStore;
+
+/**
+ * A data source with archived data that must no be deleted.
+ *
+ * @author Alexandra Roatis
+ */
+public class ArchivedDataSource implements IByteArrayKeyValueStore {
+
+    IByteArrayKeyValueDatabase data, archive;
+
+    public ArchivedDataSource(IByteArrayKeyValueDatabase _db, IByteArrayKeyValueDatabase _archive) {
+        this.data = _db;
+        this.archive = _archive;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return data.isEmpty();
+    }
+
+    @Override
+    public Set<byte[]> keys() {
+        return data.keys();
+    }
+
+    @Override
+    public Optional<byte[]> get(byte[] key) {
+        return data.get(key);
+    }
+
+    @Override
+    public void put(byte[] key, byte[] value) {
+        if (value != null) {
+            data.put(key, value);
+        } else {
+            // internal delete will check if archived
+            delete(key);
+        }
+    }
+
+    @Override
+    public void delete(byte[] key) {
+        // delete key only if not archived
+        if (!archive.get(key).isPresent()) {
+            data.delete(key);
+        }
+    }
+
+    @Override
+    public void putBatch(Map<byte[], byte[]> batch) {
+        for (Map.Entry<byte[], byte[]> entry : batch.entrySet()) {
+            // will check if archived
+            putToBatch(entry.getKey(), entry.getValue());
+        }
+        commitBatch();
+    }
+
+    @Override
+    public void putToBatch(byte[] key, byte[] value) {
+        if (value != null) {
+            data.putToBatch(key, value);
+        } else {
+            // deleted key only if not archived
+            if (!archive.get(key).isPresent()) {
+                data.putToBatch(key, null);
+            }
+        }
+    }
+
+    @Override
+    public void commitBatch() {
+        data.commitBatch();
+    }
+
+    @Override
+    public void deleteBatch(Collection<byte[]> keys) {
+        for (byte[] key : keys) {
+            // will check if archived
+            putToBatch(key, null);
+        }
+        commitBatch();
+    }
+
+    @Override
+    public void close() {
+        data.close();
+        archive.close();
+    }
+}

--- a/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
@@ -128,4 +128,8 @@ public class ArchivedDataSource implements IByteArrayKeyValueStore {
         data.close();
         archive.close();
     }
+
+    public IByteArrayKeyValueDatabase getArchiveDatabase() {
+        return archive;
+    }
 }

--- a/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
@@ -118,6 +118,12 @@ public class ArchivedDataSource implements IByteArrayKeyValueStore {
     }
 
     @Override
+    public void check() {
+        data.check();
+        archive.check();
+    }
+
+    @Override
     public void close() {
         data.close();
         archive.close();

--- a/modMcf/src/org/aion/mcf/ds/XorDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/XorDataSource.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/* ******************************************************************************
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -34,12 +34,10 @@
  ******************************************************************************/
 package org.aion.mcf.ds;
 
-import org.aion.base.db.IByteArrayKeyValueDatabase;
+import java.util.*;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.base.util.ByteUtil;
-
-import java.util.*;
 
 public class XorDataSource implements IByteArrayKeyValueStore {
     IByteArrayKeyValueStore source;
@@ -89,8 +87,9 @@ public class XorDataSource implements IByteArrayKeyValueStore {
     }
 
     public void updateBatch(Map<ByteArrayWrapper, byte[]> rows, boolean erasure) {
-        //not supported
-        throw new UnsupportedOperationException("ByteArrayWrapper map not supported in XorDataSource.updateBatch yet");
+        // not supported
+        throw new UnsupportedOperationException(
+                "ByteArrayWrapper map not supported in XorDataSource.updateBatch yet");
     }
 
     @Override
@@ -102,6 +101,11 @@ public class XorDataSource implements IByteArrayKeyValueStore {
     public void deleteBatch(Collection<byte[]> keys) {
         // TODO Auto-generated method stub
 
+    }
+
+    @Override
+    public void check() {
+        source.check();
     }
 
     @Override

--- a/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
+++ b/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
@@ -38,10 +38,12 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
+import org.aion.mcf.ds.ArchivedDataSource;
 import org.slf4j.Logger;
 
 /**
@@ -89,13 +91,19 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
     private LinkedHashMap<ByteArrayWrapper, Updates> blockUpdates = new LinkedHashMap<>();
     private Updates currentUpdates = new Updates();
     private AtomicBoolean enabled = new AtomicBoolean(true);
+    private final boolean hasArchive;
 
     public JournalPruneDataSource(IByteArrayKeyValueStore src) {
         this.src = src;
+        this.hasArchive = src instanceof ArchivedDataSource;
     }
 
     public void setPruneEnabled(boolean _enabled) {
         enabled.set(_enabled);
+    }
+
+    public boolean isArchiveEnabled() {
+        return hasArchive;
     }
 
     public void put(byte[] key, byte[] value) {
@@ -413,6 +421,14 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
 
     public IByteArrayKeyValueStore getSrc() {
         return src;
+    }
+
+    public IByteArrayKeyValueDatabase getArchiveSource() {
+        if (!hasArchive) {
+            return null;
+        } else {
+            return ((ArchivedDataSource) src).getArchiveDatabase();
+        }
     }
 
     @Override

--- a/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
+++ b/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
@@ -151,10 +151,11 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
     }
 
     public void delete(byte[] key) {
+        checkNotNull(key);
         if (!enabled.get()) {
+            check();
             return;
         }
-        checkNotNull(key);
 
         lock.writeLock().lock();
 
@@ -376,10 +377,11 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
 
     @Override
     public void deleteBatch(Collection<byte[]> keys) {
+        checkNotNull(keys);
         if (!enabled.get()) {
+            check();
             return;
         }
-        checkNotNull(keys);
 
         lock.writeLock().lock();
 

--- a/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
+++ b/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
@@ -90,7 +90,7 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
     // block hash => updates
     private LinkedHashMap<ByteArrayWrapper, Updates> blockUpdates = new LinkedHashMap<>();
     private Updates currentUpdates = new Updates();
-    private AtomicBoolean enabled = new AtomicBoolean(true);
+    private AtomicBoolean enabled = new AtomicBoolean(false);
     private final boolean hasArchive;
 
     public JournalPruneDataSource(IByteArrayKeyValueStore src) {

--- a/modMcf/src/org/aion/mcf/trie/Trie.java
+++ b/modMcf/src/org/aion/mcf/trie/Trie.java
@@ -1,36 +1,45 @@
-/*******************************************************************************
+/* ******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
  *
- * Copyright (c) 2017, 2018 Aion foundation.
+ *     This file is part of the aion network project.
  *
- * 	This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
  *
  *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <https://www.gnu.org/licenses/>
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
  *
- * Contributors:
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
  *     Aion foundation.
  *******************************************************************************/
 package org.aion.mcf.trie;
 
+import org.aion.base.db.IByteArrayKeyValueDatabase;
+
 /**
- * Trie interface for the main data structure in Ethereum
- * which is used to store both the account state and storage of each account.
+ * Trie interface for the main data structure in Ethereum which is used to store both the account
+ * state and storage of each account.
  */
 public interface Trie {
 
     /**
      * Gets a value from the trie for a given key
      *
-     * @param key
-     *         - any length byte array
+     * @param key - any length byte array
      * @return an rlp encoded byte array of the stored object
      */
     byte[] get(byte[] key);
@@ -38,18 +47,15 @@ public interface Trie {
     /**
      * Insert or update a value in the trie for a specified key
      *
-     * @param key
-     *         - any length byte array
-     * @param value
-     *         rlp encoded byte array of the object to store
+     * @param key - any length byte array
+     * @param value rlp encoded byte array of the object to store
      */
     void update(byte[] key, byte[] value);
 
     /**
      * Deletes a key/value from the trie for a given key
      *
-     * @param key
-     *         - any length byte array
+     * @param key - any length byte array
      */
     void delete(byte[] key);
 
@@ -63,37 +69,36 @@ public interface Trie {
     /**
      * Set the top node of the trie
      *
-     * @param root
-     *         - 32-byte SHA-3 hash of the root node
+     * @param root - 32-byte SHA-3 hash of the root node
      */
     void setRoot(byte[] root);
 
     /**
      * Used to check for corruption in the database.
      *
-     * @param root
-     *         a world state trie root
+     * @param root a world state trie root
      * @return {@code true} if the root is valid, {@code false} otherwise
      */
     boolean isValidRoot(byte[] root);
 
-    /**
-     * Commit all the changes until now
-     */
+    /** Commit all the changes until now */
     void sync();
 
     void sync(boolean flushCache);
 
-    /**
-     * Discard all the changes until now
-     */
+    /** Discard all the changes until now */
     @Deprecated
     void undo();
 
     String getTrieDump();
+
     String getTrieDump(byte[] stateRoot);
+
     int getTrieSize(byte[] stateRoot);
 
     boolean validate();
 
+    long saveFullStateToDatabase(byte[] stateRoot, IByteArrayKeyValueDatabase db);
+
+    long saveDiffStateToDatabase(byte[] stateRoot, IByteArrayKeyValueDatabase db);
 }

--- a/modMcf/src/org/aion/mcf/trie/TrieImpl.java
+++ b/modMcf/src/org/aion/mcf/trie/TrieImpl.java
@@ -1,41 +1,32 @@
-/*******************************************************************************
+/* ******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
  *
- * Copyright (c) 2017, 2018 Aion foundation.
+ *     This file is part of the aion network project.
  *
- * 	This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
  *
  *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <https://www.gnu.org/licenses/>
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
  *
- * Contributors:
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
  *     Aion foundation.
  *******************************************************************************/
 package org.aion.mcf.trie;
-
-import org.aion.base.db.IByteArrayKeyValueStore;
-import org.aion.base.util.ByteArrayWrapper;
-import org.aion.base.util.FastByteComparisons;
-import org.aion.base.util.Hex;
-import org.aion.crypto.HashUtil;
-import org.aion.mcf.trie.scan.CollectFullSetOfNodes;
-import org.aion.mcf.trie.scan.CountNodes;
-import org.aion.mcf.trie.scan.ScanAction;
-import org.aion.mcf.trie.scan.TraceAllNodes;
-import org.aion.rlp.RLP;
-import org.aion.rlp.RLPItem;
-import org.aion.rlp.RLPList;
-import org.aion.rlp.Value;
-
-import java.io.*;
-import java.util.*;
 
 import static java.util.Arrays.copyOfRange;
 import static org.aion.base.util.ByteArrayWrapper.wrap;
@@ -46,32 +37,42 @@ import static org.aion.rlp.CompactEncoder.*;
 import static org.aion.rlp.RLP.calcElementPrefixSize;
 import static org.spongycastle.util.Arrays.concatenate;
 
+import java.io.*;
+import java.util.*;
+import org.aion.base.db.IByteArrayKeyValueDatabase;
+import org.aion.base.db.IByteArrayKeyValueStore;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.base.util.FastByteComparisons;
+import org.aion.base.util.Hex;
+import org.aion.crypto.HashUtil;
+import org.aion.mcf.trie.scan.*;
+import org.aion.rlp.RLP;
+import org.aion.rlp.RLPItem;
+import org.aion.rlp.RLPList;
+import org.aion.rlp.Value;
+
 /**
- * The modified Merkle Patricia tree (trie) provides a persistent data structure
- * to map between arbitrary-length binary data (byte arrays). It is defined in
- * terms of a mutable data structure to map between 256-bit binary fragments and
- * arbitrary-length binary data, typically implemented as a database. The core
- * of the trie, and its sole requirement in terms of the protocol specification
- * is to provide a single value that identifies a given set of key-value pairs,
- * which may either a 32 byte sequence or the empty byte sequence. It is left as
- * an implementation consideration to store and maintain the structure of the
- * trie in a manner the allows effective and efficient realisation of the
- * protocol.
- * <p>
- * The trie implements a caching mechanism and will use cached values if they
- * are present. If a node is not present in the cache it will try to fetch it
- * from the database and store the cached value.
- * <p>
- * <b>Note:</b> the data isn't persisted unless `sync` is explicitly called.
- * <p>
- * This Trie implementation supports node pruning (i.e. obsolete nodes are
- * marked for removal in the Cache and actually removed from the underlying
- * storage on [sync] call), but the algorithm is not suitable for the most
- * general case. In general case a trie node might be referenced from several
- * parent nodes and for correct pruning the reference counting algorithm needs
- * to be implemented. As soon as the real life tree keys are hashes it is very
- * unlikely the case so the pruning algorithm is simplified in this
- * implementation.
+ * The modified Merkle Patricia tree (trie) provides a persistent data structure to map between
+ * arbitrary-length binary data (byte arrays). It is defined in terms of a mutable data structure to
+ * map between 256-bit binary fragments and arbitrary-length binary data, typically implemented as a
+ * database. The core of the trie, and its sole requirement in terms of the protocol specification
+ * is to provide a single value that identifies a given set of key-value pairs, which may either a
+ * 32 byte sequence or the empty byte sequence. It is left as an implementation consideration to
+ * store and maintain the structure of the trie in a manner the allows effective and efficient
+ * realisation of the protocol.
+ *
+ * <p>The trie implements a caching mechanism and will use cached values if they are present. If a
+ * node is not present in the cache it will try to fetch it from the database and store the cached
+ * value.
+ *
+ * <p><b>Note:</b> the data isn't persisted unless `sync` is explicitly called.
+ *
+ * <p>This Trie implementation supports node pruning (i.e. obsolete nodes are marked for removal in
+ * the Cache and actually removed from the underlying storage on [sync] call), but the algorithm is
+ * not suitable for the most general case. In general case a trie node might be referenced from
+ * several parent nodes and for correct pruning the reference counting algorithm needs to be
+ * implemented. As soon as the real life tree keys are hashes it is very unlikely the case so the
+ * pruning algorithm is simplified in this implementation.
  *
  * @author Nick Savers
  * @since 20.05.2014
@@ -81,8 +82,7 @@ public class TrieImpl implements Trie {
     private static byte LIST_SIZE = 17;
     private static int MAX_SIZE = 20;
 
-    @Deprecated
-    private Object prevRoot;
+    @Deprecated private Object prevRoot;
     private Object root;
     private Cache cache;
 
@@ -119,9 +119,7 @@ public class TrieImpl implements Trie {
         return root;
     }
 
-    /**
-     * for testing TrieTest.testRollbackToRootScenarios
-     */
+    /** for testing TrieTest.testRollbackToRootScenarios */
     public void setRoot(Object root) {
         this.root = root;
     }
@@ -152,9 +150,7 @@ public class TrieImpl implements Trie {
         return this;
     }
 
-    /**
-     * Retrieve a value from a key as String.
-     */
+    /** Retrieve a value from a key as String. */
     public byte[] get(String key) {
         return this.get(key.getBytes());
     }
@@ -169,9 +165,7 @@ public class TrieImpl implements Trie {
         }
     }
 
-    /**
-     * Insert key/value pair into trie.
-     */
+    /** Insert key/value pair into trie. */
     public void update(String key, String value) {
         this.update(key.getBytes(), value.getBytes());
     }
@@ -198,9 +192,7 @@ public class TrieImpl implements Trie {
         return !(this.getNode(root) == null);
     }
 
-    /**
-     * Delete a key/value pair from the trie.
-     */
+    /** Delete a key/value pair from the trie. */
     public void delete(String key) {
         this.update(key.getBytes(), EMPTY_BYTE_ARRAY);
     }
@@ -215,8 +207,9 @@ public class TrieImpl implements Trie {
     @Override
     public byte[] getRootHash() {
         synchronized (cache) {
-            if (root == null || (root instanceof byte[] && ((byte[]) root).length == 0) || (root instanceof String && ""
-                    .equals(root))) {
+            if (root == null
+                    || (root instanceof byte[] && ((byte[]) root).length == 0)
+                    || (root instanceof String && "".equals(root))) {
                 return EMPTY_TRIE_HASH;
             } else if (root instanceof byte[]) {
                 return (byte[]) this.getRoot();
@@ -241,8 +234,8 @@ public class TrieImpl implements Trie {
                     byte[] k = unpackToNibbles(currentNode.get(0).asBytes());
                     Object v = currentNode.get(1).asObj();
 
-                    if (key.length - keypos >= k.length && Arrays
-                            .equals(k, copyOfRange(key, keypos, k.length + keypos))) {
+                    if (key.length - keypos >= k.length
+                            && Arrays.equals(k, copyOfRange(key, keypos, k.length + keypos))) {
                         node = v;
                         keypos += k.length;
                     } else {
@@ -277,7 +270,7 @@ public class TrieImpl implements Trie {
         }
 
         if (isEmptyNode(node)) {
-            Object[] newNode = new Object[] { packNibbles(key), value };
+            Object[] newNode = new Object[] {packNibbles(key), value};
             return this.putToCache(newNode);
         }
 
@@ -295,7 +288,7 @@ public class TrieImpl implements Trie {
 
             // Matching key pair (ie. there's already an object with this key)
             if (Arrays.equals(k, key)) {
-                Object[] newNode = new Object[] { packNibbles(key), value };
+                Object[] newNode = new Object[] {packNibbles(key), value};
                 return this.putToCache(newNode);
             }
 
@@ -311,7 +304,8 @@ public class TrieImpl implements Trie {
                 // Expand the 2 length slice to a 17 length slice
                 // Create two nodes to putToCache into the new 17 length node
                 Object oldNode = this.insert("", copyOfRange(k, matchingLength + 1, k.length), v);
-                Object newNode = this.insert("", copyOfRange(key, matchingLength + 1, key.length), value);
+                Object newNode =
+                        this.insert("", copyOfRange(key, matchingLength + 1, key.length), value);
 
                 // Create an expanded slice
                 Object[] scaledSlice = emptyStringSlice(17);
@@ -328,7 +322,8 @@ public class TrieImpl implements Trie {
                 // End of the chain, return
                 return newHash;
             } else {
-                Object[] newNode = new Object[] { packNibbles(copyOfRange(key, 0, matchingLength)), newHash };
+                Object[] newNode =
+                        new Object[] {packNibbles(copyOfRange(key, 0, matchingLength)), newHash};
                 return this.putToCache(newNode);
             }
         } else {
@@ -337,10 +332,15 @@ public class TrieImpl implements Trie {
             Object[] newNode = copyNode(currentNode);
 
             // Replace the first nibble in the key
-            newNode[key[0]] = this.insert(currentNode.get(key[0]).asObj(), copyOfRange(key, 1, key.length), value);
+            newNode[key[0]] =
+                    this.insert(
+                            currentNode.get(key[0]).asObj(),
+                            copyOfRange(key, 1, key.length),
+                            value);
 
-            if (!FastByteComparisons
-                    .equal(HashUtil.h256(getNode(newNode).encode()), HashUtil.h256(currentNode.encode()))) {
+            if (!FastByteComparisons.equal(
+                    HashUtil.h256(getNode(newNode).encode()),
+                    HashUtil.h256(currentNode.encode()))) {
                 markRemoved(HashUtil.h256(currentNode.encode()));
                 if (!isEmptyNode(currentNode.get(key[0]))) {
                     markRemoved(currentNode.get(key[0]).asBytes());
@@ -379,9 +379,9 @@ public class TrieImpl implements Trie {
                 Object newNode;
                 if (child.length() == PAIR_SIZE) {
                     byte[] newKey = concatenate(k, unpackToNibbles(child.get(0).asBytes()));
-                    newNode = new Object[] { packNibbles(newKey), child.get(1).asObj() };
+                    newNode = new Object[] {packNibbles(newKey), child.get(1).asObj()};
                 } else {
-                    newNode = new Object[] { currentNode.get(0), hash };
+                    newNode = new Object[] {currentNode.get(0), hash};
                 }
                 markRemoved(HashUtil.h256(currentNode.encode()));
                 return this.putToCache(newNode);
@@ -408,21 +408,22 @@ public class TrieImpl implements Trie {
 
             Object[] newNode = null;
             if (amount == 16) {
-                newNode = new Object[] { packNibbles(new byte[] { 16 }), itemList[amount] };
+                newNode = new Object[] {packNibbles(new byte[] {16}), itemList[amount]};
             } else if (amount >= 0) {
                 Value child = this.getNode(itemList[amount]);
                 if (child.length() == PAIR_SIZE) {
-                    key = concatenate(new byte[] { amount }, unpackToNibbles(child.get(0).asBytes()));
-                    newNode = new Object[] { packNibbles(key), child.get(1).asObj() };
+                    key = concatenate(new byte[] {amount}, unpackToNibbles(child.get(0).asBytes()));
+                    newNode = new Object[] {packNibbles(key), child.get(1).asObj()};
                 } else if (child.length() == LIST_SIZE) {
-                    newNode = new Object[] { packNibbles(new byte[] { amount }), itemList[amount] };
+                    newNode = new Object[] {packNibbles(new byte[] {amount}), itemList[amount]};
                 }
             } else {
                 newNode = itemList;
             }
 
-            if (!FastByteComparisons
-                    .equal(HashUtil.h256(getNode(newNode).encode()), HashUtil.h256(currentNode.encode()))) {
+            if (!FastByteComparisons.equal(
+                    HashUtil.h256(getNode(newNode).encode()),
+                    HashUtil.h256(currentNode.encode()))) {
                 markRemoved(HashUtil.h256(currentNode.encode()));
             }
 
@@ -437,8 +438,8 @@ public class TrieImpl implements Trie {
     }
 
     /**
-     * Helper method to retrieve the actual node. If the node is not a list and
-     * length is > 32 bytes get the actual node from the db.
+     * Helper method to retrieve the actual node. If the node is not a list and length is > 32 bytes
+     * get the actual node from the db.
      */
     private Value getNode(Object node) {
 
@@ -465,7 +466,9 @@ public class TrieImpl implements Trie {
 
     private boolean isEmptyNode(Object node) {
         Value n = new Value(node);
-        return (node == null || (n.isString() && (n.asString().isEmpty() || n.get(0).isNull())) || n.length() == 0);
+        return (node == null
+                || (n.isString() && (n.asString().isEmpty() || n.get(0).isNull()))
+                || n.length() == 0);
     }
 
     private Object[] copyNode(Value currentNode) {
@@ -485,7 +488,8 @@ public class TrieImpl implements Trie {
         if (this == trie) {
             return true;
         }
-        return trie instanceof Trie && Arrays.equals(this.getRootHash(), ((Trie) trie).getRootHash());
+        return trie instanceof Trie
+                && Arrays.equals(this.getRootHash(), ((Trie) trie).getRootHash());
     }
 
     @Override
@@ -524,10 +528,7 @@ public class TrieImpl implements Trie {
         }
     }
 
-    /**
-     * ****************************** Utility functions *
-     * *****************************
-     */
+    /** ****************************** Utility functions * ***************************** */
     // Created an array of empty elements of required length
     private static Object[] emptyStringSlice(int l) {
         Object[] slice = new Object[l];
@@ -538,13 +539,12 @@ public class TrieImpl implements Trie {
     }
 
     /**
-     * Insert/delete operations on a Trie structure leaves the old nodes in
-     * cache, this method scans the cache and removes them. The method is not
-     * thread safe, the tree should not be modified during the cleaning process.
+     * Insert/delete operations on a Trie structure leaves the old nodes in cache, this method scans
+     * the cache and removes them. The method is not thread safe, the tree should not be modified
+     * during the cleaning process.
      */
     public void cleanCache() {
         synchronized (cache) {
-
             CollectFullSetOfNodes collectAction = new CollectFullSetOfNodes();
 
             this.scanTree(this.getRootHash(), collectAction);
@@ -576,7 +576,6 @@ public class TrieImpl implements Trie {
 
     public void scanTree(byte[] hash, ScanAction scanAction) {
         synchronized (cache) {
-
             Value node = this.getCache().get(hash);
             if (node == null) {
                 throw new RuntimeException("Not found: " + Hex.toHexString(hash));
@@ -633,6 +632,57 @@ public class TrieImpl implements Trie {
                         }
                     }
                     scanAction.doOnNode(myHash, node);
+                }
+            }
+        }
+    }
+
+    /**
+     * Scans the trie similar to {@link #scanTreeLoop(byte[], ScanAction)}, but stops once a state
+     * is found in the given database.
+     *
+     * @param hash state root
+     * @param scanAction action to perform on each node
+     * @param db database containing keys that need not be explored
+     */
+    public void scanTreeDiffLoop(
+            byte[] hash, ScanAction scanAction, IByteArrayKeyValueDatabase db) {
+
+        ArrayList<byte[]> hashes = new ArrayList<>();
+        hashes.add(hash);
+
+        while (!hashes.isEmpty()) {
+            synchronized (cache) {
+                byte[] myHash = hashes.remove(0);
+                Value node = this.getCache().get(myHash);
+                if (node == null) {
+                    System.out.println("Skipped key. Not found: " + Hex.toHexString(myHash));
+                } else {
+                    if (node.isList()) {
+                        List<Object> siblings = node.asList();
+                        if (siblings.size() == PAIR_SIZE) {
+                            Value val = new Value(siblings.get(1));
+                            if (val.isHashCode() && !hasTerminator((byte[]) siblings.get(0))) {
+                                // scanTree(val.asBytes(), scanAction);
+                                byte[] valBytes = val.asBytes();
+                                if (!db.get(valBytes).isPresent()) {
+                                    hashes.add(valBytes);
+                                }
+                            }
+                        } else {
+                            for (int j = 0; j < LIST_SIZE; ++j) {
+                                Value val = new Value(siblings.get(j));
+                                if (val.isHashCode()) {
+                                    // scanTree(val.asBytes(), scanAction);
+                                    byte[] valBytes = val.asBytes();
+                                    if (!db.get(valBytes).isPresent()) {
+                                        hashes.add(valBytes);
+                                    }
+                                }
+                            }
+                        }
+                        scanAction.doOnNode(myHash, node);
+                    }
                 }
             }
         }
@@ -695,21 +745,43 @@ public class TrieImpl implements Trie {
 
             byte[] keysHeader = RLP.encodeLongElementHeader(keysTotalSize);
             byte[] valsHeader = RLP.encodeListHeader(valsTotalSize);
-            byte[] listHeader = RLP.encodeListHeader(
-                    keysTotalSize + keysHeader.length + valsTotalSize + valsHeader.length + root.length);
+            byte[] listHeader =
+                    RLP.encodeListHeader(
+                            keysTotalSize
+                                    + keysHeader.length
+                                    + valsTotalSize
+                                    + valsHeader.length
+                                    + root.length);
 
-            byte[] rlpData = new byte[keysTotalSize + keysHeader.length + valsTotalSize + valsHeader.length
-                    + listHeader.length + root.length];
+            byte[] rlpData =
+                    new byte
+                            [keysTotalSize
+                                    + keysHeader.length
+                                    + valsTotalSize
+                                    + valsHeader.length
+                                    + listHeader.length
+                                    + root.length];
 
             // copy headers:
             // [ rlp_list_header, rlp_keys_header, rlp_keys, rlp_vals_header,
             // rlp_val]
             System.arraycopy(listHeader, 0, rlpData, 0, listHeader.length);
             System.arraycopy(keysHeader, 0, rlpData, listHeader.length, keysHeader.length);
-            System.arraycopy(valsHeader, 0, rlpData, (listHeader.length + keysHeader.length + keysTotalSize),
+            System.arraycopy(
+                    valsHeader,
+                    0,
+                    rlpData,
+                    (listHeader.length + keysHeader.length + keysTotalSize),
                     valsHeader.length);
-            System.arraycopy(root, 0, rlpData,
-                    (listHeader.length + keysHeader.length + keysTotalSize + valsTotalSize + valsHeader.length),
+            System.arraycopy(
+                    root,
+                    0,
+                    rlpData,
+                    (listHeader.length
+                            + keysHeader.length
+                            + keysTotalSize
+                            + valsTotalSize
+                            + valsHeader.length),
                     root.length);
 
             int k_1 = 0;
@@ -720,15 +792,26 @@ public class TrieImpl implements Trie {
                     continue;
                 }
 
-                System.arraycopy(key.getData(), 0, rlpData, (listHeader.length + keysHeader.length + k_1),
+                System.arraycopy(
+                        key.getData(),
+                        0,
+                        rlpData,
+                        (listHeader.length + keysHeader.length + k_1),
                         key.getData().length);
 
                 k_1 += key.getData().length;
 
                 byte[] valBytes = RLP.encodeElement(node.getValue().getData());
 
-                System.arraycopy(valBytes, 0, rlpData,
-                        listHeader.length + keysHeader.length + keysTotalSize + valsHeader.length + k_2,
+                System.arraycopy(
+                        valBytes,
+                        0,
+                        rlpData,
+                        listHeader.length
+                                + keysHeader.length
+                                + keysTotalSize
+                                + valsHeader.length
+                                + k_2,
                         valBytes.length);
                 k_2 += valBytes.length;
             }
@@ -793,12 +876,14 @@ public class TrieImpl implements Trie {
         synchronized (cache) {
             final int[] cnt = new int[1];
             try {
-                scanTree(getRootHash(), new ScanAction() {
-                    @Override
-                    public void doOnNode(byte[] hash, Value node) {
-                        cnt[0]++;
-                    }
-                });
+                scanTree(
+                        getRootHash(),
+                        new ScanAction() {
+                            @Override
+                            public void doOnNode(byte[] hash, Value node) {
+                                cnt[0]++;
+                            }
+                        });
             } catch (Exception e) {
                 return false;
             }
@@ -806,4 +891,29 @@ public class TrieImpl implements Trie {
         }
     }
 
+    @Override
+    public long saveFullStateToDatabase(byte[] stateRoot, IByteArrayKeyValueDatabase db) {
+        ExtractToDatabase traceAction = new ExtractToDatabase(db);
+        traceTrie(stateRoot, traceAction);
+        return traceAction.count;
+    }
+
+    private void traceDiffTrie(byte[] stateRoot, ScanAction action, IByteArrayKeyValueDatabase db) {
+        synchronized (cache) {
+            Value value = new Value(stateRoot);
+
+            if (value.isHashCode() && !db.get(value.asBytes()).isPresent()) {
+                scanTreeDiffLoop(stateRoot, action, db);
+            } else {
+                action.doOnNode(stateRoot, value);
+            }
+        }
+    }
+
+    @Override
+    public long saveDiffStateToDatabase(byte[] stateRoot, IByteArrayKeyValueDatabase db) {
+        ExtractToDatabase traceAction = new ExtractToDatabase(db);
+        traceDiffTrie(stateRoot, traceAction, db);
+        return traceAction.count;
+    }
 }

--- a/modMcf/src/org/aion/mcf/trie/scan/ExtractToDatabase.java
+++ b/modMcf/src/org/aion/mcf/trie/scan/ExtractToDatabase.java
@@ -1,0 +1,51 @@
+/* ******************************************************************************
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ ******************************************************************************/
+package org.aion.mcf.trie.scan;
+
+import org.aion.base.db.IByteArrayKeyValueDatabase;
+import org.aion.rlp.Value;
+
+/** @author Alexandra Roatis */
+public class ExtractToDatabase implements ScanAction {
+
+    // only the keys are relevant so the value will be this constant
+    byte[] dummy_value = new byte[] {0};
+    IByteArrayKeyValueDatabase db;
+    public long count = 0;
+
+    public ExtractToDatabase(IByteArrayKeyValueDatabase _db) {
+        this.db = _db;
+    }
+
+    @Override
+    public void doOnNode(byte[] hash, Value node) {
+        db.put(hash, dummy_value);
+        count++;
+    }
+}

--- a/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
+++ b/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
@@ -475,6 +475,8 @@ public class JournalPruneDataSourceTest {
 
     @Test
     public void testDeleteBatch_wPrune() {
+        db.setPruneEnabled(true);
+
         // ensure existence
         Map<byte[], byte[]> map = new HashMap<>();
         map.put(k1, v1);
@@ -612,6 +614,7 @@ public class JournalPruneDataSourceTest {
 
     @Test(expected = RuntimeException.class)
     public void testIsEmpty_wClosedDatabase_wInsertedKeys() {
+        db.setPruneEnabled(true);
         db.put(randomBytes(32), randomBytes(32));
 
         source_db.close();
@@ -659,7 +662,18 @@ public class JournalPruneDataSourceTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testDelete_wClosedDatabase() {
+    public void testDelete_wClosedDatabase_wPrune() {
+        db.setPruneEnabled(true);
+        source_db.close();
+        assertThat(source_db.isOpen()).isFalse();
+
+        // attempt delete on closed db
+        db.delete(randomBytes(32));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testDelete_wClosedDatabase_woPrune() {
+        db.setPruneEnabled(false);
         source_db.close();
         assertThat(source_db.isOpen()).isFalse();
 
@@ -682,7 +696,23 @@ public class JournalPruneDataSourceTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testDeleteBatch_wClosedDatabase() {
+    public void testDeleteBatch_wClosedDatabase_wPrune() {
+        db.setPruneEnabled(true);
+        source_db.close();
+        assertThat(source_db.isOpen()).isFalse();
+
+        List<byte[]> list = new ArrayList<>();
+        list.add(randomBytes(32));
+        list.add(randomBytes(32));
+        list.add(randomBytes(32));
+
+        // attempt deleteBatch on closed db
+        db.deleteBatch(list);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testDeleteBatch_wClosedDatabase_woPrune() {
+        db.setPruneEnabled(false);
         source_db.close();
         assertThat(source_db.isOpen()).isFalse();
 
@@ -1297,6 +1327,7 @@ public class JournalPruneDataSourceTest {
 
     @Test
     public void pruningTest_woStoredLevel() {
+        db.setPruneEnabled(true);
 
         source_db.put(k2, v2);
         source_db.put(k3, v3);

--- a/modP2p/src/org/aion/p2p/P2pConstant.java
+++ b/modP2p/src/org/aion/p2p/P2pConstant.java
@@ -23,5 +23,7 @@ public class P2pConstant {
     READ_MAX_RATE_TXBC = 20,
 
     // write queue timeout
-    WRITE_MSG_TIMEOUT = 5000;
+    WRITE_MSG_TIMEOUT = 5000,
+
+    BACKWARD_SYNC_STEP = 128;
 }


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Functionality for saving full states to a separate database which prevents the deletion of the keys in the archived states. Together with the already implemented state recovery methods this feature allows maintaining the appearance of disk storage for all state, while also reducing the size of the state database.

Fixes Issue #54.

## Note: this PR builds on top of #482.  

* The PR in #482 should be reviewed and merged first. After which this PR can be rebased to `master-pre-merge` branch.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [x] New feature.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Existing suite of unit tests.
- Running the kernel with pruning and archiving enabled and checking the existence of archived and current states by executing `./aion.sh --dump-state-size X` where X is the height of the blockchain.
- Running the kernel with a database containing a side chain and ensuring correct behavior in the different sync modes. Recovery from archived states works correctly when sync walks back to already pruned blocks. 

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
