### PR TITLE
properly shutdown zmq socket

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/BroadcastTxHandler.java
@@ -181,7 +181,7 @@ public final class BroadcastTxHandler extends Handler {
 
     @Override
     public void shutDown() {
-        log.info("BroadcastTxHandler shutdown!");
+        log.info("BroadcastTxHandler shutting down!");
         if (ex != null) {
             ex.shutdown();
         }

--- a/modApiServer/src/org/aion/api/server/zmq/Proxy.java
+++ b/modApiServer/src/org/aion/api/server/zmq/Proxy.java
@@ -105,7 +105,7 @@ public class Proxy {
                 }
             }
 
-            LOG.info("zmq-proxy thread was interrupted.");
+            LOG.debug("zmq-proxy thread was interrupted.");
         } catch (Exception e) {
             LOG.error("aion.api.server.zmq.Proxy exception" + e.getMessage());
         }
@@ -173,10 +173,10 @@ public class Proxy {
     }
 
     public static void shutdown() throws InterruptedException {
-        LOG.info("zmq-proxy thread shuting down...");
+        LOG.debug("zmq-proxy thread shutting down...");
         shutDown.set(true);
 
-        LOG.info("waiting zmq-proxy thread shutdown");
+        LOG.debug("waiting zmq-proxy thread shutdown");
         Thread.sleep(3000);
     }
 }


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Zmq socket doesn't shutdown properly. It causes the client side native zmq lib has a chance to throw errors and crash the application when the kernel is shutting down.

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- use javaAPI client API test suite to verify the issues.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
