### PR TITLE
ModApiServer unit tests

### DIFF
--- a/modApiServer/build.xml
+++ b/modApiServer/build.xml
@@ -7,6 +7,8 @@
     <property name="src.test" value="./test"/>
     <property name="test.report.dir" value="report"/>
     <property name="dir.javaAPIlib" value="../javaAPIlib"/>
+    <property name="native.dir" value="native"/>
+    <property name="native.src.dir" value="../../native"/>
 
     <path id="classpath.dependency">
         <pathelement location="${dir.mod}/modAionBase.jar"/>
@@ -45,6 +47,10 @@
     </target>
 
     <target name="test" depends="test_build">
+        <mkdir dir="${native.dir}"/>
+        <copy todir="${native.dir}">
+            <fileset dir="${native.src.dir}"/>
+        </copy>
         <mkdir dir="${test.report.dir}"/>
         <junit printsummary="on" haltonfailure="yes" fork="true">
             <classpath>

--- a/modApiServer/src/org/aion/api/server/Api.java
+++ b/modApiServer/src/org/aion/api/server/Api.java
@@ -50,7 +50,20 @@ public abstract class Api<B extends AbstractBlock<?, ?>> {
 
     private final AccountManager ACCOUNT_MANAGER = AccountManager.inst();
     private final Compiler solc = Compiler.getInstance();
-    protected final AionPendingStateImpl pendingState = AionPendingStateImpl.inst();
+    protected final AionPendingStateImpl pendingState;
+
+    // This is the constructor that should always be used, unless testing
+    Api() {
+        pendingState = AionPendingStateImpl.inst();
+    }
+
+    // Only for testing purposes
+    Api(boolean test) {
+        if (!test)
+            pendingState = AionPendingStateImpl.inst();
+        else
+            pendingState = null;
+    }
 
     public abstract String getCoinbase();
 

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -665,7 +665,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         Message.rsp_compile.Builder b = Message.rsp_compile.newBuilder();
 
                         for (Entry<String, CompiledContr> entry : _contrs.entrySet()) {
-                            if (entry.getKey().contains("AionCompileError")) {
+                            if (entry.getKey().contains("compile-error")) {
                                 byte[] retHeader =
                                     ApiUtil.toReturnHeader(
                                         getApiVersion(),

--- a/modApiServer/test/org/aion/api/server/ApiAionTests.java
+++ b/modApiServer/test/org/aion/api/server/ApiAionTests.java
@@ -2,7 +2,6 @@ package org.aion.api.server;
 
 import org.aion.api.server.types.ArgTxCall;
 import org.aion.api.server.types.SyncInfo;
-import org.aion.api.server.types.TxRecpt;
 import org.aion.base.type.Address;
 import org.aion.base.type.ITransaction;
 import org.aion.base.type.ITxReceipt;

--- a/modApiServer/test/org/aion/api/server/ApiAionTests.java
+++ b/modApiServer/test/org/aion/api/server/ApiAionTests.java
@@ -1,0 +1,165 @@
+package org.aion.api.server;
+
+import org.aion.api.server.types.SyncInfo;
+import org.aion.base.type.ITransaction;
+import org.aion.base.type.ITxReceipt;
+import org.aion.evtmgr.impl.evt.EventBlock;
+import org.aion.evtmgr.impl.evt.EventDummy;
+import org.aion.evtmgr.impl.evt.EventTx;
+import org.aion.zero.impl.AionBlockchainImpl;
+import org.aion.zero.impl.blockchain.AionImpl;
+import org.aion.zero.impl.types.AionBlock;
+import org.aion.zero.impl.types.AionBlockSummary;
+import org.aion.zero.types.AionTransaction;
+import org.aion.zero.types.AionTxReceipt;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ApiAionTests {
+
+    private class ApiAionImpl extends ApiAion {
+
+        private boolean onBlockFlag;
+        private boolean pendingRcvdFlag;
+        private boolean pendingUpdateFlag;
+
+        @Override
+        protected void onBlock(AionBlockSummary cbs) {
+            onBlockFlag = true;
+        }
+
+        @Override
+        protected void pendingTxReceived(ITransaction _tx) {
+            pendingRcvdFlag = true;
+        }
+
+        @Override
+        protected void pendingTxUpdate(ITxReceipt _txRcpt, EventTx.STATE _state) {
+            pendingUpdateFlag = true;
+        }
+
+        public boolean allFlagsSet() {
+            return (onBlockFlag && pendingRcvdFlag && pendingUpdateFlag);
+        }
+
+
+        public ApiAionImpl(AionImpl impl) {
+            super(impl);
+            onBlockFlag = false;
+            pendingRcvdFlag = false;
+            pendingUpdateFlag = false;
+        }
+
+        public void addEvents() {
+            EventTx pendingRcvd = new EventTx(EventTx.CALLBACK.PENDINGTXRECEIVED0);
+            AionTransaction tx = new AionTransaction(null);
+            List l1 = new ArrayList<ITransaction>();
+            l1.add(tx);
+            l1.add(tx);
+            l1.add(tx);
+            pendingRcvd.setFuncArgs(Collections.singletonList(l1));
+
+            ees.add(pendingRcvd);
+
+            EventTx pendingUpdate = new EventTx(EventTx.CALLBACK.PENDINGTXUPDATE0);
+            List l2 = new ArrayList<>();
+            l2.add(new AionTxReceipt());
+            l2.add(-1);
+            pendingUpdate.setFuncArgs(l2);
+
+            ees.add(pendingUpdate);
+
+            EventBlock evBlock = new EventBlock(EventBlock.CALLBACK.ONBLOCK0);
+            AionBlockSummary abs = new AionBlockSummary(null, null, null, null);
+            evBlock.setFuncArgs(Collections.singletonList(abs));
+
+            ees.add(evBlock);
+
+            //provokes exception in EpApi.run()
+            ees.add(new EventBlock(EventBlock.CALLBACK.ONBLOCK0));
+            ees.add(new EventDummy());
+        }
+
+    }
+
+    @Test
+    public void TestCreate() {
+        System.out.println("run TestCreate.");
+        AionImpl impl = AionImpl.inst();
+        ApiAionTests.ApiAionImpl api = new ApiAionTests.ApiAionImpl(impl);
+        System.out.println("API Version = " + api.getApiVersion());
+        assertNotNull(api.getInstalledFltrs());
+        assertNotNull(api.getCoinbase());
+    }
+
+    @Test
+    public void TestInitNrgOracle() {
+        System.out.println("run TestInitNrgOracle.");
+        AionImpl impl = AionImpl.inst();
+        ApiAionTests.ApiAionImpl api = new ApiAionTests.ApiAionImpl(impl);
+        api.initNrgOracle(impl);
+        assertNotNull(ApiAion.NRG_ORACLE);
+        // Initing a second time should not create a new NrgOracle
+        api.initNrgOracle(impl);
+        assertNotNull(ApiAion.NRG_ORACLE);
+    }
+
+    @Test
+    public void TestStartES() {
+        System.out.println("run TestStartES.");
+        AionImpl impl = AionImpl.inst();
+        ApiAionTests.ApiAionImpl api = new ApiAionTests.ApiAionImpl(impl);
+        api.startES("thName");
+        api.addEvents();
+        try
+        {
+            Thread.sleep(5000);
+        }
+        catch(InterruptedException ex) {}
+        api.shutDownES();
+        assertTrue(api.allFlagsSet());
+    }
+
+    @Test
+    public void TestGetBlock() {
+        System.out.println("run TestGetBlock.");
+        AionImpl impl = AionImpl.inst();
+        ApiAionTests.ApiAionImpl api = new ApiAionTests.ApiAionImpl(impl);
+        assertNotNull(api.getBlockTemplate());
+
+        AionBlock blk = impl.getBlockchain().getBestBlock();
+
+        assertEquals(blk, api.getBestBlock());
+        assertEquals(blk.toString(), api.getBlockByHash(blk.getHash()).toString());
+        assertEquals(blk.toString(), api.getBlock(blk.getNumber()).toString());
+
+        Map.Entry rslt = api.getBlockWithTotalDifficulty(blk.getNumber());
+        assertEquals(rslt.getKey().toString(), blk.toString());
+        assertEquals(rslt.getValue(), blk.getDifficultyBI());
+    }
+
+
+    @Test
+    public void TestGetSync() {
+        System.out.println("run TestGetSync.");
+        AionImpl impl = AionImpl.inst();
+        ApiAionTests.ApiAionImpl api = new ApiAionTests.ApiAionImpl(impl);
+        SyncInfo sync = api.getSync();
+        assertNotNull(sync);
+        assertEquals(sync.done, impl.isSyncComplete());
+        if (impl.getInitialStartingBlockNumber().isPresent())
+            assertEquals(sync.chainStartingBlkNumber, (long) impl.getInitialStartingBlockNumber().get());
+        if (impl.getInitialStartingBlockNumber().isPresent())
+            assertEquals(sync.networkBestBlkNumber, (long) impl.getNetworkBestBlockNumber().get());
+        if (impl.getInitialStartingBlockNumber().isPresent())
+            assertEquals(sync.chainBestBlkNumber, (long) impl.getLocalBestBlockNumber().get());
+    }
+}

--- a/modApiServer/test/org/aion/api/server/ApiTests.java
+++ b/modApiServer/test/org/aion/api/server/ApiTests.java
@@ -52,7 +52,7 @@ public class ApiTests {
 
     @Test
     public void TestCreate() {
-        System.out.println("run TestApiConnect.");
+        System.out.println("run TestCreate.");
         ApiImpl api = new ApiImpl();
         api.solcVersion();
         assertNotNull(api.LOG);

--- a/modApiServer/test/org/aion/api/server/ApiTests.java
+++ b/modApiServer/test/org/aion/api/server/ApiTests.java
@@ -1,0 +1,119 @@
+package org.aion.api.server;
+
+import org.aion.api.server.types.CompiledContr;
+import org.aion.base.type.Address;
+import org.aion.mcf.types.AbstractBlock;
+import org.junit.Test;
+
+
+import java.math.BigInteger;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ApiTests {
+
+    private class ApiImpl extends Api {
+
+        @Override
+        public String getCoinbase() {
+            return null;
+        }
+
+        @Override
+        public byte getApiVersion() {
+            return 0;
+        }
+
+        @Override
+        public AbstractBlock getBestBlock() {
+            return null;
+        }
+
+        @Override
+        public AbstractBlock<?, ?> getBlock(long _bn) {
+            return null;
+        }
+
+        @Override
+        public AbstractBlock<?, ?> getBlockByHash(byte[] hash) {
+            return null;
+        }
+
+        @Override
+        public BigInteger getBalance(String _address) throws Exception {
+            return null;
+        }
+
+        public ApiImpl() {
+            super(true);
+        }
+    }
+
+    @Test
+    public void TestCreate() {
+        System.out.println("run TestApiConnect.");
+        ApiImpl api = new ApiImpl();
+        api.solcVersion();
+        assertNotNull(api.LOG);
+    }
+
+    @Test
+    public void TestLockAndUnlock() {
+        System.out.println("run TestLockAndUnlock.");
+        ApiImpl api = new ApiImpl();
+        assertFalse(api.unlockAccount(Address.ZERO_ADDRESS(), "testPassword", 0));
+        assertFalse(api.unlockAccount(Address.ZERO_ADDRESS().toString(), "testPassword", 0));
+        assertFalse(api.lockAccount(Address.ZERO_ADDRESS(), "testPassword"));
+    }
+
+    @Test
+    public void TestAccountRetrieval() {
+        System.out.println("run TestAccountRetrieval.");
+        ApiImpl api = new ApiImpl();
+        assertTrue(api.getAccounts().isEmpty());
+        assertNull(api.getAccountKey(Address.ZERO_ADDRESS().toString()));
+    }
+
+    @Test
+    public void TestCompileFail() {
+        System.out.println("run TestCompileFail.");
+        ApiImpl api = new ApiImpl();
+        String contract = "This should fail\n";
+        assertNotNull(api.contract_compileSolidity(contract).get("compile-error"));
+    }
+
+    @Test
+    public void TestCompilePass1() {
+        System.out.println("run TestCompilePass1.");
+        ApiImpl api = new ApiImpl();
+
+        // Taken from FastVM CompilerTest.java
+        String contract = "pragma solidity ^0.4.0;\n" + //
+                "\n" + //
+                "contract SimpleStorage {\n" + //
+                "    uint storedData;\n" + //
+                "\n" + //
+                "    function set(uint x) {\n" + //
+                "        storedData = x;\n" + //
+                "    }\n" + //
+                "\n" + //
+                "    function get() constant returns (uint) {\n" + //
+                "        return storedData;\n" + //
+                "    }\n" + //
+                "}";
+        Map<String, CompiledContr> compileResult = api.contract_compileSolidity(contract);
+        CompiledContr compiledContr = compileResult.get("SimpleStorage");
+        assertNull(compiledContr.error);
+    }
+
+    @Test
+    public void TestContractCreateResult() {
+        System.out.println("run TestContractCreateResult.");
+        ApiImpl api = new ApiImpl();
+        ApiImpl.ContractCreateResult ccr = api.new ContractCreateResult();
+        assertNull(ccr.address);
+        assertNull(ccr.transId);
+    }
+
+}

--- a/modApiServer/test/org/aion/api/server/ApiTests.java
+++ b/modApiServer/test/org/aion/api/server/ApiTests.java
@@ -2,6 +2,8 @@ package org.aion.api.server;
 
 import org.aion.api.server.types.CompiledContr;
 import org.aion.base.type.Address;
+import org.aion.mcf.account.AccountManager;
+import org.aion.mcf.account.Keystore;
 import org.aion.mcf.types.AbstractBlock;
 import org.junit.Test;
 
@@ -65,14 +67,21 @@ public class ApiTests {
         assertFalse(api.unlockAccount(Address.ZERO_ADDRESS(), "testPassword", 0));
         assertFalse(api.unlockAccount(Address.ZERO_ADDRESS().toString(), "testPassword", 0));
         assertFalse(api.lockAccount(Address.ZERO_ADDRESS(), "testPassword"));
+
+        Address addr = new Address(Keystore.create("testPwd"));
+        assertTrue(api.unlockAccount(addr, "testPwd", 50000));
     }
 
     @Test
     public void TestAccountRetrieval() {
         System.out.println("run TestAccountRetrieval.");
         ApiImpl api = new ApiImpl();
-        assertTrue(api.getAccounts().isEmpty());
         assertNull(api.getAccountKey(Address.ZERO_ADDRESS().toString()));
+
+        String addr = Keystore.create("testPwd");
+        assertEquals(AccountManager.inst().getKey(Address.wrap(addr)), api.getAccountKey(addr));
+
+        assertTrue(api.getAccounts().contains(addr));
     }
 
     @Test

--- a/modApiServer/test/org/aion/api/server/ApiUtilTests.java
+++ b/modApiServer/test/org/aion/api/server/ApiUtilTests.java
@@ -1,0 +1,137 @@
+package org.aion.api.server;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ApiUtilTests {
+
+    private byte vers, retCode;
+
+    private byte errorLength;
+    private byte resultLength;
+
+    private byte[] hash;
+    private byte[] error;
+    private byte[] result;
+
+    public ApiUtilTests() {
+        errorLength = 7;
+        resultLength = 6;
+        vers = RandomUtils.nextBytes(1)[0];
+        retCode = RandomUtils.nextBytes(1)[0];
+        hash = RandomUtils.nextBytes(ApiUtil.HASH_LEN);
+        error = RandomUtils.nextBytes(errorLength);
+        result = RandomUtils.nextBytes(resultLength);
+    }
+
+    @Test
+    public void TestNulls() {
+        System.out.println("run TestNulls.");
+
+        assertNull(ApiUtil.toReturnHeader(vers, retCode, null));
+        assertNull(ApiUtil.toReturnHeader(vers, retCode, null, null));
+        assertNull(ApiUtil.toReturnHeader(vers, retCode, null, null, null));
+        assertNull(ApiUtil.combineRetMsg(null, null));
+        assertNull(ApiUtil.combineRetMsg(null, (byte) 1));
+        assertNull(ApiUtil.getApiMsgHash(null));
+    }
+
+    @Test
+    public void TestHeader() {
+        System.out.println("run TestHeader.");
+
+        byte[] header = ApiUtil.toReturnHeader(vers, retCode);
+        assertEquals(vers, header[0]);
+        assertEquals(retCode, header[1]);
+        assertEquals(0, header[2]);
+    }
+
+
+    @Test
+    public void TestHeaderHash() {
+        System.out.println("run TestHeaderHash.");
+
+        byte[] header = ApiUtil.toReturnHeader(vers, retCode, hash);
+        assertEquals(vers, header[0]);
+        assertEquals(retCode, header[1]);
+        assertEquals(1, header[2]);
+        assertArrayEquals(hash, Arrays.copyOfRange(header, 3, header.length));
+
+    }
+
+    @Test
+    public void TestHeaderHashError() {
+        System.out.println("run TestHeaderHashError.");
+
+        byte[] header = ApiUtil.toReturnHeader(vers, retCode, hash, error);
+        assertEquals(vers, header[0]);
+        assertEquals(retCode, header[1]);
+        assertEquals(1, header[2]);
+        assertArrayEquals(hash, Arrays.copyOfRange(header, 3, ApiUtil.HASH_LEN + 3));
+        assertEquals(error.length, header[ApiUtil.HASH_LEN + 3]);
+        assertArrayEquals(error, Arrays.copyOfRange(header, ApiUtil.HASH_LEN + 4, header.length));
+
+        error = new byte[0];
+        header = ApiUtil.toReturnHeader(vers, retCode, hash, error);
+        assertEquals(vers, header[0]);
+        assertEquals(retCode, header[1]);
+        assertEquals(1, header[2]);
+        assertArrayEquals(hash, Arrays.copyOfRange(header, 3, header.length - 1));
+        assertEquals(0, header[header.length - 1]);
+
+    }
+
+    @Test
+    public void TestHeaderHashErrorResult() {
+        System.out.println("run TestHeaderHashErrorResult.");
+
+        byte[] header = ApiUtil.toReturnHeader(vers, retCode, hash, error, result);
+        assertEquals(vers, header[0]);
+        assertEquals(retCode, header[1]);
+        assertEquals(1, header[2]);
+        assertArrayEquals(hash, Arrays.copyOfRange(header, 3, ApiUtil.HASH_LEN + 3));
+        assertEquals(error.length, header[ApiUtil.HASH_LEN + 3]);
+        assertArrayEquals(error, Arrays.copyOfRange(header, ApiUtil.HASH_LEN + 4, ApiUtil.HASH_LEN + errorLength + 4));
+        assertArrayEquals(result, Arrays.copyOfRange(header, ApiUtil.HASH_LEN + errorLength + 4, header.length));
+
+        error = new byte[0];
+        header = ApiUtil.toReturnHeader(vers, retCode, hash, error, result);
+        assertEquals(vers, header[0]);
+        assertEquals(retCode, header[1]);
+        assertEquals(1, header[2]);
+        assertArrayEquals(hash, Arrays.copyOfRange(header, 3, ApiUtil.HASH_LEN + 3));
+        assertEquals(0, header[ApiUtil.HASH_LEN + 3]);
+        assertArrayEquals(result, Arrays.copyOfRange(header, ApiUtil.HASH_LEN + 4, header.length));
+    }
+
+    @Test
+    public void TestReturnEvtHeader() {
+        System.out.println("run TestReturnEvtHeader.");
+
+        byte[] header = ApiUtil.toReturnEvtHeader(vers, result);
+        assertEquals(vers, header[0]);
+        assertEquals(106, header[1]);
+        assertEquals(0, header[2]);
+        assertArrayEquals(result, Arrays.copyOfRange(header, 3, header.length));
+    }
+
+    @Test
+    public void TestCombineRetMsg() {
+        System.out.println("run TestCombineRetMsg.");
+
+        byte[] header = ApiUtil.combineRetMsg(hash, (byte) 5);
+        assertArrayEquals(hash, Arrays.copyOfRange(header, 0, hash.length));
+        assertEquals(5, header[hash.length]);
+
+        header = ApiUtil.combineRetMsg(hash, result);
+        assertArrayEquals(hash, Arrays.copyOfRange(header, 0, hash.length));
+        assertArrayEquals(result, Arrays.copyOfRange(header, hash.length, header.length));
+    }
+
+}

--- a/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
+++ b/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
@@ -1,22 +1,52 @@
 package org.aion.api.server.pb;
 
+import com.google.protobuf.ByteString;
+import org.aion.api.impl.internal.ApiUtils;
+import org.aion.api.server.ApiUtil;
+import org.aion.base.type.Address;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.base.util.TypeConverter;
+import org.aion.equihash.EquihashMiner;
+import org.aion.mcf.account.AccountManager;
+import org.aion.mcf.account.Keystore;
+import org.aion.zero.impl.Version;
 import org.aion.zero.impl.blockchain.AionImpl;
+import org.aion.zero.impl.blockchain.AionPendingStateImpl;
+import org.aion.zero.types.AionTransaction;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ApiAion0Tests {
 
-    byte[] msg;
+    byte[] msg, socketId, hash;
     int requestSize;
+
+    private static final int MSG_HASH_LEN = 8;
+    private static final int RSP_HEADER_NOHASH_LEN = 3;
+    public static final int REQ_HEADER_NOHASH_LEN = 4;
+    private static final int RSP_HEADER_LEN = RSP_HEADER_NOHASH_LEN + MSG_HASH_LEN;
 
     public ApiAion0Tests() {
         msg = "test message".getBytes();
+        socketId = RandomUtils.nextBytes(5);
+        hash = RandomUtils.nextBytes(ApiUtil.HASH_LEN);
         requestSize = msg.length + 3;
+    }
+
+    private byte[] stripHeader(byte[] rsp) {
+        boolean hasHash = (rsp[2] == 1 ? true : false);
+        int bodyLen = rsp.length - (hasHash ? RSP_HEADER_LEN : RSP_HEADER_NOHASH_LEN);
+
+        if (hasHash) {
+            return Arrays.copyOfRange(rsp, RSP_HEADER_LEN, RSP_HEADER_LEN + bodyLen);
+        } else {
+            return Arrays.copyOfRange(rsp, RSP_HEADER_NOHASH_LEN, RSP_HEADER_NOHASH_LEN + bodyLen);
+        }
     }
 
     @Test
@@ -50,18 +80,36 @@ public class ApiAion0Tests {
         AionImpl impl = AionImpl.inst();
         ApiAion0 api = new ApiAion0(impl);
 
-        byte[] request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+        byte[] request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
                 .put((byte) Message.Servs.s_net_VALUE)
                 .put((byte) Message.Funcs.f_protocolVersion_VALUE)
+                .put((byte) 1)
+                .put(hash)
                 .put(msg).array();
-        assertEquals(Message.Retcode.r_success_VALUE, api.process(request, null)[1]);
 
-        request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_protocolVersion pv = Message.rsp_protocolVersion.parseFrom(stripHeader(rsp));
+            assertEquals(Integer.toString(api.getApiVersion()), pv.getApi());
+            assertEquals(Version.KERNEL_VERSION, pv.getKernel());
+            assertEquals(EquihashMiner.VERSION, pv.getMiner());
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
                 .put((byte) Message.Servs.s_hb_VALUE)
                 .put((byte) Message.Funcs.f_protocolVersion_VALUE)
+                .put((byte) 1)
+                .put(hash)
                 .put(msg).array();
-        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, null)[1]);
 
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
 
         api.shutDown();
     }
@@ -72,39 +120,215 @@ public class ApiAion0Tests {
         AionImpl impl = AionImpl.inst();
         ApiAion0 api = new ApiAion0(impl);
 
-        byte[] request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+        byte[] request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
                 .put((byte) Message.Servs.s_wallet_VALUE)
                 .put((byte) Message.Funcs.f_minerAddress_VALUE)
+                .put((byte) 1)
+                .put(hash)
                 .put(msg).array();
-        assertEquals(Message.Retcode.r_success_VALUE, api.process(request, null)[1]);
 
-        request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_minerAddress ma = Message.rsp_minerAddress.parseFrom(stripHeader(rsp));
+
+            assertEquals(ByteString.copyFrom(
+                    TypeConverter.StringHexToByteArray(api.getCoinbase())),
+                    ma.getMinerAddr());
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
                 .put((byte) Message.Servs.s_hb_VALUE)
                 .put((byte) Message.Funcs.f_minerAddress_VALUE)
+                .put((byte) 1)
+                .put(hash)
                 .put(msg).array();
-        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, null)[1]);
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
 
         api.shutDown();
     }
-//
-//    @Test
-//    public void TestProcessContractDeploy() {
-//        System.out.println("run TestProcessContractDeploy.");
-//        AionImpl impl = AionImpl.inst();
-//        ApiAion0 api = new ApiAion0(impl);
-//
-//        byte[] request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
-//                .put((byte) Message.Servs.s_tx_VALUE)
-//                .put((byte) Message.Funcs.f_contractDeploy_VALUE)
-//                .put(msg).array();
-//        assertEquals(Message.Retcode.r_success_VALUE, api.process(request, null)[1]);
-//
-//        request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
-//                .put((byte) Message.Servs.s_hb_VALUE)
-//                .put((byte) Message.Funcs.f_contractDeploy_VALUE)
-//                .put(msg).array();
-//        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, null)[1]);
-//
-//        api.shutDown();
-//    }
+
+    @Test
+    public void TestProcessContractDeploy() {
+        System.out.println("run TestProcessContractDeploy.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Address addr = new Address(Keystore.create("testPwd"));
+        AccountManager.inst().unlockAccount(addr, "testPwd", 50000);
+
+        byte[] val = {50, 30};
+
+
+        Message.req_contractDeploy reqBody = Message.req_contractDeploy.newBuilder()
+                .setFrom(ByteString.copyFrom(addr.toBytes()))
+                .setNrgLimit(100000)
+                .setNrgPrice(5000)
+                .setData(ByteString.copyFrom(msg))
+                .setValue(ByteString.copyFrom(val))
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_tx_VALUE)
+                .put((byte) Message.Funcs.f_contractDeploy_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_tx_Recved_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_contractDeploy rslt = Message.rsp_contractDeploy.parseFrom(stripHeader(rsp));
+            assertNotNull(rslt.getContractAddress());
+            assertNotNull(rslt.getTxHash());
+
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_contractDeploy_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessAccountsValue() {
+        System.out.println("run TestProcessAccountsValue.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Address addr = new Address(Keystore.create("testPwd"));
+        AccountManager.inst().unlockAccount(addr, "testPwd", 50000);
+
+        byte[] request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_wallet_VALUE)
+                .put((byte) Message.Funcs.f_accounts_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_accounts accts = Message.rsp_accounts.parseFrom(stripHeader(rsp));
+            assertEquals(api.getAccounts().size(),
+                    accts.getAccoutCount());
+
+            assertEquals(ByteString.copyFrom(TypeConverter.StringHexToByteArray((String) api.getAccounts().get(0))),
+                    accts.getAccout(0));
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_accounts_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessBlockNumber() {
+        System.out.println("run TestProcessBlockNumber.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Address addr = new Address(Keystore.create("testPwd"));
+        AccountManager.inst().unlockAccount(addr, "testPwd", 50000);
+
+        byte[] request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_chain_VALUE)
+                .put((byte) Message.Funcs.f_blockNumber_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_blockNumber rslt = Message.rsp_blockNumber.parseFrom(stripHeader(rsp));
+            assertEquals(api.getBestBlock().getNumber(),
+                    rslt.getBlocknumber());
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_accounts_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+
+    @Test
+    public void TestProcessUnlockAccount() {
+        System.out.println("run TestProcessUnlockAccount.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Address addr = new Address(Keystore.create("testPwd"));
+        AccountManager.inst().unlockAccount(addr, "testPwd", 50000);
+
+        Message.req_unlockAccount reqBody = Message.req_unlockAccount.newBuilder()
+                .setAccount(ByteString.copyFrom(addr.toBytes()))
+                .setDuration(500)
+                .setPassword("testPwd")
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_wallet_VALUE)
+                .put((byte) Message.Funcs.f_unlockAccount_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_accounts_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
 }

--- a/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
+++ b/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
@@ -1822,4 +1822,280 @@ public class ApiAion0Tests {
         api.shutDown();
     }
 
+    @Test
+    public void TestProcessBlockDetails() {
+        System.out.println("run TestProcessEventDeregister.");
+
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Message.req_getBlockDetailsByNumber reqBody = Message.req_getBlockDetailsByNumber.newBuilder()
+                .addBlkNumbers(api.getBestBlock().getNumber())
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_admin_VALUE)
+                .put((byte) Message.Funcs.f_getBlockDetailsByNumber_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_getBlockDetailsByNumber rslt = Message.rsp_getBlockDetailsByNumber.parseFrom(stripHeader(rsp));
+            assertEquals(1, rslt.getBlkDetailsCount());
+            Message.t_BlockDetail blkdtl = rslt.getBlkDetails(0);
+            assertEquals(api.getBestBlock().getNumber(), blkdtl.getBlockNumber());
+            assertEquals(api.getBestBlock().getNrgConsumed(), blkdtl.getNrgConsumed());
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_getBlockDetailsByNumber_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessBlockSqlRange() {
+        System.out.println("run TestProcessBlockSqlRange.");
+
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        long bestBlkNum = api.getBestBlock().getNumber();
+
+        Message.req_getBlockSqlByRange reqBody = Message.req_getBlockSqlByRange.newBuilder()
+                .setBlkNumberStart(bestBlkNum)
+                .setBlkNumberEnd(bestBlkNum + 20)
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_admin_VALUE)
+                .put((byte) Message.Funcs.f_getBlockSqlByRange_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_getBlockSqlByRange rslt = Message.rsp_getBlockSqlByRange.parseFrom(stripHeader(rsp));
+            assertEquals(1, rslt.getBlkSqlCount());
+            Message.t_BlockSql blksql = rslt.getBlkSql(0);
+            assertEquals(api.getBestBlock().getNumber(), blksql.getBlockNumber());
+        }   catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_getBlockSqlByRange_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessBlockDetailsRange() {
+        System.out.println("run TestProcessBlockDetailsRange.");
+
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        long bestBlkNum = api.getBestBlock().getNumber();
+
+        Message.req_getBlockDetailsByRange reqBody = Message.req_getBlockDetailsByRange.newBuilder()
+                .setBlkNumberStart(bestBlkNum)
+                .setBlkNumberEnd(bestBlkNum + 20)
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_admin_VALUE)
+                .put((byte) Message.Funcs.f_getBlockDetailsByRange_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_getBlockDetailsByRange rslt = Message.rsp_getBlockDetailsByRange.parseFrom(stripHeader(rsp));
+            assertEquals(1, rslt.getBlkDetailsCount());
+            Message.t_BlockDetail blksql = rslt.getBlkDetails(0);
+            assertEquals(api.getBestBlock().getNumber(), blksql.getBlockNumber());
+        }   catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_getBlockDetailsByRange_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessBlockDetailsLatest() {
+        System.out.println("run TestProcessBlockDetailsLatest.");
+
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Message.req_getBlockDetailsByLatest reqBody = Message.req_getBlockDetailsByLatest.newBuilder()
+                .setCount(20)
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_admin_VALUE)
+                .put((byte) Message.Funcs.f_getBlockDetailsByLatest_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_getBlockDetailsByLatest rslt = Message.rsp_getBlockDetailsByLatest.parseFrom(stripHeader(rsp));
+            assertEquals(20, rslt.getBlkDetailsCount());
+            Message.t_BlockDetail blksql = rslt.getBlkDetails(19);
+            assertEquals(api.getBestBlock().getNumber(), blksql.getBlockNumber());
+        }   catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_getBlockDetailsByLatest_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessBlocksLatest() {
+        System.out.println("run TestProcessBlocksLatest.");
+
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Message.req_getBlocksByLatest reqBody = Message.req_getBlocksByLatest.newBuilder()
+                .setCount(20)
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_admin_VALUE)
+                .put((byte) Message.Funcs.f_getBlocksByLatest_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_getBlocksByLatest rslt = Message.rsp_getBlocksByLatest.parseFrom(stripHeader(rsp));
+            assertEquals(20, rslt.getBlksCount());
+            Message.t_Block blksql = rslt.getBlks(19);
+            assertEquals(api.getBestBlock().getNumber(), blksql.getBlockNumber());
+        }   catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_getBlocksByLatest_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessAccountDetails() {
+        System.out.println("run TestProcessAccountDetails.");
+
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        Address addr = new Address(Keystore.create("testPwd"));
+        AccountManager.inst().unlockAccount(addr, "testPwd", 50000);
+
+        Message.req_getAccountDetailsByAddressList reqBody = Message.req_getAccountDetailsByAddressList.newBuilder()
+                .addAddresses(ByteString.copyFrom(addr.toBytes()))
+                .addAddresses(ByteString.copyFrom(Address.ZERO_ADDRESS().toBytes()))
+                .build();
+
+        byte[] request = ByteBuffer.allocate(reqBody.getSerializedSize() + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_admin_VALUE)
+                .put((byte) Message.Funcs.f_getAccountDetailsByAddressList_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(reqBody.toByteArray())
+                .array();
+
+        byte[] rsp = api.process(request, socketId);
+
+        assertEquals(Message.Retcode.r_success_VALUE, rsp[1]);
+
+        try {
+            Message.rsp_getAccountDetailsByAddressList rslt = Message.rsp_getAccountDetailsByAddressList.parseFrom(stripHeader(rsp));
+            assertEquals(2, rslt.getAccountsCount());
+            Message.t_AccountDetail acctDtl = rslt.getAccounts(0);
+            assertEquals(ByteString.copyFrom(addr.toBytes()), acctDtl.getAddress());
+            assertEquals(ByteString.copyFrom(api.getBalance(addr).toByteArray()), acctDtl.getBalance());
+        }   catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_getAccountDetailsByAddressList_VALUE)
+                .put((byte) 1)
+                .put(hash)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, socketId)[1]);
+
+        api.shutDown();
+    }
+
 }

--- a/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
+++ b/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
@@ -2082,7 +2082,6 @@ public class ApiAion0Tests {
                 .put((byte) Message.Servs.s_admin_VALUE)
                 .put((byte) Message.Funcs.f_getAccountDetailsByAddressList_VALUE)
                 .put((byte) 1)
-                .put((byte) 1)
                 .put(hash)
                 .put(reqBody.toByteArray())
                 .array();

--- a/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
+++ b/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
@@ -13,6 +13,7 @@ import org.aion.zero.impl.blockchain.AionImpl;
 import org.aion.zero.impl.config.CfgAion;
 import org.aion.zero.impl.db.AionRepositoryImpl;
 import org.aion.zero.impl.types.AionBlock;
+import org.aion.zero.impl.types.AionBlockSummary;
 import org.aion.zero.types.AionTransaction;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
@@ -1769,6 +1770,19 @@ public class ApiAion0Tests {
             fail();
         }
 
+        AionRepositoryImpl repo = AionRepositoryImpl.inst();
+        AionBlock parentBlk = impl.getBlockchain().getBestBlock();
+
+        AionTransaction tx = new AionTransaction(repo.getNonce(Address.ZERO_ADDRESS()).toByteArray(),
+                Address.ZERO_ADDRESS(), Address.ZERO_ADDRESS(), BigInteger.ONE.toByteArray(),
+                msg,100000, 100000);
+        tx.sign(new ECKeyEd25519());
+
+        AionBlock blk = impl.getAionHub().getBlockchain().createNewBlock(parentBlk,
+                Collections.singletonList(tx), false);
+
+        api.onBlock((AionBlockSummary) impl.getAionHub().getBlockchain().add(blk));
+
         request = ByteBuffer.allocate(msg.length + REQ_HEADER_NOHASH_LEN + hash.length).put(api.getApiVersion())
                 .put((byte) Message.Servs.s_hb_VALUE)
                 .put((byte) Message.Funcs.f_eventRegister_VALUE)
@@ -2068,6 +2082,7 @@ public class ApiAion0Tests {
                 .put((byte) Message.Servs.s_admin_VALUE)
                 .put((byte) Message.Funcs.f_getAccountDetailsByAddressList_VALUE)
                 .put((byte) 1)
+                .put((byte) 1)
                 .put(hash)
                 .put(reqBody.toByteArray())
                 .array();
@@ -2097,5 +2112,4 @@ public class ApiAion0Tests {
 
         api.shutDown();
     }
-
 }

--- a/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
+++ b/modApiServer/test/org/aion/api/server/pb/ApiAion0Tests.java
@@ -1,0 +1,110 @@
+package org.aion.api.server.pb;
+
+import org.aion.zero.impl.blockchain.AionImpl;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ApiAion0Tests {
+
+    byte[] msg;
+    int requestSize;
+
+    public ApiAion0Tests() {
+        msg = "test message".getBytes();
+        requestSize = msg.length + 3;
+    }
+
+    @Test
+    public void TestCreate() {
+        System.out.println("run TestCreate.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+        api.shutDown();
+    }
+
+    @Test
+    public void TestHeartBeatMsg() {
+        System.out.println("run TestHeartBeatMsg.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        byte[] msg = ByteBuffer.allocate(api.getApiHeaderLen()).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE).array();
+        assertTrue(ApiAion0.heartBeatMsg(msg));
+        assertFalse(ApiAion0.heartBeatMsg(null));
+
+        msg[0] = 0;
+        assertFalse(ApiAion0.heartBeatMsg(msg));
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessProtocolVersion() {
+        System.out.println("run TestProcessProtocolVersion.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        byte[] request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_net_VALUE)
+                .put((byte) Message.Funcs.f_protocolVersion_VALUE)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_success_VALUE, api.process(request, null)[1]);
+
+        request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_protocolVersion_VALUE)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, null)[1]);
+
+
+        api.shutDown();
+    }
+
+    @Test
+    public void TestProcessMinerAddress() {
+        System.out.println("run TestProcessMinerAddress.");
+        AionImpl impl = AionImpl.inst();
+        ApiAion0 api = new ApiAion0(impl);
+
+        byte[] request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_wallet_VALUE)
+                .put((byte) Message.Funcs.f_minerAddress_VALUE)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_success_VALUE, api.process(request, null)[1]);
+
+        request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+                .put((byte) Message.Servs.s_hb_VALUE)
+                .put((byte) Message.Funcs.f_minerAddress_VALUE)
+                .put(msg).array();
+        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, null)[1]);
+
+        api.shutDown();
+    }
+//
+//    @Test
+//    public void TestProcessContractDeploy() {
+//        System.out.println("run TestProcessContractDeploy.");
+//        AionImpl impl = AionImpl.inst();
+//        ApiAion0 api = new ApiAion0(impl);
+//
+//        byte[] request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+//                .put((byte) Message.Servs.s_tx_VALUE)
+//                .put((byte) Message.Funcs.f_contractDeploy_VALUE)
+//                .put(msg).array();
+//        assertEquals(Message.Retcode.r_success_VALUE, api.process(request, null)[1]);
+//
+//        request = ByteBuffer.allocate(requestSize).put(api.getApiVersion())
+//                .put((byte) Message.Servs.s_hb_VALUE)
+//                .put((byte) Message.Funcs.f_contractDeploy_VALUE)
+//                .put(msg).array();
+//        assertEquals(Message.Retcode.r_fail_service_call_VALUE, api.process(request, null)[1]);
+//
+//        api.shutDown();
+//    }
+}


### PR DESCRIPTION
## Description

This PR adds unit tests for the ApiServer module, primarily for the classes Api, APiAion, and ApiAion0.

Also included is a change to ApiAion0.process(). In the f_compile_VALUE case, we should be checking for "compile-error", since that is the error flag introduced by Api.ContractCreateResult.contract_compileSolidity().

Api.java is modified to include 2 new constructors - one for standard purposes, and one only for testing.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Adds the first tests for the ApiServer module, passes the Jenkins build.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [x] Any dependent changes have been made.
