### PR TITLE
Run with ssl enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /pack/
 /reports/
 /cache/
+/sslKeystore/
 
 # ide
 /.idea/

--- a/aion.sh
+++ b/aion.sh
@@ -38,4 +38,4 @@ ARG=$@
 chmod +x ./rt/bin/*
 
 env EVMJIT="-cache=1" ./rt/bin/java -Xms4g \
-        -cp "./lib/*:./lib/libminiupnp/*:./mod/*" org.aion.Aion "$@"
+        -cp "./lib/*:./lib/libminiupnp/*:./mod/*:./sslKeystore/" org.aion.Aion "$@"

--- a/create_cert.sh
+++ b/create_cert.sh
@@ -26,6 +26,6 @@ then
         cd ..
     fi
 else
-    echo "Usage: ./gen_ssl_cert.sh [cert_name] [password] [opt [host] [ip]]"
+    echo "Usage: ./create_cert.sh [cert_name] [password] [opt [host] [ip]]"
     exit 1
 fi

--- a/create_cert.sh
+++ b/create_cert.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ ! -d "sslKeystore" ]
+then
+    echo ""
+    echo "The sslKeystore directory does not exist!"
+    exit 1
+fi
+
+if [ $# -eq 2 ]
+then
+    cd sslKeystore/
+    keytool -genkey -keyalg RSA -alias $1 -keystore $1.jks -storepass $2 -validity 365 -keysize 2048 -ext SAN=DNS:localhost,IP:127.0.0.1
+    if [ $? -eq 0 ]
+    then
+        echo "Certificate created!"
+    fi
+    cd ..
+elif [ $# -eq 4 ]
+then
+    cd sslKeystore/
+    keytool -genkey -keyalg RSA -alias $1 -keystore $1.jks -storepass $2 -validity 365 -keysize 2048 -ext SAN=DNS:$3,IP:$4
+    if [ $? -eq 0 ]
+    then
+        echo "Certificate created!"
+        cd ..
+    fi
+else
+    echo "Usage: ./gen_ssl_cert.sh [cert_name] [password] [opt [host] [ip]]"
+    exit 1
+fi

--- a/create_cert.sh
+++ b/create_cert.sh
@@ -23,8 +23,8 @@ then
     if [ $? -eq 0 ]
     then
         echo "Certificate created!"
-        cd ..
     fi
+    cd ..
 else
     echo "Usage: ./create_cert.sh [cert_name] [password] [opt [host] [ip]]"
     exit 1

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -32,6 +32,7 @@
 package org.aion.zero.impl.cli;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import org.aion.base.util.Hex;
@@ -39,6 +40,7 @@ import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
 import org.aion.mcf.account.Keystore;
 import org.aion.mcf.config.Cfg;
+import org.aion.mcf.config.CfgApiRpcSsl;
 import org.aion.zero.impl.Version;
 import org.aion.zero.impl.db.RecoveryUtils;
 
@@ -112,6 +114,14 @@ public class Cli {
                         System.out.println("boot nodes list: 0");
                     }
                     System.out.println("p2p: " + cfg.getNet().getP2p().getIp() + ":" + cfg.getNet().getP2p().getPort());
+                    break;
+                case "-s":
+                    File store = new File(CfgApiRpcSsl.SSL_KEYSTORE_DIR);
+                    if (store.mkdir()) {
+                        System.out.println("\nCreated sslKeystore directory.");
+                    } else {
+                        System.out.println("\nThe sslKeystore directory already exists.");
+                    }
                     break;
                 case "-r":
                     if (args.length < 2) {
@@ -189,6 +199,8 @@ public class Cli {
         System.out.println("  -c                           create config with default values");
         System.out.println();
         System.out.println("  -i                           show information");
+        System.out.println();
+        System.out.println("  -s                           create ssl keystore directory");
         System.out.println();
         System.out.println("  -r                           remove blocks on side chains and correct block info");
         System.out.println("  -r [block_number]            revert db up to specific block number");

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -1,31 +1,24 @@
 /*
  * Copyright (c) 2017-2018 Aion foundation.
  *
- * This file is part of the aion network project.
+ *     This file is part of the aion network project.
  *
- * The aion network project is free software: you can redistribute it
- * and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or any later version.
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
  *
- * The aion network project is distributed in the hope that it will
- * be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with the aion network project source files.
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
  *
- * The aion network project leverages useful source code from other
- * open source projects. We greatly appreciate the effort that was
- * invested in these projects and we thank the individual contributors
- * for their work. For provenance information and contributors
- * please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
- *
- * Contributors to the aion source files in decreasing order of code volume:
- * Aion foundation.
- *
+ * Contributors:
+ *     Aion foundation.
  */
 
 

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -1575,12 +1575,16 @@ public class ApiWeb3Aion extends ApiAion {
 
         // base.api.rpc
         CfgApiRpc rpcConfig = config.getRpc();
+        CfgApiRpcSsl sslConfig = rpcConfig.getSsl();
         JSONObject rpc = new JSONObject();
         rpc.put("ip", rpcConfig.getIp());
         rpc.put("port", rpcConfig.getPort());
         rpc.put("corsEnabled", rpcConfig.getCorsEnabled());
         rpc.put("active", rpcConfig.getActive());
         rpc.put("maxThread", rpcConfig.getMaxthread());
+        rpc.put("sslEnabled", sslConfig.getEnabled());
+        rpc.put("sslCert", sslConfig.getCert());
+        rpc.put("sslPass", sslConfig.getPass());
 
         // end
         obj.put("rpc", rpc);

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -1574,7 +1574,7 @@ public class ApiWeb3Aion extends ApiAion {
 
         // base.api.rpc
         CfgApiRpc rpcConfig = config.getRpc();
-        CfgApiRpcSsl sslConfig = rpcConfig.getSsl();
+        CfgSsl sslConfig = rpcConfig.getSsl();
         JSONObject rpc = new JSONObject();
         rpc.put("ip", rpcConfig.getIp());
         rpc.put("port", rpcConfig.getPort());

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -19,8 +19,7 @@
  *
  * Contributors:
  *     Aion foundation.
- *     
- ******************************************************************************/
+ */
 
 package org.aion.api.server.http;
 

--- a/modApiServer/src/org/aion/api/server/http/NanoServer.java
+++ b/modApiServer/src/org/aion/api/server/http/NanoServer.java
@@ -17,26 +17,27 @@ public class NanoServer {
     private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
 
     private NanoHttpd server;
-
-
     private String hostname;
     private int port;
     private boolean corsEnabled;
     private List<String> enabledEndpoints;
-
     private ExecutorService workers;
+    private boolean sslEnabled;
+    private String sslCert;
+    private String sslPass;
 
-    public NanoServer(String hostname,
-                      int port,
-                      boolean corsEnabled,
-                      List<String> enabledEndpoints,
-                      int tpoolSize) {
+    public NanoServer(String hostname, int port, boolean corsEnabled, List<String> enabledEndpoints,
+        int tpoolSize, boolean sslEnabled, String sslCert, String sslPass) {
 
         this.corsEnabled = corsEnabled;
         this.enabledEndpoints = enabledEndpoints;
 
         this.hostname = hostname;
         this.port = port;
+
+        this.sslEnabled = sslEnabled;
+        this.sslCert = sslCert;
+        this.sslPass = sslPass;
 
         // do not protect user from over-allocating resources to api.
         // int fixedPoolSize = Math.min(Runtime.getRuntime().availableProcessors()-1, tpoolSize);

--- a/modApiServer/src/org/aion/api/server/http/NanoServer.java
+++ b/modApiServer/src/org/aion/api/server/http/NanoServer.java
@@ -29,7 +29,7 @@ import org.aion.api.server.nanohttpd.BoundRunner;
 import org.aion.api.server.rpc.RpcThreadFactory;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
-import org.aion.mcf.config.CfgApiRpcSsl;
+import org.aion.mcf.config.CfgSsl;
 import org.slf4j.Logger;
 
 import java.util.*;
@@ -84,7 +84,7 @@ public class NanoServer {
             server.setAsyncRunner(new BoundRunner(workers));
 
             if (this.sslEnabled) {
-                if (!(new File(CfgApiRpcSsl.SSL_KEYSTORE_DIR)).isDirectory()) {
+                if (!(new File(CfgSsl.SSL_KEYSTORE_DIR)).isDirectory()) {
                     LOG.error("<rpc-server - no sslKeystore directory found>");
                     System.exit(1);
                 }

--- a/modApiServer/src/org/aion/api/server/http/NanoServer.java
+++ b/modApiServer/src/org/aion/api/server/http/NanoServer.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contributors:
+ *     Aion foundation.
+ */
 package org.aion.api.server.http;
 
 import fi.iki.elonen.NanoHTTPD;

--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -17,11 +17,9 @@
  *     along with the aion network project source files.
  *     If not, see <https://www.gnu.org/licenses/>.
  *
- * Contributors to the aion source files in decreasing order of code volume:
- * 
+ * Contributors:
  *     Aion foundation.
- *     
- ******************************************************************************/
+ */
 
 package org.aion;
 

--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -34,7 +34,7 @@ import org.aion.evtmgr.EventMgrModule;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.aion.mcf.config.CfgApiRpc;
-import org.aion.mcf.config.CfgApiRpcSsl;
+import org.aion.mcf.config.CfgSsl;
 import org.aion.mcf.mine.IMineRunner;
 import org.aion.zero.impl.blockchain.AionFactory;
 import org.aion.zero.impl.blockchain.IAionChain;
@@ -126,7 +126,7 @@ public class Aion {
         NanoServer rpcServer = null;
         if(cfg.getApi().getRpc().getActive()) {
             CfgApiRpc rpcCfg =  cfg.getApi().getRpc();
-            CfgApiRpcSsl sslCfg = rpcCfg.getSsl();
+            CfgSsl sslCfg = rpcCfg.getSsl();
             rpcServer = new NanoServer(
                     rpcCfg.getIp(),
                     rpcCfg.getPort(),

--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -36,6 +36,7 @@ import org.aion.evtmgr.EventMgrModule;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.aion.mcf.config.CfgApiRpc;
+import org.aion.mcf.config.CfgApiRpcSsl;
 import org.aion.mcf.mine.IMineRunner;
 import org.aion.zero.impl.blockchain.AionFactory;
 import org.aion.zero.impl.blockchain.IAionChain;
@@ -127,12 +128,16 @@ public class Aion {
         NanoServer rpcServer = null;
         if(cfg.getApi().getRpc().getActive()) {
             CfgApiRpc rpcCfg =  cfg.getApi().getRpc();
+            CfgApiRpcSsl sslCfg = rpcCfg.getSsl();
             rpcServer = new NanoServer(
                     rpcCfg.getIp(),
                     rpcCfg.getPort(),
                     rpcCfg.getCorsEnabled(),
                     rpcCfg.getEnabled(),
-                    rpcCfg.getMaxthread());
+                    rpcCfg.getMaxthread(),
+                    sslCfg.getEnabled(),
+                    sslCfg.getCert(),
+                    sslCfg.getPass());
             rpcServer.start();
         }
 

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -19,8 +19,7 @@
  *
  * Contributors:
  *     Aion foundation.
- *
- ******************************************************************************/
+ */
 package org.aion.mcf.config;
 
 import javax.xml.stream.XMLOutputFactory;

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -32,7 +32,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,6 +49,7 @@ public final class CfgApiRpc {
         this.corsEnabled = false;
         this.maxthread = 1;
         this.filtersEnabled = true;
+        this.ssl = new CfgApiRpcSsl();
     }
 
     private boolean active;
@@ -59,6 +59,7 @@ public final class CfgApiRpc {
     private boolean corsEnabled;
     private int maxthread;
     private boolean filtersEnabled;
+    private CfgApiRpcSsl ssl;
 
     public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
         // get the attributes
@@ -108,6 +109,9 @@ public final class CfgApiRpc {
                                 System.out.println("failed to read config node: aion.api.rpc.filters-enabled; using preset: " + this.filtersEnabled);
                                 e.printStackTrace();
                             }
+                            break;
+                        case "ssl":
+                            this.ssl.fromXML(sr);
                             break;
                         default:
                             Cfg.skipElement(sr);
@@ -160,6 +164,8 @@ public final class CfgApiRpc {
             xmlWriter.writeCharacters(this.maxthread + "");
             xmlWriter.writeEndElement();
 
+            xmlWriter.writeCharacters(this.ssl.toXML());
+
             xmlWriter.writeCharacters("\r\n\t\t");
             xmlWriter.writeEndElement();
             xml = strWriter.toString();
@@ -193,4 +199,5 @@ public final class CfgApiRpc {
     public boolean isFiltersEnabled() {
         return filtersEnabled;
     }
+    public CfgApiRpcSsl getSsl() { return this.ssl; }
 }

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -48,7 +48,7 @@ public final class CfgApiRpc {
         this.corsEnabled = false;
         this.maxthread = 1;
         this.filtersEnabled = true;
-        this.ssl = new CfgApiRpcSsl();
+        this.ssl = new CfgSsl();
     }
 
     private boolean active;
@@ -58,7 +58,7 @@ public final class CfgApiRpc {
     private boolean corsEnabled;
     private int maxthread;
     private boolean filtersEnabled;
-    private CfgApiRpcSsl ssl;
+    private CfgSsl ssl;
 
     public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
         // get the attributes
@@ -198,5 +198,5 @@ public final class CfgApiRpc {
     public boolean isFiltersEnabled() {
         return filtersEnabled;
     }
-    public CfgApiRpcSsl getSsl() { return this.ssl; }
+    public CfgSsl getSsl() { return this.ssl; }
 }

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpcSsl.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpcSsl.java
@@ -1,0 +1,123 @@
+package org.aion.mcf.config;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+
+public class CfgApiRpcSsl {
+    private static final String ENABLED_TAG = "enabled";
+    private static final String CERTIFICATE_TAG = "certificate";
+    private static final String PASSWORD_TAG = "password";
+    private boolean enabled;
+    private String cert;
+    private String pass;
+
+    CfgApiRpcSsl() {
+        this.enabled = false;
+        this.cert = "identity.jks";
+        this.pass = "password";
+    }
+
+    public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
+        loop:
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            switch (eventType) {
+                case XMLStreamReader.START_ELEMENT:
+                    String elementName = sr.getLocalName().toLowerCase();
+                    switch (elementName) {
+                        case ENABLED_TAG:
+                            try {
+                                this.enabled = Boolean.parseBoolean(Cfg.readValue(sr));
+                            } catch (Exception e) {
+                                System.out.println("failed to read config node: " +
+                                    "aion.api.rpc.ssl.enabled; using preset: " + this.enabled);
+                                e.printStackTrace();
+                            }
+                            break;
+                        case CERTIFICATE_TAG:
+                            try {
+                                this.cert = String.valueOf(Cfg.readValue(sr));
+                            } catch (Exception e) {
+                                System.out.println("failed to read config node: " +
+                                    "aion.api.rpc.ssl.enabled; using preset: " + this.enabled);
+                                e.printStackTrace();
+                            }
+                            break;
+                        case PASSWORD_TAG:
+                            try {
+                                this.pass = String.valueOf(Cfg.readValue(sr));
+                            } catch (Exception e) {
+                                System.out.println("failed to read config node: " +
+                                    "aion.api.rpc.ssl.password; using preset: " + this.pass);
+                                e.printStackTrace();
+                            }
+                            break;
+                        default:
+                            Cfg.skipElement(sr);
+                            break;
+                    }
+                    break;
+                case XMLStreamConstants.END_ELEMENT:
+                    break loop;
+            }
+        }
+        //sr.next();
+    }
+
+    String toXML() {
+        final XMLOutputFactory output = XMLOutputFactory.newInstance();
+        output.setProperty("escapeCharacters", false);
+        XMLStreamWriter xmlWriter;
+        String xml;
+        try {
+            Writer strWriter = new StringWriter();
+            xmlWriter = output.createXMLStreamWriter(strWriter);
+            xmlWriter.writeCharacters("\r\n\t\t\t");
+            xmlWriter.writeStartElement("ssl");
+
+            xmlWriter.writeCharacters("\r\n\t\t\t\t");
+            xmlWriter.writeComment("toggle ssl on-off " +
+                "(if on you cannot access json-rpc over plain http)");
+            xmlWriter.writeCharacters("\r\n\t\t\t\t");
+            xmlWriter.writeStartElement(ENABLED_TAG);
+            xmlWriter.writeCharacters(this.enabled ? "true" : "false");
+            xmlWriter.writeEndElement();
+
+            xmlWriter.writeCharacters("\r\n\t\t\t\t");
+            xmlWriter.writeComment("file name of certificate to use (eg. identity.jks)");
+            xmlWriter.writeCharacters("\r\n\t\t\t\t");
+            xmlWriter.writeStartElement(CERTIFICATE_TAG);
+            xmlWriter.writeCharacters(this.cert);
+            xmlWriter.writeEndElement();
+
+            xmlWriter.writeCharacters("\r\n\t\t\t\t");
+            xmlWriter.writeComment("password for ssl certificate");
+            xmlWriter.writeCharacters("\r\n\t\t\t\t");
+            xmlWriter.writeStartElement(PASSWORD_TAG);
+            xmlWriter.writeCharacters(this.pass);
+            xmlWriter.writeEndElement();
+
+            xmlWriter.writeCharacters("\r\n\t\t\t");
+            xmlWriter.writeEndElement();
+            xml = strWriter.toString();
+            strWriter.flush();
+            strWriter.close();
+            xmlWriter.flush();
+            xmlWriter.close();
+            return xml;
+        } catch (IOException | XMLStreamException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+    public boolean getEnabled() { return this.enabled; }
+    public String getCert() { return this.cert; }
+    public String getPass() { return this.pass; }
+}

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpcSsl.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpcSsl.java
@@ -10,6 +10,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 public class CfgApiRpcSsl {
+    public static final String SSL_KEYSTORE_DIR = "./sslKeystore";
     private static final String ENABLED_TAG = "enabled";
     private static final String CERTIFICATE_TAG = "certificate";
     private static final String PASSWORD_TAG = "password";

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpcSsl.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpcSsl.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contributors:
+ *     Aion foundation.
+ */
 package org.aion.mcf.config;
 
 import java.io.IOException;

--- a/modMcf/src/org/aion/mcf/config/CfgSsl.java
+++ b/modMcf/src/org/aion/mcf/config/CfgSsl.java
@@ -31,7 +31,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
-public class CfgApiRpcSsl {
+public class CfgSsl {
     public static final String SSL_KEYSTORE_DIR = "./sslKeystore";
     private static final String ENABLED_TAG = "enabled";
     private static final String CERTIFICATE_TAG = "certificate";
@@ -40,7 +40,7 @@ public class CfgApiRpcSsl {
     private String cert;
     private String pass;
 
-    CfgApiRpcSsl() {
+    CfgSsl() {
         this.enabled = false;
         this.cert = "identity.jks";
         this.pass = "password";


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Users now able to run aion using a self-signed ssl certificate. Additionally, I added some command line options to the aion.sh script to create the directory where the certificate will be placed and to create the certificate. Once merged, will need to update the wiki with a short description of how to use this functionality.

Fixes Issue #510.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [x] New feature.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [x] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- All manual tests, verifying a number of scearios: able to access rpc-json end points over https and not http when option is enabled; multiple certs; bad password; missing cert; missing keystore dir, etc.
- To generate a self-signed cert you will need <a href="https://www.openssl.org/source/">OpenSSL</a> and at command `cd` into project root and do `./aion.sh -s store` to create the keystore directory and then `./aion.sh -s create` (there is a second command to customize host & ip as well) and follow the prompts to create the certificate.
- In IDEA you will need to add the sslKeystore directory to the modApiServer classpath.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
