### PR TITLE
Add DoubleDataWord to db

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = https://github.com/aionnetwork/aion_fastvm
 [submodule "aion_api"]
 	path = aion_api
-	url = https://github.com/aionnetwork/aion_api
+    url = https://github.com/aionnetwork/aion_api
+    branch = db32byte

--- a/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
+++ b/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
@@ -85,8 +85,9 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
     @Override
     public void put(IDataWord key, IDataWord value) {
         WordType vType = value.getType();
+        IDataWord zero = (vType.equals(WordType.DATA_WORD)) ? DataWord.ZERO : DoubleDataWord.ZERO;
 
-        if (value.equals(vType)) {
+        if (value.equals(zero)) {
             storageTrie.delete(key.getData());
         } else {
             storageTrie.update(key.getData(), RLP.encodeElement(value.getNoLeadZeroesData()));
@@ -104,7 +105,7 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         byte[] data = storageTrie.get(key.getData());
         if (data.length > 0) {
             byte[] dataDecoded = RLP.decode2(data).get(0).getRLPData();
-            result = new DataWord(dataDecoded);
+            result = toIDataWord(dataDecoded);
         }
 
         return result;

--- a/modAion/src/org/aion/zero/db/AionRepositoryCache.java
+++ b/modAion/src/org/aion/zero/db/AionRepositoryCache.java
@@ -27,11 +27,11 @@ import org.aion.base.db.IContractDetails;
 import org.aion.base.db.IRepository;
 import org.aion.base.db.IRepositoryCache;
 import org.aion.base.type.Address;
+import org.aion.base.vm.IDataWord;
 import org.aion.mcf.core.AccountState;
 import org.aion.mcf.db.AbstractRepositoryCache;
 import org.aion.mcf.db.ContractDetailsCacheImpl;
 import org.aion.mcf.db.IBlockStoreBase;
-import org.aion.mcf.vm.types.DataWord;
 
 import java.util.HashMap;
 import java.util.List;
@@ -74,8 +74,8 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
             }
 
             // determine which contracts should get stored
-            for (Map.Entry<Address, IContractDetails<DataWord>> entry : cachedDetails.entrySet()) {
-                IContractDetails<DataWord> ctd = entry.getValue();
+            for (Map.Entry<Address, IContractDetails<IDataWord>> entry : cachedDetails.entrySet()) {
+                IContractDetails<IDataWord> ctd = entry.getValue();
                 // TODO: this functionality will be improved with the switch to a
                 // different ContractDetails implementation
                 if (ctd != null && ctd instanceof ContractDetailsCacheImpl) {
@@ -105,7 +105,7 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
     }
 
     @Override
-    public void updateBatch(Map<Address, AccountState> accounts, Map<Address, IContractDetails<DataWord>> details) {
+    public void updateBatch(Map<Address, AccountState> accounts, Map<Address, IContractDetails<IDataWord>> details) {
         fullyWriteLock();
         try {
 
@@ -113,7 +113,7 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
                 this.cachedAccounts.put(accEntry.getKey(), accEntry.getValue());
             }
 
-            for (Map.Entry<Address, IContractDetails<DataWord>> ctdEntry : details.entrySet()) {
+            for (Map.Entry<Address, IContractDetails<IDataWord>> ctdEntry : details.entrySet()) {
                 ContractDetailsCacheImpl contractDetailsCache = (ContractDetailsCacheImpl) ctdEntry.getValue();
                 if (contractDetailsCache.origContract != null
                         && !(contractDetailsCache.origContract instanceof AionContractDetailsImpl)) {

--- a/modAionBase/src/org/aion/base/db/IContractDetails.java
+++ b/modAionBase/src/org/aion/base/db/IContractDetails.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.aion.base.vm.IDataWord;
 
 public interface IContractDetails<DW> {
 
@@ -84,4 +85,5 @@ public interface IContractDetails<DW> {
     IContractDetails<DW> getSnapshotTo(byte[] hash);
 
     void setDataSource(IByteArrayKeyValueStore dataSource);
+
 }

--- a/modAionBase/src/org/aion/base/db/IRepositoryQuery.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryQuery.java
@@ -40,6 +40,7 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.aion.base.vm.IDataWord;
 
 /**
  * Repository interface for information retrieval.
@@ -203,4 +204,5 @@ public interface IRepositoryQuery<AS, DW> {
      * @return the list of transactions encoded bytes.
      */
     List<byte[]> getCacheTx();
+
 }

--- a/modAionBase/src/org/aion/base/db/IRepositoryQuery.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryQuery.java
@@ -40,7 +40,6 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Repository interface for information retrieval.

--- a/modAionBase/src/org/aion/base/vm/IDataWord.java
+++ b/modAionBase/src/org/aion/base/vm/IDataWord.java
@@ -28,5 +28,21 @@ package org.aion.base.vm;
  *
  */
 public interface IDataWord {
+    enum WordType { DATA_WORD, DOUBLE_DATA_WORD }
+
+    // Returns a convenient enum for determining the subclass type.
+    WordType getType();
+
+    // Returns the byte array data the IDataWord wraps.
+    byte[] getData();
+
+    // Returns the underlying byte array, truncated so that leading zero bytes are removed.
+    byte[] getNoLeadZeroesData();
+
+    // Returns a copy of the IDataWord.
+    IDataWord copy();
+
+    // Returns true only if the underlying byte array consists only of zero bits.
+    boolean isZero();
 
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
@@ -169,12 +169,7 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
 
     public IDataWord getStorageValue(Address addr, IDataWord key) {
         IContractDetails<IDataWord> details = getContractDetails(addr);
-
-        if (details == null) {
-            return null;
-        }
-
-        return details.get(key);
+        return (details == null) ? null : details.get(key);
     }
 
     public void addStorageRow(Address addr, IDataWord key, IDataWord value) {

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
@@ -37,10 +37,9 @@ import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.base.util.Hex;
+import org.aion.base.vm.IDataWord;
 import org.aion.mcf.core.AccountState;
-//import org.aion.types.vm.DataWord;
 import org.aion.mcf.db.ContractDetailsCacheImpl;
-import org.aion.mcf.vm.types.DataWord;
 import org.aion.zero.db.AionRepositoryCache;
 import org.aion.zero.types.IAionBlock;
 import org.slf4j.Logger;
@@ -53,7 +52,7 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
 
     private static final Logger logger = LoggerFactory.getLogger("repository");
     private Map<ByteArrayWrapper, AccountState> worldState = new HashMap<>();
-    private Map<ByteArrayWrapper, IContractDetails<DataWord>> detailsDB = new HashMap<>();
+    private Map<ByteArrayWrapper, IContractDetails<IDataWord>> detailsDB = new HashMap<>();
 
     public AionRepositoryDummy(IRepositoryConfig cfg) {
         super(cfg);
@@ -75,12 +74,12 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
     }
 
     public void updateBatch(HashMap<ByteArrayWrapper, AccountState> stateCache,
-            HashMap<ByteArrayWrapper, IContractDetails<DataWord>> detailsCache) {
+            HashMap<ByteArrayWrapper, IContractDetails<IDataWord>> detailsCache) {
 
         for (ByteArrayWrapper hash : stateCache.keySet()) {
 
             AccountState accountState = stateCache.get(hash);
-            IContractDetails<DataWord> contractDetails = detailsCache.get(hash);
+            IContractDetails<IDataWord> contractDetails = detailsCache.get(hash);
 
             if (accountState.isDeleted()) {
                 worldState.remove(hash);
@@ -168,8 +167,8 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
         return account.getBalance();
     }
 
-    public DataWord getStorageValue(Address addr, DataWord key) {
-        IContractDetails<DataWord> details = getContractDetails(addr);
+    public IDataWord getStorageValue(Address addr, IDataWord key) {
+        IContractDetails<IDataWord> details = getContractDetails(addr);
 
         if (details == null) {
             return null;
@@ -178,8 +177,8 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
         return details.get(key);
     }
 
-    public void addStorageRow(Address addr, DataWord key, DataWord value) {
-        IContractDetails<DataWord> details = getContractDetails(addr);
+    public void addStorageRow(Address addr, IDataWord key, IDataWord value) {
+        IContractDetails<IDataWord> details = getContractDetails(addr);
 
         if (details == null) {
             createAccount(addr);
@@ -191,7 +190,7 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
     }
 
     public byte[] getCode(Address addr) {
-        IContractDetails<DataWord> details = getContractDetails(addr);
+        IContractDetails<IDataWord> details = getContractDetails(addr);
 
         if (details == null) {
             return null;
@@ -201,7 +200,7 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
     }
 
     public void saveCode(Address addr, byte[] code) {
-        IContractDetails<DataWord> details = getContractDetails(addr);
+        IContractDetails<IDataWord> details = getContractDetails(addr);
 
         if (details == null) {
             createAccount(addr);
@@ -254,7 +253,7 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
         detailsDB.remove(addr.toByteArrayWrapper());
     }
 
-    public IContractDetails<DataWord> getContractDetails(Address addr) {
+    public IContractDetails<IDataWord> getContractDetails(Address addr) {
 
         return detailsDB.get(addr.toByteArrayWrapper());
     }
@@ -267,7 +266,7 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
         AccountState accountState = new AccountState();
         worldState.put(addr.toByteArrayWrapper(), accountState);
 
-        IContractDetails<DataWord> contractDetails = this.cfg.contractDetailsImpl();
+        IContractDetails<IDataWord> contractDetails = this.cfg.contractDetailsImpl();
         detailsDB.put(addr.toByteArrayWrapper(), contractDetails);
 
         return accountState;
@@ -282,10 +281,10 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
     }
 
     public void loadAccount(Address addr, HashMap<ByteArrayWrapper, AccountState> cacheAccounts,
-            HashMap<ByteArrayWrapper, IContractDetails<DataWord>> cacheDetails) {
+            HashMap<ByteArrayWrapper, IContractDetails<IDataWord>> cacheDetails) {
 
         AccountState account = getAccountState(addr);
-        IContractDetails<DataWord> details = getContractDetails(addr);
+        IContractDetails<IDataWord> details = getContractDetails(addr);
 
         if (account == null) {
             account = new AccountState();

--- a/modAionImpl/src/org/aion/zero/impl/db/ContractDetailsAion.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/ContractDetailsAion.java
@@ -26,10 +26,8 @@ package org.aion.zero.impl.db;
 
 import org.aion.base.db.DetailsProvider;
 import org.aion.base.db.IContractDetails;
-import org.aion.mcf.config.CfgDb;
-import org.aion.mcf.vm.types.DataWord;
+import org.aion.base.vm.IDataWord;
 import org.aion.zero.db.AionContractDetailsImpl;
-import org.aion.zero.impl.config.CfgAion;
 
 /**
  * Contract details provider for Aion.
@@ -89,7 +87,7 @@ public class ContractDetailsAion implements DetailsProvider {
     }
 
     @Override
-    public IContractDetails<DataWord> getDetails() {
+    public IContractDetails<IDataWord> getDetails() {
         return new AionContractDetailsImpl(this.prune, this.memStorageLimit);
     }
 

--- a/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
@@ -24,12 +24,16 @@
  ******************************************************************************/
 package org.aion.mcf.db;
 
+import javax.xml.crypto.Data;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.base.util.Hex;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.aion.base.vm.IDataWord;
+import org.aion.mcf.vm.types.DataWord;
+import org.aion.mcf.vm.types.DoubleDataWord;
 
 import static org.aion.base.util.ByteUtil.EMPTY_BYTE_ARRAY;
 import static org.aion.crypto.HashUtil.EMPTY_DATA_HASH;
@@ -122,5 +126,18 @@ public abstract class AbstractContractDetails<DW> implements IContractDetails<DW
         String ret = "  Code: " + (codes.size() < 2 ? Hex.toHexString(getCode()) : codes.size() + " versions") + "\n";
         ret += "  Storage: " + getStorageHash();
         return ret;
+    }
+
+    /**
+     * Returns an IDataWord object that wraps data appropriately. If data is 16 bytes a DataWord
+     * object is used. Otherwise if 32 bytes a DoubleDataWord object is used.
+     *
+     * Precondition: data is not null and data.length == 16 or 32.
+     *
+     * @param data The data to convert.
+     * @return the data as an IDataWord object.
+     */
+    protected IDataWord toIDataWord(byte[] data) {
+        return (data.length == DataWord.BYTES) ? new DataWord(data) : new DoubleDataWord(data);
     }
 }

--- a/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
@@ -24,7 +24,6 @@
  ******************************************************************************/
 package org.aion.mcf.db;
 
-import javax.xml.crypto.Data;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.base.util.Hex;

--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -330,4 +330,5 @@ public abstract class AbstractRepository<
     public boolean isSnapshot() {
         return isSnapshot;
     }
+
 }

--- a/modMcf/src/org/aion/mcf/db/AbstractRepository.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepository.java
@@ -34,6 +34,7 @@ import org.aion.base.db.IRepository;
 import org.aion.base.db.IRepositoryConfig;
 import org.aion.base.type.IBlockHeader;
 import org.aion.base.type.ITransaction;
+import org.aion.base.vm.IDataWord;
 import org.aion.db.impl.DatabaseFactory;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
@@ -44,7 +45,6 @@ import org.aion.mcf.ds.ArchivedDataSource;
 import org.aion.mcf.trie.JournalPruneDataSource;
 import org.aion.mcf.trie.Trie;
 import org.aion.mcf.types.AbstractBlock;
-import org.aion.mcf.vm.types.DataWord;
 import org.slf4j.Logger;
 
 // import org.aion.dbmgr.exception.DriverManagerNoSuitableDriverRegisteredException;
@@ -54,7 +54,7 @@ public abstract class AbstractRepository<
                 BLK extends AbstractBlock<BH, ? extends ITransaction>,
                 BH extends IBlockHeader,
                 BSB extends IBlockStoreBase<?, ?>>
-        implements IRepository<AccountState, DataWord, BSB> {
+        implements IRepository<AccountState, IDataWord, BSB> {
 
     // Logger
     protected static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.DB.name());

--- a/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
@@ -24,17 +24,16 @@ import org.aion.base.db.IContractDetails;
 import org.aion.base.db.IRepository;
 import org.aion.base.db.IRepositoryCache;
 import org.aion.base.type.Address;
+import org.aion.base.vm.IDataWord;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.aion.mcf.core.AccountState;
-import org.aion.mcf.vm.types.DataWord;
 import org.slf4j.Logger;
 
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -47,7 +46,7 @@ import static org.aion.crypto.HashUtil.h256;
  * @author Alexandra Roatis
  */
 public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
-        implements IRepositoryCache<AccountState, DataWord, BSB> {
+        implements IRepositoryCache<AccountState, IDataWord, BSB> {
 
     // Logger
     protected static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.DB.name());
@@ -55,7 +54,7 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     /**
      * the repository being tracked
      */
-    protected IRepository<AccountState, DataWord, BSB> repository;
+    protected IRepository<AccountState, IDataWord, BSB> repository;
 
     /**
      * local accounts cache
@@ -65,7 +64,7 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     /**
      * local contract details cache
      */
-    protected Map<Address, IContractDetails<DataWord>> cachedDetails;
+    protected Map<Address, IContractDetails<IDataWord>> cachedDetails;
     protected ReadWriteLock lockDetails = new ReentrantReadWriteLock();
 
     @Override
@@ -76,7 +75,7 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
             cachedAccounts.put(address, accountState);
 
             // TODO: unify contract details initialization from Impl and Track
-            IContractDetails<DataWord> contractDetails = new ContractDetailsCacheImpl(null);
+            IContractDetails<IDataWord> contractDetails = new ContractDetailsCacheImpl(null);
             // TODO: refactor to use makeDirty() from AbstractState
             contractDetails.setDirty(true);
             cachedDetails.put(address, contractDetails);
@@ -141,11 +140,11 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     }
 
     @Override
-    public IContractDetails<DataWord> getContractDetails(Address address) {
+    public IContractDetails<IDataWord> getContractDetails(Address address) {
         lockDetails.readLock().lock();
 
         try {
-            IContractDetails<DataWord> contractDetails = this.cachedDetails.get(address);
+            IContractDetails<IDataWord> contractDetails = this.cachedDetails.get(address);
 
             if (contractDetails == null) {
                 // loads the address into cache
@@ -173,7 +172,7 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
         lockDetails.readLock().lock();
 
         try {
-            IContractDetails<DataWord> contractDetails = cachedDetails.get(address);
+            IContractDetails<IDataWord> contractDetails = cachedDetails.get(address);
 
             if (contractDetails == null) {
                 // ask repository when not cached
@@ -192,13 +191,13 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
      */
     @Override
     public void loadAccountState(Address address, Map<Address, AccountState> accounts,
-            Map<Address, IContractDetails<DataWord>> details) {
+            Map<Address, IContractDetails<IDataWord>> details) {
         fullyReadLock();
 
         try {
             // check if the account is cached locally
             AccountState accountState = this.cachedAccounts.get(address);
-            IContractDetails<DataWord> contractDetails = this.cachedDetails.get(address);
+            IContractDetails<IDataWord> contractDetails = this.cachedDetails.get(address);
 
             // when account not cached load from repository
             if (accountState == null) {
@@ -293,7 +292,7 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
         try {
             // save the code
             // TODO: why not create contract here directly? also need to check that there is no preexisting code!
-            IContractDetails<DataWord> contractDetails = getContractDetails(address);
+            IContractDetails<IDataWord> contractDetails = getContractDetails(address);
             contractDetails.setCode(code);
             // TODO: ensure that setDirty is done by the class itself
             contractDetails.setDirty(true);
@@ -318,7 +317,7 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     }
 
     @Override
-    public void addStorageRow(Address address, DataWord key, DataWord value) {
+    public void addStorageRow(Address address, IDataWord key, IDataWord value) {
         lockDetails.writeLock().lock();
         try {
             getContractDetails(address).put(key, value);
@@ -328,13 +327,13 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     }
 
     @Override
-    public DataWord getStorageValue(Address address, DataWord key) {
+    public IDataWord getStorageValue(Address address, IDataWord key) {
         return getContractDetails(address).get(key);
     }
 
     @Override
-    public Map<DataWord, DataWord> getStorage(Address address, Collection<DataWord> keys) {
-        IContractDetails<DataWord> details = getContractDetails(address);
+    public Map<IDataWord, IDataWord> getStorage(Address address, Collection<IDataWord> keys) {
+        IContractDetails<IDataWord> details = getContractDetails(address);
         return (details == null) ? Collections.emptyMap() : details.getStorage(keys);
     }
 

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -23,21 +23,23 @@ package org.aion.mcf.db;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.type.Address;
-import org.aion.base.util.ByteArrayWrapper;
+import org.aion.base.vm.IDataWord;
+import org.aion.base.vm.IDataWord.WordType;
 import org.aion.mcf.vm.types.DataWord;
 
 import java.util.*;
+import org.aion.mcf.vm.types.DoubleDataWord;
 
 /**
  * Contract details cache implementation.
  */
-public class ContractDetailsCacheImpl extends AbstractContractDetails<DataWord> {
+public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord> {
 
-    private Map<DataWord, DataWord> storage = new HashMap<>();
+    private Map<IDataWord, IDataWord> storage = new HashMap<>();
 
-    public IContractDetails<DataWord> origContract;
+    public IContractDetails<IDataWord> origContract;
 
-    public ContractDetailsCacheImpl(IContractDetails<DataWord> origContract) {
+    public ContractDetailsCacheImpl(IContractDetails<IDataWord> origContract) {
         this.origContract = origContract;
         if (origContract != null) {
             if (origContract instanceof AbstractContractDetails) {
@@ -49,23 +51,25 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<DataWord> 
     }
 
     @Override
-    public void put(DataWord key, DataWord value) {
+    public void put(IDataWord key, IDataWord value) {
         storage.put(key, value);
         setDirty(true);
     }
 
     @Override
-    public DataWord get(DataWord key) {
+    public IDataWord get(IDataWord key) {
+        WordType kType = key.getType();
+        IDataWord zero = (kType.equals(WordType.DATA_WORD)) ? DataWord.ZERO : DoubleDataWord.ZERO;
 
-        DataWord value = storage.get(key);
+        IDataWord value = storage.get(key);
         if (value != null) {
-            value = value.clone();
+            value = value.copy();
         } else {
             if (origContract == null) {
                 return null;
             }
             value = origContract.get(key);
-            storage.put(key.clone(), value == null ? DataWord.ZERO.clone() : value.clone());
+            storage.put(key.copy(), value == null ? zero : value.copy());
         }
 
         if (value == null || value.isZero()) {
@@ -91,13 +95,13 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<DataWord> 
     }
 
     @Override
-    public Map<DataWord, DataWord> getStorage(Collection<DataWord> keys) {
-        Map<DataWord, DataWord> storage = new HashMap<>();
+    public Map<IDataWord, IDataWord> getStorage(Collection<IDataWord> keys) {
+        Map<IDataWord, IDataWord> storage = new HashMap<>();
         if (keys == null) {
             throw new IllegalArgumentException("Input keys can't be null");
         } else {
-            for (DataWord key : keys) {
-                DataWord value = get(key);
+            for (IDataWord key : keys) {
+                IDataWord value = get(key);
 
                 // we check if the value is not null,
                 // cause we keep all historical keys
@@ -111,12 +115,12 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<DataWord> 
     }
 
     @Override
-    public void setStorage(List<DataWord> storageKeys, List<DataWord> storageValues) {
+    public void setStorage(List<IDataWord> storageKeys, List<IDataWord> storageValues) {
 
         for (int i = 0; i < storageKeys.size(); ++i) {
 
-            DataWord key = storageKeys.get(i);
-            DataWord value = storageValues.get(i);
+            IDataWord key = storageKeys.get(i);
+            IDataWord value = storageValues.get(i);
 
             put(key, value);
         }
@@ -124,8 +128,8 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<DataWord> 
     }
 
     @Override
-    public void setStorage(Map<DataWord, DataWord> storage) {
-        for (Map.Entry<DataWord, DataWord> entry : storage.entrySet()) {
+    public void setStorage(Map<IDataWord, IDataWord> storage) {
+        for (Map.Entry<IDataWord, IDataWord> entry : storage.entrySet()) {
             put(entry.getKey(), entry.getValue());
         }
     }
@@ -155,7 +159,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<DataWord> 
             return;
         }
 
-        for (DataWord key : storage.keySet()) {
+        for (IDataWord key : storage.keySet()) {
             origContract.put(key, storage.get(key));
         }
 
@@ -168,7 +172,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<DataWord> 
     }
 
     @Override
-    public IContractDetails<DataWord> getSnapshotTo(byte[] hash) {
+    public IContractDetails<IDataWord> getSnapshotTo(byte[] hash) {
         throw new UnsupportedOperationException("No snapshot option during cache state");
     }
 

--- a/modMcf/src/org/aion/mcf/db/DetailsDataStore.java
+++ b/modMcf/src/org/aion/mcf/db/DetailsDataStore.java
@@ -44,9 +44,9 @@ import org.aion.base.type.Address;
 import org.aion.base.type.IBlockHeader;
 import org.aion.base.type.ITransaction;
 import org.aion.base.util.ByteArrayWrapper;
+import org.aion.base.vm.IDataWord;
 import org.aion.mcf.trie.JournalPruneDataSource;
 import org.aion.mcf.types.AbstractBlock;
-import org.aion.mcf.vm.types.DataWord;
 
 /** Detail data storage , */
 public class DetailsDataStore<
@@ -84,7 +84,7 @@ public class DetailsDataStore<
      * @param key
      * @return
      */
-    public synchronized IContractDetails<DataWord> get(byte[] key) {
+    public synchronized IContractDetails<IDataWord> get(byte[] key) {
 
         ByteArrayWrapper wrappedKey = wrap(key);
         Optional<byte[]> rawDetails = detailsSrc.get(key);
@@ -101,7 +101,7 @@ public class DetailsDataStore<
         }
 
         // Found something from cache or database, return it by decoding it.
-        IContractDetails<DataWord> detailsImpl = repoConfig.contractDetailsImpl();
+        IContractDetails<IDataWord> detailsImpl = repoConfig.contractDetailsImpl();
         detailsImpl.setDataSource(storageDSPrune);
         detailsImpl.decode(rawDetails.get()); // We can safely get as we checked
         // if it is present.
@@ -109,7 +109,7 @@ public class DetailsDataStore<
         return detailsImpl;
     }
 
-    public synchronized void update(Address key, IContractDetails<DataWord> contractDetails) {
+    public synchronized void update(Address key, IContractDetails<IDataWord> contractDetails) {
 
         contractDetails.setAddress(key);
         ByteArrayWrapper wrappedKey = wrap(key.toBytes());
@@ -171,7 +171,7 @@ public class DetailsDataStore<
             }
 
             // Decode the details.
-            IContractDetails<DataWord> detailsImpl = repoConfig.contractDetailsImpl();
+            IContractDetails<IDataWord> detailsImpl = repoConfig.contractDetailsImpl();
             detailsImpl.setDataSource(storageDSPrune);
             detailsImpl.decode(rawDetails.get()); // We can safely get as we
             // checked if it is present.

--- a/modMcf/src/org/aion/mcf/vm/types/DataWord.java
+++ b/modMcf/src/org/aion/mcf/vm/types/DataWord.java
@@ -37,6 +37,7 @@ public class DataWord implements Comparable<DataWord>, IDataWord {
 
     public static final BigInteger MAX_VALUE = BigInteger.valueOf(2).pow(128).subtract(BigInteger.ONE);
 
+    private static final WordType wType = WordType.DATA_WORD;
     public static final DataWord ZERO = new DataWord(0);
     public static final DataWord ONE = new DataWord(1);
     public static final int BYTES = 16;
@@ -86,10 +87,12 @@ public class DataWord implements Comparable<DataWord>, IDataWord {
         this(wrapper.getData());
     }
 
+    @Override
     public byte[] getData() {
         return data;
     }
 
+    @Override
     public byte[] getNoLeadZeroesData() {
         return ByteUtil.stripLeadingZeroes(data);
     }
@@ -118,6 +121,7 @@ public class DataWord implements Comparable<DataWord>, IDataWord {
         return v;
     }
 
+    @Override
     public boolean isZero() {
         for (int i = 0; i < BYTES; i++) {
             if (data[BYTES - 1 - i] != 0) {
@@ -133,7 +137,8 @@ public class DataWord implements Comparable<DataWord>, IDataWord {
     }
 
 
-    public DataWord clone() {
+    @Override
+    public DataWord copy() {
         byte[] bs = new byte[BYTES];
         System.arraycopy(data, 0, bs, 0, BYTES);
         return new DataWord(bs);
@@ -163,5 +168,8 @@ public class DataWord implements Comparable<DataWord>, IDataWord {
     public String toString() {
         return Hex.toHexString(data);
     }
+
+    @Override
+    public WordType getType() { return wType; }
 
 }

--- a/modMcf/src/org/aion/mcf/vm/types/DoubleDataWord.java
+++ b/modMcf/src/org/aion/mcf/vm/types/DoubleDataWord.java
@@ -1,0 +1,37 @@
+package org.aion.mcf.vm.types;
+
+import org.aion.base.vm.IDataWord;
+
+public class DoubleDataWord implements IDataWord {
+    private static final WordType wType = WordType.DOUBLE_DATA_WORD;
+
+    public static final DoubleDataWord ZERO = null;
+
+    @Override
+    public WordType getType() { return wType; }
+
+    @Override
+    public byte[] getData() {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public byte[] getNoLeadZeroesData() {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public IDataWord copy() {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public boolean isZero() {
+        //TODO
+        return false;
+    }
+
+}

--- a/modMcf/src/org/aion/mcf/vm/types/DoubleDataWord.java
+++ b/modMcf/src/org/aion/mcf/vm/types/DoubleDataWord.java
@@ -1,37 +1,174 @@
 package org.aion.mcf.vm.types;
 
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.base.util.ByteUtil;
+import org.aion.base.util.Hex;
 import org.aion.base.vm.IDataWord;
 
-public class DoubleDataWord implements IDataWord {
+/**
+ * DoubleDataWord is double the size of the basic unit data (DataWord) used by the VM. A
+ * DoubleDataWord is 256 bits. Its intended use is strictly within pre-compiled contracts, which
+ * often have need of 32-byte storage keys.
+ */
+public class DoubleDataWord implements Comparable<DoubleDataWord>, IDataWord {
     private static final WordType wType = WordType.DOUBLE_DATA_WORD;
+    public static final BigInteger MAX_VALUE = BigInteger.valueOf(2).pow(256).subtract(BigInteger.ONE);
 
-    public static final DoubleDataWord ZERO = null;
+    public static final DataWord ZERO = new DataWord(0);
+    public static final DataWord ONE = new DataWord(1);
+    public static final int BYTES = 32;
+
+    private byte[] data;
+
+    /**
+     * Constructs a new DoubleDataWord of 32 zero bytes.
+     */
+    public DoubleDataWord() { this.data = new byte[BYTES]; }
+
+    /**
+     * Constructs a new DoubleDataWord whose numeric representation is equal to num.
+     */
+    public DoubleDataWord(int num) {
+        ByteBuffer bb = ByteBuffer.allocate(BYTES);
+        bb.position(BYTES - Integer.BYTES);
+        bb.putInt(num);
+        data = bb.array();
+    }
+
+    /**
+     * Constructs a new DoubleDataWord whose numeric representation is equal to num.
+     */
+    public DoubleDataWord(long num) {
+        ByteBuffer bb = ByteBuffer.allocate(BYTES);
+        bb.position(BYTES - Long.BYTES);
+        bb.putLong(num);
+        data = bb.array();
+    }
+
+    /**
+     * Constructs a new DoubleDataWord that will wrap data. If data is less than 32 bytes then it
+     * will be prepended by the necessary amount of leading zero bytes.
+     */
+    public DoubleDataWord(byte[] data) {
+        if (data == null) {
+            throw new NullPointerException("Construct DoubleDataWord with null data.");
+        } else if (data.length == BYTES) {
+            this.data = Arrays.copyOf(data, data.length);
+        } else if (data.length < BYTES) {
+            this.data = new byte[BYTES];
+            System.arraycopy(data, 0, this.data, BYTES - data.length, data.length);
+        } else {
+            throw new RuntimeException("DoubleDataWord can't exceed 32 bytes: " + Hex.toHexString(data));
+        }
+    }
+
+    /**
+     * Constructs a new DoubleDataWord whose numeric representation is equal to num.
+     */
+    public DoubleDataWord(BigInteger num) {
+        this(num.toByteArray());
+    }
+
+    /**
+     * Constructs a new DoubleDataWord whose underlying byte array matches the hex string data.
+     */
+    public DoubleDataWord(String data) {
+        this(Hex.decode(data));
+    }
+
+    /**
+     * Constructs a new DoubleDataWord from wrapper.
+     */
+    public DoubleDataWord(ByteArrayWrapper wrapper) {
+        this(wrapper.getData());
+    }
 
     @Override
     public WordType getType() { return wType; }
 
     @Override
     public byte[] getData() {
-        //TODO
-        return null;
+        return this.data;
     }
 
     @Override
     public byte[] getNoLeadZeroesData() {
-        //TODO
-        return null;
+        return ByteUtil.stripLeadingZeroes(data);
+    }
+
+    public BigInteger value() {
+        return new BigInteger(1, data);
+    }
+
+    /**
+     * Returns an integer representation of this DoubleDataWord.
+     */
+    public int intValue() {
+        int v = 0;
+        for (int i = (BYTES - Integer.BYTES); i < BYTES; i++) {
+            v = (v << Byte.SIZE) + (data[i] & 0xff);
+        }
+        return v;
+    }
+
+    /**
+     * Returns a long representation of this DoubleDataWord.
+     */
+    public long longValue() {
+        long v = 0;
+        for (int i = (BYTES - Long.BYTES); i < BYTES; i++) {
+            v = (v << Byte.SIZE) + (data[i] & 0xff);
+        }
+        return v;
+    }
+
+    public boolean isNegative() {
+        return (data[0] & 0x80) == 0x80;
     }
 
     @Override
     public IDataWord copy() {
-        //TODO
-        return null;
+        byte[] bs = new byte[BYTES];
+        System.arraycopy(data, 0, bs, 0, BYTES);
+        return new DataWord(bs);
     }
 
     @Override
     public boolean isZero() {
-        //TODO
-        return false;
+        for (int i = 0; i < BYTES; i++) {
+            if (data[BYTES - 1 - i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) { return false; }
+        if (this == o) { return true; }
+        if (!(o instanceof DoubleDataWord)) { return false; }
+
+        DoubleDataWord doubleDataWordWord = (DoubleDataWord) o;
+        return Arrays.equals(this.data, doubleDataWordWord.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(data);
+    }
+
+    @Override
+    public int compareTo(DoubleDataWord o) {
+        return Arrays.compare(this.data, o.data);
+    }
+
+    @Override
+    public String toString() {
+        return Hex.toHexString(data);
     }
 
 }

--- a/modMcf/src/org/aion/mcf/vm/types/DoubleDataWord.java
+++ b/modMcf/src/org/aion/mcf/vm/types/DoubleDataWord.java
@@ -17,8 +17,8 @@ public class DoubleDataWord implements Comparable<DoubleDataWord>, IDataWord {
     private static final WordType wType = WordType.DOUBLE_DATA_WORD;
     public static final BigInteger MAX_VALUE = BigInteger.valueOf(2).pow(256).subtract(BigInteger.ONE);
 
-    public static final DataWord ZERO = new DataWord(0);
-    public static final DataWord ONE = new DataWord(1);
+    public static final DoubleDataWord ZERO = new DoubleDataWord(0);
+    public static final DoubleDataWord ONE = new DoubleDataWord(1);
     public static final int BYTES = 32;
 
     private byte[] data;
@@ -133,7 +133,7 @@ public class DoubleDataWord implements Comparable<DoubleDataWord>, IDataWord {
     public IDataWord copy() {
         byte[] bs = new byte[BYTES];
         System.arraycopy(data, 0, bs, 0, BYTES);
-        return new DataWord(bs);
+        return new DoubleDataWord(bs);
     }
 
     @Override

--- a/modMcf/test/org/aion/DoubleDataWordTest.java
+++ b/modMcf/test/org/aion/DoubleDataWordTest.java
@@ -1,0 +1,112 @@
+package org.aion;
+
+import static org.junit.Assert.*;
+
+import java.util.Random;
+import org.aion.base.db.IRepository;
+import org.aion.base.db.IRepositoryCache;
+import org.aion.base.type.Address;
+import org.aion.base.vm.IDataWord;
+import org.aion.crypto.ECKeyFac;
+import org.aion.mcf.core.AccountState;
+import org.aion.mcf.db.IBlockStoreBase;
+import org.aion.mcf.vm.types.DataWord;
+import org.aion.mcf.vm.types.DoubleDataWord;
+import org.aion.zero.db.AionRepositoryCache;
+import org.aion.zero.impl.db.AionRepositoryImpl;
+import org.junit.Test;
+
+/**
+ * Tests the DoubleDataWord class, mainly that it integrates well with the db.
+ */
+public class DoubleDataWordTest {
+    private IRepository repo = AionRepositoryImpl.inst();
+    private IRepositoryCache<AccountState, IDataWord, IBlockStoreBase<?, ?>> track = new AionRepositoryCache(repo);
+    private Random rand = new Random();
+    private Address addr = Address.wrap(ECKeyFac.inst().create().getAddress());
+
+    /**
+     * Tests that a using a single key that is a prefix of a double key and also a single key that
+     * is a suffix of a double key (first 16 and last 16 bytes matching) will not cause ambiguity
+     * and the db will fetch and store the correct entries.
+     */
+    @Test
+    public void testPrefixSuffixAmbiguity() {
+        // doubleKeyFirst has its first 16 bytes identical to singleKey
+        // doubleKeyLast has its last 16 bytes identical to singleKey
+        byte[] singleKey = new byte[DataWord.BYTES];
+        byte[] doubleKeyFirst = new byte[DoubleDataWord.BYTES];
+        byte[] doubleKeyLast = new byte[DoubleDataWord.BYTES];
+        rand.nextBytes(singleKey);
+        System.arraycopy(singleKey, 0, doubleKeyFirst, 0, DataWord.BYTES);
+        System.arraycopy(singleKey, 0, doubleKeyLast, DataWord.BYTES, DataWord.BYTES);
+
+        byte[] singleVal = new byte[DataWord.BYTES];
+        byte[] doubleValFirst = new byte[DoubleDataWord.BYTES];
+        byte[] doubleValLast = new byte[DoubleDataWord.BYTES];
+        singleVal[0] = (byte) 0x1;
+        doubleValFirst[0] = (byte) 0x2;
+        doubleValLast[0] = (byte) 0x3;
+
+        track.addStorageRow(addr, new DataWord(singleKey), new DataWord(singleVal));
+        track.addStorageRow(addr, new DoubleDataWord(doubleKeyFirst), new DoubleDataWord(doubleValFirst));
+        track.addStorageRow(addr, new DoubleDataWord(doubleKeyLast), new DoubleDataWord(doubleValLast));
+        track.flush();
+
+        byte[] singleRes = track.getStorageValue(addr, new DataWord(singleKey)).getData();
+        byte[] doubleResFirst = track.getStorageValue(addr, new DoubleDataWord(doubleKeyFirst)).getData();
+        byte[] doubleResLast = track.getStorageValue(addr, new DoubleDataWord(doubleKeyLast)).getData();
+
+        assertArrayEquals(singleVal, singleRes);
+        assertArrayEquals(doubleValFirst, doubleResFirst);
+        assertArrayEquals(doubleValLast, doubleResLast);
+    }
+
+    /**
+     * Tests that when we add a single key to the db that then we cannot use double keys that are
+     * prefixes or suffixes of the single key to confuse the db and get the single entry.
+     */
+    @Test
+    public void testPrefixSuffixAmbiguity2() {
+        byte[] singKey = new byte[DataWord.BYTES];
+        rand.nextBytes(singKey);
+
+        byte[] singVal = new byte[DataWord.BYTES];
+        singVal[0] = (byte) 0xAC;
+        track.addStorageRow(addr, new DataWord(singKey), new DataWord(singVal));
+        track.flush();
+
+        byte[] doubleKeyPrefix = new byte[DoubleDataWord.BYTES];
+        byte[] doubleKeySuffix = new byte[DoubleDataWord.BYTES];
+        System.arraycopy(singKey, 0, doubleKeyPrefix, 0, DataWord.BYTES);
+        System.arraycopy(singKey, 0, doubleKeySuffix, DataWord.BYTES, DataWord.BYTES);
+
+        byte[] singRes = track.getStorageValue(addr, new DataWord(singKey)).getData();
+        assertArrayEquals(singVal, singRes);
+        assertNull(track.getStorageValue(addr, new DoubleDataWord(doubleKeyPrefix)));
+        assertNull(track.getStorageValue(addr, new DoubleDataWord(doubleKeySuffix)));
+    }
+
+    /**
+     * Tests that the key-value pairs added to the db do not both have to be singles or both doubles
+     * but that we can have single-double and double-single pairings too.
+     */
+    @Test
+    public void testMixOfSingleAndDoubleDataWordsInRepo() {
+        byte[] key16 = new byte[DataWord.BYTES];
+        byte[] key32 = new byte[DoubleDataWord.BYTES];
+        byte[] val16 = new byte[DataWord.BYTES];
+        byte[] val32 = new byte[DoubleDataWord.BYTES];
+        rand.nextBytes(key16);
+        rand.nextBytes(key32);
+        rand.nextBytes(val16);
+        rand.nextBytes(val32);
+
+        track.addStorageRow(addr, new DataWord(key16), new DoubleDataWord(val32));
+        track.addStorageRow(addr, new DoubleDataWord(key32), new DataWord(val16));
+
+        assertArrayEquals(val16, track.getStorageValue(addr, new DoubleDataWord(key32)).getData());
+        assertArrayEquals(val32, track.getStorageValue(addr, new DataWord(key16)).getData());
+    }
+
+}


### PR DESCRIPTION
## Description

(Putting this on pause temporarily)
- Introduces a DoubleDataWord implementation of IDataWord, which is 32 instead of 16 bytes long. The db now takes type IDataWord instead of DataWord. The change is mostly to facilitate pre-compiled contracts, since they regularly need to store 32 byte keys rather than 16.
- These changes depend upon the db32byte branch in aion_api, I will remove this dependency from the .gitmodules file once that branch is merged into master. That PR is <a href="https://github.com/aionnetwork/aion_api/pull/31">here</a>.

Fixes Issue # N/A.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Tested against our own test suite, ran the kernel and added my own tests.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
