### PR TITLE
Add optional to IRepoQuery

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "aion_fastvm"]
 	path = aion_fastvm
 	url = https://github.com/aionnetwork/aion_fastvm
+    branch = add_optional2db
 [submodule "aion_api"]
 	path = aion_api
 	url = https://github.com/aionnetwork/aion_api

--- a/modAion/src/org/aion/zero/db/AionRepositoryCache.java
+++ b/modAion/src/org/aion/zero/db/AionRepositoryCache.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -17,10 +17,9 @@
  *     along with the aion network project source files.
  *     If not, see <https://www.gnu.org/licenses/>.
  *
- *
  * Contributors:
  *     Aion foundation.
- ******************************************************************************/
+ */
 package org.aion.zero.db;
 
 import org.aion.base.db.IContractDetails;

--- a/modAionBase/src/org/aion/base/db/IRepositoryQuery.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryQuery.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -31,16 +31,16 @@
  *     Samuel Neves through the BLAKE2 implementation.
  *     Zcash project team.
  *     Bitcoinj team.
- ******************************************************************************/
+ */
 package org.aion.base.db;
 
+import java.util.Optional;
 import org.aion.base.type.Address;
 
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Repository interface for information retrieval.
@@ -187,9 +187,9 @@ public interface IRepositoryQuery<AS, DW> {
      *            the address of the account of interest
      * @param key
      *            the key of interest
-     * @return a {@link DW} representing the data associated with the given key
+     * @return an {@link Optional} of {@link DW} representing the data associated with the given key
      */
-    DW getStorageValue(Address address, DW key);
+    Optional<DW> getStorageValue(Address address, DW key);
 
     /**
      * Retrieves the stored transactions for recovering pool tx.

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -19,8 +19,7 @@
  *
  * Contributors:
  *     Aion foundation.
- *     
- ******************************************************************************/
+ */
 
 package org.aion.zero.impl.db;
 
@@ -29,6 +28,7 @@ import static org.aion.crypto.HashUtil.h256;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.aion.base.db.IContractDetails;
@@ -38,7 +38,6 @@ import org.aion.base.type.Address;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.base.util.Hex;
 import org.aion.mcf.core.AccountState;
-//import org.aion.types.vm.DataWord;
 import org.aion.mcf.db.ContractDetailsCacheImpl;
 import org.aion.mcf.vm.types.DataWord;
 import org.aion.zero.db.AionRepositoryCache;
@@ -168,14 +167,14 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
         return account.getBalance();
     }
 
-    public DataWord getStorageValue(Address addr, DataWord key) {
+    public Optional<DataWord> getStorageValue(Address addr, DataWord key) {
         IContractDetails<DataWord> details = getContractDetails(addr);
 
         if (details == null) {
-            return null;
+            return Optional.empty();
         }
 
-        return details.get(key);
+        return Optional.of(details.get(key));
     }
 
     public void addStorageRow(Address addr, DataWord key, DataWord value) {

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -1,4 +1,4 @@
-/* ******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -19,7 +19,7 @@
  *
  * Contributors:
  *     Aion foundation.
- ******************************************************************************/
+ */
 package org.aion.zero.impl.db;
 
 import static org.aion.base.util.ByteUtil.EMPTY_BYTE_ARRAY;
@@ -295,9 +295,9 @@ public class AionRepositoryImpl
     }
 
     @Override
-    public DataWord getStorageValue(Address address, DataWord key) {
+    public Optional<DataWord> getStorageValue(Address address, DataWord key) {
         IContractDetails<DataWord> details = getContractDetails(address);
-        return (details == null) ? null : details.get(key);
+        return (details == null) ? Optional.empty() : Optional.of(details.get(key));
     }
 
     @Override

--- a/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/db/AionRepositoryImplTest.java
@@ -146,7 +146,7 @@ public class AionRepositoryImplTest {
         track.flush();
 
         byte[] retrievedValue =
-                repository.getStorageValue(defaultAccount, new DataWord(key)).getNoLeadZeroesData();
+                repository.getStorageValue(defaultAccount, new DataWord(key)).get().getNoLeadZeroesData();
         assertThat(retrievedValue).isEqualTo(value);
 
         byte[] newRoot = repository.getRoot();
@@ -207,13 +207,13 @@ public class AionRepositoryImplTest {
         repoTrack.addStorageRow(defaultAccount, new DataWord(key), new DataWord(value));
 
         DataWord retrievedStorageValue =
-                repoTrack.getStorageValue(defaultAccount, new DataWord(key));
+                repoTrack.getStorageValue(defaultAccount, new DataWord(key)).get();
         assertThat(retrievedStorageValue).isEqualTo(new DataWord(value));
 
         // commit changes, then check that the root has updated
         repoTrack.flush();
 
-        assertThat(repository.getStorageValue(defaultAccount, new DataWord(key)))
+        assertThat(repository.getStorageValue(defaultAccount, new DataWord(key)).get())
                 .isEqualTo(retrievedStorageValue);
 
         final byte[] newRoot = repository.getRoot();

--- a/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/http/ApiWeb3Aion.java
@@ -1,4 +1,4 @@
-/* ******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -19,8 +19,7 @@
  *
  * Contributors:
  *     Aion foundation.
- *
- ******************************************************************************/
+ */
 
 package org.aion.api.server.http;
 
@@ -43,6 +42,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -472,11 +472,12 @@ public class ApiWeb3Aion extends ApiAion {
         IRepository repo = this.ac.getRepository();
 
         @SuppressWarnings("unchecked")
-        DataWord storageValue = (DataWord) repo.getStorageValue(address, key);
-        if (storageValue != null)
-            return new RpcMsg(TypeConverter.toJsonHex(storageValue.getData()));
-        else
+        Optional<DataWord> storageValue = repo.getStorageValue(address, key);
+        if (storageValue.isPresent()) {
+            return new RpcMsg(TypeConverter.toJsonHex(storageValue.get().getData()));
+        } else {
             return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Storage value not found");
+        }
     }
 
     public RpcMsg eth_getTransactionCount(Object _params) {

--- a/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
@@ -1,25 +1,28 @@
-/*******************************************************************************
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
  *
- * Copyright (c) 2017, 2018 Aion foundation.
+ *     This file is part of the aion network project.
  *
- * 	This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
  *
  *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <https://www.gnu.org/licenses/>
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
  *
  * Contributors:
  *     Aion foundation.
- *******************************************************************************/
+ */
 package org.aion.mcf.db;
 
+import java.util.Optional;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.db.IRepository;
 import org.aion.base.db.IRepositoryCache;
@@ -34,7 +37,6 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -328,8 +330,9 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     }
 
     @Override
-    public DataWord getStorageValue(Address address, DataWord key) {
-        return getContractDetails(address).get(key);
+    public Optional<DataWord> getStorageValue(Address address, DataWord key) {
+        DataWord res = getContractDetails(address).get(key);
+        return (res == null) ? Optional.empty() : Optional.of(res);
     }
 
     @Override


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Modifies IRepositoryQuery's getStorageValue to return an Optional. This ensures implementing subclasses will handle invalid key requests consistently. Some pre-compiled contracts will rely on this consistency for correctness. Changes in vm are on the add_optional2db branch currently

Fixes Issue # N/A.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Tested against the current test suite.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
