### PR TITLE
Fix TRS test timestamp issue

### DIFF
--- a/modPrecompiled/build.xml
+++ b/modPrecompiled/build.xml
@@ -23,6 +23,7 @@
         <pathelement location="${dir.lib}/commons-collections4-4.0.jar"/>
         <pathelement location="${dir.lib}/jsr305-3.0.2.jar"/>
         <pathelement location="${dir.lib}/mockito-core-2.12.0.jar"/>
+        <pathelement location="${dir.lib}/byte-buddy-1.7.9.jar"/>
         <pathelement location="${dir.mod}/modMcf.jar"/>
         <pathelement location="${dir.mod}/modAionBase.jar"/>
         <pathelement location="${dir.mod}/modCrypto.jar"/>

--- a/modPrecompiled/build.xml
+++ b/modPrecompiled/build.xml
@@ -22,6 +22,7 @@
         <pathelement location="${dir.lib}/commons-lang3-3.4.jar"/>
         <pathelement location="${dir.lib}/commons-collections4-4.0.jar"/>
         <pathelement location="${dir.lib}/jsr305-3.0.2.jar"/>
+        <pathelement location="${dir.lib}/mockito-core-2.12.0.jar"/>
         <pathelement location="${dir.mod}/modMcf.jar"/>
         <pathelement location="${dir.mod}/modAionBase.jar"/>
         <pathelement location="${dir.mod}/modCrypto.jar"/>

--- a/modPrecompiled/build.xml
+++ b/modPrecompiled/build.xml
@@ -24,6 +24,8 @@
         <pathelement location="${dir.lib}/jsr305-3.0.2.jar"/>
         <pathelement location="${dir.lib}/mockito-core-2.12.0.jar"/>
         <pathelement location="${dir.lib}/byte-buddy-1.7.9.jar"/>
+        <pathelement location="${dir.lib}/byte-buddy-agent-1.7.9.jar"/>
+        <pathelement location="${dir.lib}/objenesis-2.6.jar"/>
         <pathelement location="${dir.mod}/modMcf.jar"/>
         <pathelement location="${dir.mod}/modAionBase.jar"/>
         <pathelement location="${dir.mod}/modCrypto.jar"/>

--- a/modPrecompiled/test/org/aion/precompiled/TRS/TRSstateContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/TRS/TRSstateContractTest.java
@@ -32,12 +32,12 @@ public class TRSstateContractTest extends TRShelpers {
     private static final int MAX_OP = 3;
 
     @Before
-    public void setup() throws InterruptedException {
+    public void setup() {
         repo = new DummyRepo();
         ((DummyRepo) repo).storageErrorReturn = null;
         tempAddrs = new ArrayList<>();
         repo.addBalance(AION, BigInteger.ONE);
-        createBlockchain(0, 0);
+        mockBlockchain(0);
     }
 
     @After
@@ -1337,8 +1337,8 @@ public class TRSstateContractTest extends TRShelpers {
     }
 
     @Test
-    public void testOpenFundsWithdrawIsNowWithdrawAll() throws InterruptedException {
-        createBlockchain(0, 0);
+    public void testOpenFundsWithdrawIsNowWithdrawAll() {
+        mockBlockchain(0);
         BigInteger bal1 = new BigInteger("2375628376523");
         BigInteger bal2 = new BigInteger("438756347565782346578");
         BigInteger bal3 = new BigInteger("98124329685948546");
@@ -1389,8 +1389,8 @@ public class TRSstateContractTest extends TRShelpers {
     }
 
     @Test
-    public void testOpenFundsBulkWithdrawIsNowBulkWithdrawAll() throws InterruptedException {
-        createBlockchain(0, 0);
+    public void testOpenFundsBulkWithdrawIsNowBulkWithdrawAll() {
+        mockBlockchain(0);
         BigInteger bal1 = new BigInteger("4366234645");
         BigInteger bal2 = new BigInteger("5454757853");
         BigInteger bal3 = new BigInteger("43534654754342");


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Some of the TRS tests would randomly fail because the timestamps they relied on were genuinely generated using `System.currentTimeMillis` and in a few cases if Jenkins was slow enough some contracts were moved into the next period unexpectedly. I've replaced the blockchain with a mocked blockchain that uses mocked timestamps to eliminate all randomness.

Fixes Issue # N/A.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- The tests in question

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
