### PR TITLE
Fix to null/zero byte db handling

### DIFF
--- a/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
+++ b/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
@@ -210,7 +210,7 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
 
                 // we check if the value is not null,
                 // cause we keep all historical keys
-                if ((value != null) && (!value.isZero())) {
+                if (value != null) {
                     storage.put(key, value);
                 }
             }

--- a/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
+++ b/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
@@ -210,7 +210,7 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
 
                 // we check if the value is not null,
                 // cause we keep all historical keys
-                if (value != null) {
+                if ((value != null) && (!value.isZero())) {
                     storage.put(key, value);
                 }
             }

--- a/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
+++ b/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -17,12 +17,9 @@
  *     along with the aion network project source files.
  *     If not, see <https://www.gnu.org/licenses/>.
  *
- *
  * Contributors:
  *     Aion foundation.
- *     
- ******************************************************************************/
-
+ */
 package org.aion.zero.db;
 
 import org.aion.base.db.IByteArrayKeyValueStore;
@@ -110,11 +107,11 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
     }
 
     /**
-     * Returns a DataWord whose 16 bytes consists of all zeros if key is not in the database.
-     * Otherwise returns the IDataWord value corresponding to key in the database.
+     * Returns the value associated with key if it exists, otherwise returns a DataWord consisting
+     * entirely of zero bytes.
      *
      * @param key The key to query.
-     * @return the corresponding value or a zero DataWord if no such value.
+     * @return the corresponding value or a zero-byte DataWord if no such value.
      */
     @Override
     public IDataWord get(IDataWord key) {
@@ -130,11 +127,21 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         return result;
     }
 
+    /**
+     * Returns the storage hash.
+     *
+     * @return the storage hash.
+     */
     @Override
     public byte[] getStorageHash() {
         return storageTrie.getRootHash();
     }
 
+    /**
+     * Decodes an AionContractDetailsImpl object from the RLP encoding rlpCode.
+     *
+     * @param rlpCode The encoding to decode.
+     */
     @Override
     public void decode(byte[] rlpCode) {
         RLPList data = RLP.decode2(rlpCode);
@@ -178,6 +185,11 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         this.rlpEncoded = rlpCode;
     }
 
+    /**
+     * Returns an rlp encoding of this AionContractDetailsImpl object.
+     *
+     * @return an rlp encoding of this.
+     */
     @Override
     public byte[] getEncoded() {
         if (rlpEncoded == null) {
@@ -199,6 +211,12 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         return rlpEncoded;
     }
 
+    /**
+     * Returns a mapping of all the key-value pairs who have keys in the collection keys.
+     *
+     * @param keys The keys to query for.
+     * @return The associated mappings.
+     */
     @Override
     public Map<IDataWord, IDataWord> getStorage(Collection<IDataWord> keys) {
         Map<IDataWord, IDataWord> storage = new HashMap<>();
@@ -219,6 +237,13 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         return storage;
     }
 
+    /**
+     * Sets the storage to contain the specified keys and values. This method creates pairings of
+     * the keys and values by mapping the i'th key in storageKeys to the i'th value in storageValues.
+     *
+     * @param storageKeys The keys.
+     * @param storageValues The values.
+     */
     @Override
     public void setStorage(List<IDataWord> storageKeys, List<IDataWord> storageValues) {
         for (int i = 0; i < storageKeys.size(); ++i) {
@@ -226,6 +251,11 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         }
     }
 
+    /**
+     * Sets the storage to contain the specified key-value mappings.
+     *
+     * @param storage The specified mappings.
+     */
     @Override
     public void setStorage(Map<IDataWord, IDataWord> storage) {
         for (IDataWord key : storage.keySet()) {
@@ -233,17 +263,30 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         }
     }
 
+    /**
+     * Get the address associated with this AionContractDetailsImpl.
+     *
+     * @return the associated address.
+     */
     @Override
     public Address getAddress() {
         return address;
     }
 
+    /**
+     * Sets the associated address to address.
+     *
+     * @param address The address to set.
+     */
     @Override
     public void setAddress(Address address) {
         this.address = address;
         this.rlpEncoded = null;
     }
 
+    /**
+     * Syncs the storage trie.
+     */
     @Override
     public void syncStorage() {
         if (externalStorage) {
@@ -251,10 +294,20 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         }
     }
 
+    /**
+     * Sets the data source to dataSource.
+     *
+     * @param dataSource The new dataSource.
+     */
     public void setDataSource(IByteArrayKeyValueStore dataSource) {
         this.dataSource = dataSource;
     }
 
+    /**
+     * Returns the external storage data source.
+     *
+     * @return the external storage data source.
+     */
     private IByteArrayKeyValueStore getExternalStorageDataSource() {
         if (externalStorageDataSource == null) {
             externalStorageDataSource = new XorDataSource(dataSource,
@@ -263,12 +316,24 @@ public class AionContractDetailsImpl extends AbstractContractDetails<IDataWord> 
         return externalStorageDataSource;
     }
 
+    /**
+     * Sets the external storage data source to dataSource.
+     *
+     * @param dataSource The new data source.
+     */
     public void setExternalStorageDataSource(IByteArrayKeyValueStore dataSource) {
         this.externalStorageDataSource = dataSource;
         this.externalStorage = true;
         this.storageTrie = new SecureTrie(getExternalStorageDataSource());
     }
 
+    /**
+     * Returns an AionContractDetailsImpl object pertaining to a specific point in time given by the
+     * root hash hash.
+     *
+     * @param hash The root hash to search for.
+     * @return the specified AionContractDetailsImpl.
+     */
     @Override
     public IContractDetails<IDataWord> getSnapshotTo(byte[] hash) {
 

--- a/modAionBase/src/org/aion/base/db/IContractDetails.java
+++ b/modAionBase/src/org/aion/base/db/IContractDetails.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2017-2018 Aion foundation.
  *
  *     This file is part of the aion network project.
@@ -31,7 +31,7 @@
  *     Samuel Neves through the BLAKE2 implementation.
  *     Zcash project team.
  *     Bitcoinj team.
- ******************************************************************************/
+ */
 package org.aion.base.db;
 
 import org.aion.base.type.Address;
@@ -42,45 +42,164 @@ import java.util.Map;
 
 public interface IContractDetails<DW> {
 
+    /**
+     * Inserts key and value as a key-value pair. If the underlying byte array of value consists
+     * only of zero bytes then ay existing key-value pair that has the same key as key will be
+     * deleted.
+     *
+     * @param key The key.
+     * @param value The value.
+     */
     void put(DW key, DW value);
 
+    /**
+     * Returns the value associated with key.
+     *
+     * @implNote Some implementations may handle a non-existent key-value pair differently.
+     * @param key The key to query.
+     * @return The associated value or some non-value indicator in the case of no such key-value pair.
+     */
     DW get(DW key);
 
+    /**
+     * Returns the code of the address associated with this IContractDetails class. This is for
+     * addresses that are smart contracts.
+     *
+     * @return the code of the associated address.
+     */
     byte[] getCode();
 
+    /**
+     * Returns the code whose hash is codeHash.
+     *
+     * @param codeHash The hashed code.
+     * @return the code.
+     */
     byte[] getCode(byte[] codeHash);
 
+    /**
+     * Sets the code of the associated address to code.
+     *
+     * @param code The code to set.
+     */
     void setCode(byte[] code);
 
+    /**
+     * Returns the storage hash.
+     *
+     * @return the storage hash.
+     */
     byte[] getStorageHash();
 
+    /**
+     * Decodes an IContractDetails object from the RLP encoding rlpCode.
+     *
+     * @implNote Implementing classes may not necessarily support this method.
+     * @param rlpCode The encoding to decode.
+     */
     void decode(byte[] rlpCode);
 
+    /**
+     * Sets the dirty value to dirty.
+     *
+     * @param dirty The dirty value.
+     */
     void setDirty(boolean dirty);
 
+    /**
+     * Sets the deleted value to deleted.
+     *
+     * @param deleted the deleted value.
+     */
     void setDeleted(boolean deleted);
 
+    /**
+     * Returns true iff the IContractDetails is dirty.
+     *
+     * @return only if this is dirty.
+     */
     boolean isDirty();
 
+    /**
+     * Returns true iff the IContractDetails is deleted.
+     *
+     * @return only if this is deleted.
+     */
     boolean isDeleted();
 
+    /**
+     * Returns an rlp encoding of this IContractDetails object.
+     *
+     * @implNote Implementing classes may not necessarily support this method.
+     * @return an rlp encoding of this.
+     */
     byte[] getEncoded();
 
+    /**
+     * Returns a mapping of all the key-value pairs who have keys in the collection keys.
+     *
+     * @param keys The keys to query for.
+     * @return The associated mappings.
+     */
     Map<DW, DW> getStorage(Collection<DW> keys);
 
+    /**
+     * Sets the storage to contain the specified keys and values. This method creates pairings of
+     * the keys and values by mapping the i'th key in storageKeys to the i'th value in storageValues.
+     *
+     * @param storageKeys The keys.
+     * @param storageValues The values.
+     */
     void setStorage(List<DW> storageKeys, List<DW> storageValues);
 
+    /**
+     * Sets the storage to contain the specified key-value mappings.
+     *
+     * @param storage The specified mappings.
+     */
     void setStorage(Map<DW, DW> storage);
 
+    /**
+     * Get the address associated with this IContractDetails.
+     *
+     * @return the associated address.
+     */
     Address getAddress();
 
+    /**
+     * Sets the associated address to address.
+     *
+     * @param address The address to set.
+     */
     void setAddress(Address address);
 
+    /**
+     * Returns a string representation of this IContractDetails.
+     *
+     * @return a string representation.
+     */
     String toString();
 
+    /**
+     * Syncs the storage trie.
+     */
     void syncStorage();
 
+    /**
+     * Returns an IContractDetails object pertaining to a specific point in time given by the root
+     * hash hash.
+     *
+     * @implNote Implementing classes may not necessarily support this method.
+     * @param hash The root hash to search for.
+     * @return the specified IContractDetails.
+     */
     IContractDetails<DW> getSnapshotTo(byte[] hash);
 
+    /**
+     * Sets the data source to dataSource.
+     *
+     * @implNote Implementing classes may not necessarily support this method.
+     * @param dataSource The new dataSource.
+     */
     void setDataSource(IByteArrayKeyValueStore dataSource);
 }

--- a/modMcf/build.xml
+++ b/modMcf/build.xml
@@ -22,17 +22,18 @@
 		<pathelement location="${dir.lib}/junit_4/junit-4.12.jar" />
 		<pathelement location="${dir.lib}/hamcrest/hamcrest-all-1.3.jar" />
 		<pathelement location="${dir.lib}/mockito-core-2.12.0.jar" />
-                <pathelement location="${dir.lib}/truth-0.36.jar" />
+		<pathelement location="${dir.lib}/truth-0.36.jar" />
 		<pathelement location="${dir.lib}/libnsc.jar" />
 		<pathelement location="${dir.lib}/slf4j-api-1.7.25.jar" />
 		<pathelement location="${dir.lib}/logback-classic-1.2.3.jar" />
 		<pathelement location="${dir.lib}/logback-core-1.2.3.jar" />
-                <pathelement location="${dir.lib}/JUnitParams-1.1.1.jar" />
+		<pathelement location="${dir.lib}/JUnitParams-1.1.1.jar" />
 		<pathelement location="${dir.lib}/commons-collections4-4.0.jar" />
+		<pathelement location="${dir.lib}/commons-lang3-3.4.jar"/>
 		<pathelement location="${dir.lib}/guava-19.0.jar" />
 		<pathelement location="${dir.lib}/byte-buddy-1.7.9.jar" />
-                <pathelement location="${dir.lib}/libJson.jar" />
-                <pathelement location="${dir.lib}/objenesis-2.6.jar" />
+		<pathelement location="${dir.lib}/libJson.jar" />
+		<pathelement location="${dir.lib}/objenesis-2.6.jar" />
 
 		<pathelement location="${dir.mod}/modRlp.jar" />
 		<pathelement location="${dir.mod}/modMcf.jar" />

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -65,7 +65,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
                 return null;
             }
             value = origContract.get(key);
-            storage.put(key.copy(), value.isZero() ? DataWord.ZERO.copy() : value.copy());
+            storage.put(key.copy(), value == null ? DataWord.ZERO : value.copy());
         }
 
         if (value == null || value.isZero()) {
@@ -101,7 +101,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
 
                 // we check if the value is not null,
                 // cause we keep all historical keys
-                if ((value != null) && (!value.isZero())) {
+                if (value != null) {
                     storage.put(key, value);
                 }
             }

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -1,23 +1,25 @@
-/*******************************************************************************
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
  *
- * Copyright (c) 2017, 2018 Aion foundation.
+ *     This file is part of the aion network project.
  *
- * 	This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
  *
  *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <https://www.gnu.org/licenses/>
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
  *
  * Contributors:
  *     Aion foundation.
- *******************************************************************************/
+ */
 package org.aion.mcf.db;
 
 import org.aion.base.db.IByteArrayKeyValueStore;
@@ -48,12 +50,25 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
         }
     }
 
+    /**
+     * Inserts the key-value pair key and value, or if value consists only of zero bytes, deletes
+     * any key-value pair whose key is key.
+     *
+     * @param key The key.
+     * @param value The value.
+     */
     @Override
     public void put(IDataWord key, IDataWord value) {
         storage.put(key, value);
         setDirty(true);
     }
 
+    /**
+     * Returns the value associated with key if it exists, otherwise returns null.
+     *
+     * @param key The key to query.
+     * @return the associated value or null.
+     */
     @Override
     public IDataWord get(IDataWord key) {
 
@@ -75,21 +90,38 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
         }
     }
 
+    /**
+     * Returns the storage hash.
+     *
+     * @return the storage hash.
+     */
     @Override
     public byte[] getStorageHash() {
         return origContract.getStorageHash();
     }
 
+    /**
+     * This method is not supported.
+     */
     @Override
     public void decode(byte[] rlpCode) {
         throw new RuntimeException("Not supported by this implementation.");
     }
 
+    /**
+     * This method is not supported.
+     */
     @Override
     public byte[] getEncoded() {
         throw new RuntimeException("Not supported by this implementation.");
     }
 
+    /**
+     * Returns a mapping of all the key-value pairs who have keys in the collection keys.
+     *
+     * @param keys The keys to query for.
+     * @return The associated mappings.
+     */
     @Override
     public Map<IDataWord, IDataWord> getStorage(Collection<IDataWord> keys) {
         Map<IDataWord, IDataWord> storage = new HashMap<>();
@@ -110,6 +142,13 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
         return storage;
     }
 
+    /**
+     * Sets the storage to contain the specified keys and values. This method creates pairings of
+     * the keys and values by mapping the i'th key in storageKeys to the i'th value in storageValues.
+     *
+     * @param storageKeys The keys.
+     * @param storageValues The values.
+     */
     @Override
     public void setStorage(List<IDataWord> storageKeys, List<IDataWord> storageValues) {
 
@@ -123,6 +162,11 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
 
     }
 
+    /**
+     * Sets the storage to contain the specified key-value mappings.
+     *
+     * @param storage The specified mappings.
+     */
     @Override
     public void setStorage(Map<IDataWord, IDataWord> storage) {
         for (Map.Entry<IDataWord, IDataWord> entry : storage.entrySet()) {
@@ -130,11 +174,21 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
         }
     }
 
+    /**
+     * Get the address associated with this ContractDetailsCacheImpl.
+     *
+     * @return the associated address.
+     */
     @Override
     public Address getAddress() {
         return (origContract == null) ? null : origContract.getAddress();
     }
 
+    /**
+     * Sets the address associated with this ContractDetailsCacheImpl.
+     *
+     * @param address The address to set.
+     */
     @Override
     public void setAddress(Address address) {
         if (origContract != null) {
@@ -142,6 +196,9 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
         }
     }
 
+    /**
+     * Syncs the storage trie.
+     */
     @Override
     public void syncStorage() {
         if (origContract != null) {
@@ -149,6 +206,11 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
         }
     }
 
+    /**
+     * Puts all of the key-value pairs in this ContractDetailsCacheImple into the original contract
+     * injected into this class' constructor, transfers over any code and sets the original contract
+     * to dirty only if it already is dirty or if this class is dirty, otherwise sets it as clean.
+     */
     public void commit() {
 
         if (origContract == null) {
@@ -167,11 +229,17 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
         origContract.setDirty(this.isDirty() || origContract.isDirty());
     }
 
+    /**
+     * This method is not supported.
+     */
     @Override
     public IContractDetails<IDataWord> getSnapshotTo(byte[] hash) {
         throw new UnsupportedOperationException("No snapshot option during cache state");
     }
 
+    /**
+     * This method is not supported.
+     */
     @Override
     public void setDataSource(IByteArrayKeyValueStore dataSource) {
         throw new UnsupportedOperationException("Can't set datasource in cache implementation.");

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -65,7 +65,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
                 return null;
             }
             value = origContract.get(key);
-            storage.put(key.copy(), value == null ? DataWord.ZERO : value.copy());
+            storage.put(key.copy(), (value == null || value.isZero()) ? DataWord.ZERO : value.copy());
         }
 
         if (value == null || value.isZero()) {
@@ -101,7 +101,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails<IDataWord>
 
                 // we check if the value is not null,
                 // cause we keep all historical keys
-                if (value != null) {
+                if ((value != null) && (!value.isZero())) {
                     storage.put(key, value);
                 }
             }

--- a/modMcf/test/org/aion/mcf/db/AbstractRepositoryCacheTest.java
+++ b/modMcf/test/org/aion/mcf/db/AbstractRepositoryCacheTest.java
@@ -1,0 +1,275 @@
+package org.aion.mcf.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.aion.base.db.IContractDetails;
+import org.aion.base.db.IPruneConfig;
+import org.aion.base.db.IRepositoryConfig;
+import org.aion.base.type.Address;
+import org.aion.base.vm.IDataWord;
+import org.aion.db.impl.DBVendor;
+import org.aion.db.impl.DatabaseFactory;
+import org.aion.mcf.config.CfgPrune;
+import org.aion.mcf.vm.types.DataWord;
+import org.aion.mcf.vm.types.DoubleDataWord;
+import org.aion.zero.db.AionRepositoryCache;
+import org.aion.zero.impl.db.AionRepositoryImpl;
+import org.aion.zero.impl.db.ContractDetailsAion;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractRepositoryCacheTest {
+    private AionRepositoryCache cache;
+
+    @Before
+    public void setup() {
+        IRepositoryConfig repoConfig =
+            new IRepositoryConfig() {
+                @Override
+                public String getDbPath() {
+                    return "";
+                }
+
+                @Override
+                public IPruneConfig getPruneConfig() {
+                    return new CfgPrune(false);
+                }
+
+                @Override
+                public IContractDetails contractDetailsImpl() {
+                    return ContractDetailsAion.createForTesting(0, 1000000).getDetails();
+                }
+
+                @Override
+                public Properties getDatabaseConfig(String db_name) {
+                    Properties props = new Properties();
+                    props.setProperty(DatabaseFactory.Props.DB_TYPE, DBVendor.MOCKDB.toValue());
+                    props.setProperty(DatabaseFactory.Props.ENABLE_HEAP_CACHE, "false");
+                    return props;
+                }
+            };
+        cache = new AionRepositoryCache(AionRepositoryImpl.createForTesting(repoConfig));
+    }
+
+    @After
+    public void tearDown() {
+        cache = null;
+    }
+
+    @Test
+    public void testGetStorageValueNoSuchAddress() {
+        assertNull(cache.getStorageValue(getNewAddress(), new DataWord(RandomUtils.nextBytes(DataWord.BYTES))));
+    }
+
+    @Test
+    public void testGetStorageValueIsSingleZero() {
+        Address address = getNewAddress();
+        IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        cache.addStorageRow(address, key, DataWord.ZERO);
+        assertNull(cache.getStorageValue(address, key));
+
+        key = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        cache.addStorageRow(address, key, DataWord.ZERO);
+        assertNull(cache.getStorageValue(address, key));
+    }
+
+    @Test
+    public void testGetStorageValueIsDoubleZero() {
+        Address address = getNewAddress();
+        IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        cache.addStorageRow(address, key, DoubleDataWord.ZERO);
+        assertNull(cache.getStorageValue(address, key));
+
+        key = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        cache.addStorageRow(address, key, DoubleDataWord.ZERO);
+        assertNull(cache.getStorageValue(address, key));
+    }
+
+    @Test
+    public void testGetStorageValueWithSingleZeroKey() {
+        Address address = getNewAddress();
+        IDataWord value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        cache.addStorageRow(address, DataWord.ZERO, value);
+        assertEquals(value, cache.getStorageValue(address, DataWord.ZERO));
+
+        value = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        cache.addStorageRow(address, DataWord.ZERO, value);
+        assertEquals(value, cache.getStorageValue(address, DataWord.ZERO));
+    }
+
+    @Test
+    public void testGetStorageValueWithDoubleZeroKey() {
+        Address address = getNewAddress();
+        IDataWord value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        cache.addStorageRow(address, DoubleDataWord.ZERO, value);
+        assertEquals(value, cache.getStorageValue(address, DoubleDataWord.ZERO));
+
+        value = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        cache.addStorageRow(address, DoubleDataWord.ZERO, value);
+        assertEquals(value, cache.getStorageValue(address, DoubleDataWord.ZERO));
+    }
+
+    @Test
+    public void testGetStorageValueWithZeroKeyAndValue() {
+        Address address = getNewAddress();
+
+        // single-single
+        cache.addStorageRow(address, DataWord.ZERO, DataWord.ZERO);
+        assertNull(cache.getStorageValue(address, DataWord.ZERO));
+
+        // single-double
+        cache.addStorageRow(address, DataWord.ZERO, DoubleDataWord.ZERO);
+        assertNull(cache.getStorageValue(address, DataWord.ZERO));
+
+        // double-single
+        cache.addStorageRow(address, DoubleDataWord.ZERO, DataWord.ZERO);
+        assertNull(cache.getStorageValue(address, DoubleDataWord.ZERO));
+
+        // double-double
+        cache.addStorageRow(address, DoubleDataWord.ZERO, DoubleDataWord.ZERO);
+        assertNull(cache.getStorageValue(address, DoubleDataWord.ZERO));
+    }
+
+    @Test
+    public void testOverwriteValueWithSingleZero() {
+        Address address = getNewAddress();
+        IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        IDataWord value = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        cache.addStorageRow(address, key, value);
+        assertEquals(value, cache.getStorageValue(address, key));
+        cache.addStorageRow(address, key, DataWord.ZERO);
+        assertNull(cache.getStorageValue(address, key));
+    }
+
+    @Test
+    public void testOverwriteValueWithDoubleZero() {
+        Address address = getNewAddress();
+        IDataWord key = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        IDataWord value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        cache.addStorageRow(address, key, value);
+        assertEquals(value, cache.getStorageValue(address, key));
+        cache.addStorageRow(address, key, DoubleDataWord.ZERO);
+        assertNull(cache.getStorageValue(address, key));
+    }
+
+    @Test
+    public void testGetStorageValueEnMass() {
+        int numEntries = RandomUtils.nextInt(300, 700);
+        int deleteOdds = 5;
+        int numAddrs = 8;
+        List<Address> addresses = getAddressesInBulk(numAddrs);
+        List<IDataWord> keys = getKeysInBulk(numEntries);
+        List<IDataWord> values = getValuesInBulk(numEntries);
+
+        for (Address address : addresses) {
+            massAddToCache(address, keys, values);
+            deleteEveryNthEntry(address, keys, deleteOdds);
+        }
+
+        for (Address address : addresses) {
+            checkStorage(address, keys, values, deleteOdds);
+        }
+    }
+
+    //<-----------------------------------------HELPERS-------------------------------------------->
+
+    /**
+     * Returns a new random address.
+     */
+    private Address getNewAddress() {
+        return new Address(RandomUtils.nextBytes(Address.ADDRESS_LEN));
+    }
+
+    private List<Address> getAddressesInBulk(int num) {
+        List<Address> addresses = new ArrayList<>(num);
+        for (int i = 0; i < num; i++) {
+            addresses.add(getNewAddress());
+        }
+        return addresses;
+    }
+
+    /**
+     * Checks that cache's storage, given by cache.getStorage(), contains all key-value pairs in
+     * keys and values, where it is assumed every n'th pair was deleted.
+     */
+    private void checkStorage(Address address, List<IDataWord> keys, List<IDataWord> values, int n) {
+        Map<IDataWord, IDataWord> storage = cache.getStorage(address, keys);
+        int count = 1;
+        for (IDataWord key : keys) {
+            if (count % n == 0) {
+                assertNull(storage.get(key));
+            } else {
+                assertEquals(values.get(count - 1), storage.get(key));
+            }
+            count++;
+        }
+    }
+
+    /**
+     * Iterates over every key in keys -- which are assumed to exist in cache -- and then deletes
+     * any key-value pair in cache for every n'th key in keys.
+     */
+    private void deleteEveryNthEntry(Address address, List<IDataWord> keys, int n) {
+        int count = 1;
+        for (IDataWord key : keys) {
+            if (count % n == 0) {
+                cache.addStorageRow(address, key, DataWord.ZERO);
+            }
+            count++;
+        }
+    }
+
+    /**
+     * Puts all of the key-value pairs in keys and values into cache under address.
+     */
+    private void massAddToCache(Address address, List<IDataWord> keys, List<IDataWord> values) {
+        int size = keys.size();
+        assertEquals(size, values.size());
+        for (int i = 0; i < size; i++) {
+            cache.addStorageRow(address, keys.get(i), values.get(i));
+        }
+    }
+
+    /**
+     * Returns a list of numKeys keys, every other one is single and then double.
+     */
+    private List<IDataWord> getKeysInBulk(int numKeys) {
+        List<IDataWord> keys = new ArrayList<>(numKeys);
+        boolean isSingleKey = true;
+        for (int i = 0; i < numKeys; i++) {
+            keys.add(getRandomWord(isSingleKey));
+            isSingleKey = !isSingleKey;
+        }
+        return keys;
+    }
+
+    /**
+     * Returns a list of numValues values, every other one is single and then double.
+     */
+    private List<IDataWord> getValuesInBulk(int numValues) {
+        List<IDataWord> values = new ArrayList<>(numValues);
+        boolean isSingleValue = true;
+        for (int i = 0; i < numValues; i++) {
+            values.add(getRandomWord(isSingleValue));
+            isSingleValue = !isSingleValue;
+        }
+        return values;
+    }
+
+    /**
+     * Returns a random DataWord if isSingleWord is true, otherwise a random DoubleDataWord.
+     */
+    private IDataWord getRandomWord(boolean isSingleWord) {
+        return  (isSingleWord) ?
+            new DataWord(RandomUtils.nextBytes(DataWord.BYTES)) :
+            new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+    }
+
+}

--- a/modMcf/test/org/aion/mcf/db/AionRepositoryCacheTest.java
+++ b/modMcf/test/org/aion/mcf/db/AionRepositoryCacheTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contributors:
+ *     Aion foundation.
+ */
 package org.aion.mcf.db;
 
 import static org.junit.Assert.assertEquals;
@@ -25,7 +47,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class AbstractRepositoryCacheTest {
+public class AionRepositoryCacheTest {
     private AionRepositoryCache cache;
 
     @Before

--- a/modMcf/test/org/aion/mcf/db/IContractDetailsTest.java
+++ b/modMcf/test/org/aion/mcf/db/IContractDetailsTest.java
@@ -1,0 +1,417 @@
+package org.aion.mcf.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.aion.base.db.IContractDetails;
+import org.aion.base.vm.IDataWord;
+import org.aion.mcf.vm.types.DataWord;
+import org.aion.mcf.vm.types.DoubleDataWord;
+import org.aion.zero.db.AionContractDetailsImpl;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IContractDetailsTest {
+    // The two ways of instantiating the cache.
+    private IContractDetails<IDataWord> cache1, cache2;
+
+    @Before
+    public void setup() {
+        IContractDetails<IDataWord> details = new AionContractDetailsImpl();
+        cache1 = new ContractDetailsCacheImpl(details);
+        details = new ContractDetailsCacheImpl(details);
+        cache2 = new ContractDetailsCacheImpl(details);
+    }
+
+    @After
+    public void tearDown() {
+        cache1 = null;
+        cache2 = null;
+    }
+
+    @Test
+    public void testGetNoSuchSingleKey() {
+        doGetNoSuchSingleKeyTest(cache1);
+        doGetNoSuchSingleKeyTest(cache2);
+    }
+
+    @Test
+    public void testGetNoSuchDoubleKey() {
+        doGetNoSuchDoubleKeyTest(cache1);
+        doGetNoSuchDoubleKeyTest(cache2);
+    }
+
+    @Test
+    public void testPutSingleZeroValue() {
+        IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutSingleZeroValueTest(cache1, key);
+        doPutSingleZeroValueTest(cache2, key);
+
+        key = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        doPutSingleZeroValueTest(cache1, key);
+        doPutSingleZeroValueTest(cache2, key);
+    }
+
+    @Test
+    public void testPutDoubleZeroValue() {
+        IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutDoubleZeroValueTest(cache1, key);
+        doPutDoubleZeroValueTest(cache2, key);
+
+        key = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        doPutDoubleZeroValueTest(cache1, key);
+        doPutDoubleZeroValueTest(cache2, key);
+    }
+
+    @Test
+    public void testPutSingleZeroKey() {
+        IDataWord value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutSingleZeroKeyTest(cache1, value);
+        doPutSingleZeroKeyTest(cache2, value);
+
+        value = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        doPutSingleZeroKeyTest(cache1, value);
+        doPutSingleZeroKeyTest(cache2, value);
+    }
+
+    @Test
+    public void testPutDoubleZeroKey() {
+        IDataWord value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutDoubleZeroKeyTest(cache1, value);
+        doPutDoubleZeroKeyTest(cache2, value);
+
+        value = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+        doPutDoubleZeroKeyTest(cache1, value);
+        doPutDoubleZeroKeyTest(cache2, value);
+    }
+
+    @Test
+    public void testPutZeroKeyAndValue() {
+        // Try single-single
+        cache1.put(DataWord.ZERO, DataWord.ZERO);
+        assertNull(cache1.get(DataWord.ZERO));
+        cache2.put(DataWord.ZERO, DataWord.ZERO);
+        assertNull(cache2.get(DataWord.ZERO));
+
+        // Try single-double
+        cache1.put(DataWord.ZERO, DoubleDataWord.ZERO);
+        assertNull(cache1.get(DataWord.ZERO));
+        cache2.put(DataWord.ZERO, DoubleDataWord.ZERO);
+        assertNull(cache2.get(DataWord.ZERO));
+
+        // Try double-single
+        cache1.put(DoubleDataWord.ZERO, DataWord.ZERO);
+        assertNull(cache1.get(DoubleDataWord.ZERO));
+        cache2.put(DoubleDataWord.ZERO, DataWord.ZERO);
+        assertNull(cache2.get(DoubleDataWord.ZERO));
+
+        // Try double-double
+        cache1.put(DoubleDataWord.ZERO, DoubleDataWord.ZERO);
+        assertNull(cache1.get(DoubleDataWord.ZERO));
+        cache2.put(DoubleDataWord.ZERO, DoubleDataWord.ZERO);
+        assertNull(cache2.get(DoubleDataWord.ZERO));
+    }
+
+    @Test
+    public void testPutKeyValueThenOverwriteValueWithZero() {
+        // single-single
+        IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        IDataWord value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutKeyValueThenOverwriteValueWithZero(cache1, key, value);
+        doPutKeyValueThenOverwriteValueWithZero(cache2, key, value);
+
+        // single-double
+        value = new DoubleDataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutKeyValueThenOverwriteValueWithZero(cache1, key, value);
+        doPutKeyValueThenOverwriteValueWithZero(cache2, key, value);
+
+        // double-single
+        key = new DoubleDataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutKeyValueThenOverwriteValueWithZero(cache1, key, value);
+        doPutKeyValueThenOverwriteValueWithZero(cache2, key, value);
+
+        // double-double
+        key = new DoubleDataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        value = new DoubleDataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        doPutKeyValueThenOverwriteValueWithZero(cache1, key, value);
+        doPutKeyValueThenOverwriteValueWithZero(cache2, key, value);
+    }
+
+    @Test
+    public void testPutAndGetEnMass() {
+        int numEntries = RandomUtils.nextInt(1_000, 5_000);
+        int deleteOdds = 4;
+        List<IDataWord> keys = getKeysInBulk(numEntries);
+        List<IDataWord> values = getValuesInBulk(numEntries);
+        massPutIntoCache(cache1, keys, values);
+        deleteEveryNthEntry(cache1, keys, deleteOdds);
+        checkAllPairs(cache1, keys, values, deleteOdds);
+
+        massPutIntoCache(cache2, keys, values);
+        deleteEveryNthEntry(cache2, keys, deleteOdds);
+        checkAllPairs(cache2, keys, values, deleteOdds);
+    }
+
+    @Test
+    public void testGetStorage() {
+        int numEntries = RandomUtils.nextInt(1_000, 5_000);
+        int deleteOdds = 6;
+        List<IDataWord> keys = getKeysInBulk(numEntries);
+        List<IDataWord> values = getValuesInBulk(numEntries);
+        massPutIntoCache(cache1, keys, values);
+        deleteEveryNthEntry(cache1, keys, deleteOdds);
+        checkStorage(cache1, keys, values, deleteOdds);
+
+        massPutIntoCache(cache2, keys, values);
+        deleteEveryNthEntry(cache2, keys, deleteOdds);
+        checkStorage(cache2, keys, values, deleteOdds);
+    }
+
+    @Test
+    public void testSetZeroValueViaSetStorage() {
+        doSetZeroValueViaStorageTest(cache1);
+        doSetZeroValueViaStorageTest(cache2);
+    }
+
+    @Test
+    public void testSetStorageEnMass() {
+        int numEntries = RandomUtils.nextInt(1_000, 5_000);
+        int deleteOdds = 7;
+        Map<IDataWord, IDataWord> storage = getKeyValueMappingInBulk(numEntries, deleteOdds);
+        cache1.setStorage(storage);
+        checkKeyValueMapping(cache1, storage);
+
+        cache2.setStorage(storage);
+        checkKeyValueMapping(cache2, storage);
+    }
+
+    //<------------------------------------------HELPERS------------------------------------------->
+
+    /**
+     * Calls cache.get() under assumption that cache has no key-values stored in it.
+     */
+    private void doGetNoSuchSingleKeyTest(IContractDetails<IDataWord> cache) {
+        // First try out the zero data word.
+        assertNull(cache.get(DataWord.ZERO));
+
+        // Try a random data word.
+        assertNull(cache.get(new DataWord(RandomUtils.nextBytes(DataWord.BYTES))));
+    }
+
+    /**
+     * Calls cache.get() under assumption that cache has no key-values stored in it.
+     */
+    private void doGetNoSuchDoubleKeyTest(IContractDetails<IDataWord> cache) {
+        // First try out the zero data word.
+        assertNull(cache.get(DoubleDataWord.ZERO));
+
+        // Try a random data word.
+        assertNull(cache.get(new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES))));
+    }
+
+    /**
+     * Puts a zero data word into cache with key and ensures the entry does not exist.
+     */
+    private void doPutSingleZeroValueTest(IContractDetails<IDataWord> cache, IDataWord key) {
+        cache.put(key, DataWord.ZERO);
+        assertNull(cache.get(key));
+    }
+
+    /**
+     * Puts a zero data word into cache with key and ensures the entry does not exist.
+     */
+    private void doPutDoubleZeroValueTest(IContractDetails<IDataWord> cache, IDataWord key) {
+        cache.put(key, DoubleDataWord.ZERO);
+        assertNull(cache.get(key));
+    }
+
+    /**
+     * Puts value into cache with a zero data word key and ensures the entry does not exist.
+     */
+    private void doPutSingleZeroKeyTest(IContractDetails<IDataWord> cache, IDataWord value) {
+        cache.put(DataWord.ZERO, value);
+        assertEquals(value, cache.get(DataWord.ZERO));
+    }
+
+    /**
+     * Puts value into cache with a zero data word key and ensures the entry does not exist.
+     */
+    private void doPutDoubleZeroKeyTest(IContractDetails<IDataWord> cache, IDataWord value) {
+        cache.put(DoubleDataWord.ZERO, value);
+        assertEquals(value, cache.get(DoubleDataWord.ZERO));
+    }
+
+    /**
+     * Puts the key-value pair key and value into cache and then adds a zero word to the key and
+     * ensures that key-value pair is deleted.
+     */
+    private void doPutKeyValueThenOverwriteValueWithZero(IContractDetails<IDataWord> cache,
+        IDataWord key, IDataWord value) {
+
+        cache.put(key, value);
+        assertEquals(value, cache.get(key));
+        cache.put(key, DataWord.ZERO);
+        assertNull(cache.get(key));
+        cache.put(key, value);
+        assertEquals(value, cache.get(key));
+        cache.put(key, DoubleDataWord.ZERO);
+        assertNull(cache.get(key));
+    }
+
+    /**
+     * Checks that cache contains all key-value pairs in keys and values, where it is assumed every
+     * n'th pair was deleted.
+     */
+    private void checkAllPairs(IContractDetails<IDataWord> cache, List<IDataWord> keys,
+        List<IDataWord> values, int n) {
+
+        int size = keys.size();
+        assertEquals(size, values.size());
+        int count = 1;
+        for (IDataWord key : keys) {
+            if (count % n == 0) {
+                assertNull(cache.get(key));
+            } else {
+                assertEquals(values.get(count - 1), cache.get(key));
+            }
+            count++;
+        }
+    }
+
+    /**
+     * Checks that cache's storage, given by cache.getStorage(), contains all key-value pairs in
+     * keys and values, where it is assumed every n'th pair was deleted.
+     */
+    private void checkStorage(IContractDetails<IDataWord> cache, List<IDataWord> keys,
+        List<IDataWord> values, int n) {
+
+        Map<IDataWord, IDataWord> storage = cache.getStorage(keys);
+        int count = 1;
+        for (IDataWord key : keys) {
+            if (count % n == 0) {
+                assertNull(storage.get(key));
+            } else {
+                assertEquals(values.get(count - 1), storage.get(key));
+            }
+            count++;
+        }
+    }
+
+    /**
+     * Iterates over every key in keys -- which are assumed to exist in cache -- and then deletes
+     * any key-value pair in cache for every n'th key in keys.
+     */
+    private void deleteEveryNthEntry(IContractDetails<IDataWord> cache, List<IDataWord> keys, int n) {
+        int count = 1;
+        for (IDataWord key : keys) {
+            if (count % n == 0) {
+                cache.put(key, DataWord.ZERO);
+            }
+            count++;
+        }
+    }
+
+    /**
+     * Puts all of the key-value pairs in keys and values into cache.
+     */
+    private void massPutIntoCache(IContractDetails<IDataWord> cache, List<IDataWord> keys,
+        List<IDataWord> values) {
+
+        int size = keys.size();
+        assertEquals(size, values.size());
+        for (int i = 0; i < size; i++) {
+            cache.put(keys.get(i), values.get(i));
+        }
+    }
+
+    /**
+     * Returns a list of numKeys keys, every other one is single and then double.
+     */
+    private List<IDataWord> getKeysInBulk(int numKeys) {
+        List<IDataWord> keys = new ArrayList<>(numKeys);
+        boolean isSingleKey = true;
+        for (int i = 0; i < numKeys; i++) {
+            keys.add(getRandomWord(isSingleKey));
+            isSingleKey = !isSingleKey;
+        }
+        return keys;
+    }
+
+    /**
+     * Returns a list of numValues values, every other one is single and then double.
+     */
+    private List<IDataWord> getValuesInBulk(int numValues) {
+        List<IDataWord> values = new ArrayList<>(numValues);
+        boolean isSingleValue = true;
+        for (int i = 0; i < numValues; i++) {
+            values.add(getRandomWord(isSingleValue));
+            isSingleValue = !isSingleValue;
+        }
+        return values;
+    }
+
+    /**
+     * Returns a random DataWord if isSingleWord is true, otherwise a random DoubleDataWord.
+     */
+    private IDataWord getRandomWord(boolean isSingleWord) {
+        return  (isSingleWord) ?
+            new DataWord(RandomUtils.nextBytes(DataWord.BYTES)) :
+            new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
+    }
+
+    /**
+     * Sets a key-value pair with a zero value via cache.setStorage() and ensures that null is
+     * returned when called on that same key.
+     */
+    private void doSetZeroValueViaStorageTest(IContractDetails<IDataWord> cache) {
+        Map<IDataWord, IDataWord> storage = new HashMap<>();
+        IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
+        storage.put(key, DataWord.ZERO);
+        cache.setStorage(storage);
+        assertNull(cache.get(key));
+    }
+
+    /**
+     * Checks cache returns the expected values given its storage is storage.
+     */
+    private void checkKeyValueMapping(IContractDetails<IDataWord> cache,
+        Map<IDataWord, IDataWord> storage) {
+
+        for (IDataWord key : storage.keySet()) {
+            IDataWord value = storage.get(key);
+            if (value.isZero()) {
+                assertNull(cache.get(key));
+            } else {
+                assertEquals(value, cache.get(key));
+            }
+        }
+    }
+
+    /**
+     * Returns a key-value mapping with numEntries mappings, where every n'th mapping has a zero
+     * value.
+     */
+    private Map<IDataWord, IDataWord> getKeyValueMappingInBulk(int numEntries, int n) {
+        Map<IDataWord, IDataWord> storage = new HashMap<>(numEntries);
+        List<IDataWord> keys = getKeysInBulk(numEntries);
+        List<IDataWord> values = getValuesInBulk(numEntries);
+        int size = keys.size();
+        assertEquals(size, values.size());
+        for (int i = 0; i < size; i++) {
+            if ((i + 1) % n == 0) {
+                storage.put(keys.get(i), DoubleDataWord.ZERO);
+            } else {
+                storage.put(keys.get(i), values.get(i));
+            }
+        }
+        return storage;
+    }
+
+}


### PR DESCRIPTION
## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- There was a bit of confusion about how all-zero byte values work in the db: they tell the db to delete the associated key. I've fixed how these zeroes are handled so that if a key does not exist then retrieving such a key returns `null` always.
- This was how the behaviour as originally defined, the DoubleDataWord broke this contract in a few cases, so it's back to as expected.

Fixes Issue # N/A.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- There are existing unit tests for DataWord and DoubleDataWord, I've added more thorough testing to the db itself. Also tested against our existing test suite.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
