### PR TITLE
APB - 46 Precompiled contract to allow ED25519 signature verification

### DIFF
--- a/modPrecompiled/src/org/aion/precompiled/ContractFactory.java
+++ b/modPrecompiled/src/org/aion/precompiled/ContractFactory.java
@@ -28,6 +28,7 @@ import org.aion.base.vm.IDataWord;
 import org.aion.mcf.core.AccountState;
 import org.aion.mcf.db.IBlockStoreBase;
 import org.aion.precompiled.contracts.ATB.TokenBridgeContract;
+import org.aion.precompiled.contracts.EDVerifyContract;
 import org.aion.vm.ExecutionContext;
 import org.aion.vm.IContractFactory;
 import org.aion.vm.IPrecompiledContract;
@@ -43,7 +44,9 @@ public class ContractFactory implements IContractFactory {
     private static final String TOKEN_BRIDGE = "0000000000000000000000000000000000000000000000000000000000000200";
     private static final String TOKEN_BRIDGE_INITIAL_OWNER = "a008d7b29e8d1f4bfab428adce89dc219c4714b2c6bf3fd1131b688f9ad804aa";
 
-    public ContractFactory(){}
+    private static final String ED_VERIFY = "0000000000000000000000000000000000000000000000000000000000000010";
+
+    private ContractFactory(){}
 
     /**
      * Returns a new pre-compiled contract such that the address of the new contract is address.
@@ -68,6 +71,8 @@ public class ContractFactory implements IContractFactory {
                     return null;
                 
                 return contract;
+            case ED_VERIFY:
+                return new EDVerifyContract();
             default: return null;
         }
     }
@@ -94,5 +99,12 @@ public class ContractFactory implements IContractFactory {
     public static Address getTotalCurrencyContractAddress() {
         return Address.wrap(TOTAL_CURRENCY);
     }
+
+    /**
+     * Returns the address of the EdVerifyContract contract.
+     *
+     * @return the contract address
+     */
+    public static Address getEdVerifyContractAddress() { return Address.wrap(ED_VERIFY); }
 
 }

--- a/modPrecompiled/src/org/aion/precompiled/ContractFactory.java
+++ b/modPrecompiled/src/org/aion/precompiled/ContractFactory.java
@@ -46,7 +46,7 @@ public class ContractFactory implements IContractFactory {
 
     private static final String ED_VERIFY = "0000000000000000000000000000000000000000000000000000000000000010";
 
-    private ContractFactory(){}
+    public ContractFactory(){}
 
     /**
      * Returns a new pre-compiled contract such that the address of the new contract is address.

--- a/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
@@ -1,9 +1,13 @@
 package org.aion.precompiled.contracts;
 
+import org.aion.base.type.Address;
 import org.aion.base.type.IExecutionResult;
 import org.aion.crypto.ed25519.ECKeyEd25519;
+import org.aion.crypto.ed25519.Ed25519Signature;
 import org.aion.vm.ExecutionResult;
 import org.aion.vm.IPrecompiledContract;
+
+import java.util.Arrays;
 
 /**
  * Precompiled contract that verifies a signed message with the Ed25519 signature algorithm
@@ -13,58 +17,58 @@ public class EDVerifyContract implements IPrecompiledContract {
     private final static long COST = 21000L;
 
     /**
-     * TODO: may want return the actual public key/address
-     *
+     * <p>
      * Method takes as input a byte array representing the edverify method parameters represented in hexadecimal
      * from the solidity binary as follows
-     *
-     * edverify(bytes32 hash, bytes32 signature_part_1, bytes32 signature_part_2, bytes32 public_key)
-     *
-     *                                              input
-     *                                                |
-     * | message hash (32 bytes) | signature part 1 (32 bytes) | signature part 2 (32 bytes) | public key (32 bytes) |
-     *
+     * <p>
+     * edverify(bytes32 hash, bytes32 public_key, bytes signature)
+     * <p>
+     * input
+     * |
+     * | message hash (32 bytes) | public key (32 bytes) | signature bytes (64 bytes) |
+     * <p>
      * where
-     *      - message hash = keccak hashed message
-     *      - signature part 1 = first 32 bytes of the ED25519 signature bytes
-     *      - signature part 2 = last 32 bytes of the ED25519 signature bytes
-     *      - public key = public key of the ED25519 key pair
+     * - message hash = keccak 256 hashed message
+     * - public key = public key of the ED25519 key pair
+     * - signature = 64 bytes of the ED25519 signature
      *
-     * @param input The input arguments for the contract.
+     * @param input    The input arguments for the contract.
      * @param nrgLimit The energy limit.
-     * @return byte array of length 1 with the byte set to: 1 if the message was signed with the public key of the account
-     * identified with the public key,
-     *                                                      0 otherwise
+     * @return byte array of length 32 containing: the address of the account that signed the message  if the message was
+     *                                              signed with the public key of the account sent as a parameter
+     * <p>
+     *                                              ZERO_ADDRESS 32 byte array of 0 otherwise
      */
     @Override
     public IExecutionResult execute(byte[] input, long nrgLimit) {
-        byte[] result = new byte[1];
-
         if (COST > nrgLimit) {
-            result[0] = (byte) 0;
-            return new ExecutionResult(ExecutionResult.ResultCode.OUT_OF_NRG, 0, result);
+            return new ExecutionResult(ExecutionResult.ResultCode.OUT_OF_NRG, 0, Address.ZERO_ADDRESS().toBytes());
         }
         byte[] msg = new byte[32];
-        byte[] sig = new byte[64];
         byte[] pubKey = new byte[32];
+        byte[] sig = new byte[64];
 
         try {
             System.arraycopy(input, 0, msg, 0, 32);
-            System.arraycopy(input, 32, sig, 0, 64);
-            System.arraycopy(input, 96, pubKey, 0, 32);
+            System.arraycopy(input, 32, pubKey, 0, 32);
+            System.arraycopy(input, 64, sig, 0, 64);
         } catch (Exception e) {
+            //TODO: Logging ?
             System.out.println("Invalid input. Check if size is correct: " + e.getMessage());
-            result[0] = (byte) 0;
-            return new ExecutionResult(ExecutionResult.ResultCode.INTERNAL_ERROR, 0, result);
+            return new ExecutionResult(ExecutionResult.ResultCode.INTERNAL_ERROR, 0, Address.ZERO_ADDRESS().toBytes());
         }
 
         try {
             boolean verify = ECKeyEd25519.verify(msg, sig, pubKey);
-            result[0] = verify ? (byte) 1 : (byte) 0;
-            return new ExecutionResult(ExecutionResult.ResultCode.SUCCESS, nrgLimit - COST, result);
+            if (verify) {
+                Ed25519Signature signature = new Ed25519Signature(pubKey, sig);
+                byte[] result = Arrays.copyOf(signature.getAddress(), Address.ADDRESS_LEN);
+                return new ExecutionResult(ExecutionResult.ResultCode.SUCCESS, nrgLimit - COST, result);
+            } else {
+                return new ExecutionResult(ExecutionResult.ResultCode.SUCCESS, nrgLimit - COST, Address.ZERO_ADDRESS().toBytes());
+            }
         } catch (Throwable e) {
-            result[0] = (byte) 0;
-            return new ExecutionResult(ExecutionResult.ResultCode.FAILURE, 0, result);
+            return new ExecutionResult(ExecutionResult.ResultCode.FAILURE, 0, Address.ZERO_ADDRESS().toBytes());
         }
     }
 }

--- a/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
@@ -1,0 +1,44 @@
+package org.aion.precompiled.contracts;
+
+import org.aion.base.type.IExecutionResult;
+import org.aion.base.util.Hex;
+import org.aion.crypto.ed25519.ECKeyEd25519;
+import org.aion.vm.ExecutionResult;
+import org.aion.vm.IPrecompiledContract;
+
+public class EDVerifyContract implements IPrecompiledContract {
+    // set to a default cost for now, this will need to be adjusted
+    private final static long COST = 21000L;
+
+    @Override
+    public IExecutionResult execute(byte[] input, long nrgLimit) {
+        if (COST > nrgLimit) {
+            return new ExecutionResult(ExecutionResult.ResultCode.OUT_OF_NRG, 0);
+        }
+        byte[] msg = new byte[32];
+        byte[] sig = new byte[64];
+        byte[] pubKey = new byte[32];
+
+        System.arraycopy(input, 0, msg, 0, 32);
+        System.arraycopy(input, 32, sig, 0, 64);
+        System.arraycopy(input, 96, pubKey, 0, 32);
+
+        //TODO: may need to remove after end-to-end test
+        try {
+            System.out.println("EDVERIFY Message: " + Hex.toHexString(msg));
+            System.out.println("EDVERIFY Sig: " + Hex.toHexString(sig));
+            System.out.println("EDVERIFY PubKey: " + Hex.toHexString(pubKey));
+        } catch (Exception e) {
+            System.out.println("could not get hex string: " + e.getMessage());
+        }
+
+        try {
+            boolean verify = ECKeyEd25519.verify(msg, sig, pubKey);
+            byte[] result = new byte[1];
+            result[0] = verify ? (byte)1 : (byte)0;
+            return new ExecutionResult(ExecutionResult.ResultCode.SUCCESS, nrgLimit - COST, result);
+        } catch (Throwable e) {
+            return new ExecutionResult(ExecutionResult.ResultCode.INTERNAL_ERROR, 0);
+        }
+    }
+}

--- a/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
@@ -1,44 +1,70 @@
 package org.aion.precompiled.contracts;
 
 import org.aion.base.type.IExecutionResult;
-import org.aion.base.util.Hex;
 import org.aion.crypto.ed25519.ECKeyEd25519;
 import org.aion.vm.ExecutionResult;
 import org.aion.vm.IPrecompiledContract;
 
+/**
+ * Precompiled contract that verifies a signed message with the Ed25519 signature algorithm
+ */
 public class EDVerifyContract implements IPrecompiledContract {
     // set to a default cost for now, this will need to be adjusted
     private final static long COST = 21000L;
 
+    /**
+     * TODO: may want return the actual public key/address
+     *
+     * Method takes as input a byte array representing the edverify method parameters represented in hexadecimal
+     * from the solidity binary as follows
+     *
+     * edverify(bytes32 hash, bytes32 signature_part_1, bytes32 signature_part_2, bytes32 public_key)
+     *
+     *                                              input
+     *                                                |
+     * | message hash (32 bytes) | signature part 1 (32 bytes) | signature part 2 (32 bytes) | public key (32 bytes) |
+     *
+     * where
+     *      - message hash = keccak hashed message
+     *      - signature part 1 = first 32 bytes of the ED25519 signature bytes
+     *      - signature part 2 = last 32 bytes of the ED25519 signature bytes
+     *      - public key = public key of the ED25519 key pair
+     *
+     * @param input The input arguments for the contract.
+     * @param nrgLimit The energy limit.
+     * @return byte array of length 1 with the byte set to: 1 if the message was signed with the public key of the account
+     * identified with the public key,
+     *                                                      0 otherwise
+     */
     @Override
     public IExecutionResult execute(byte[] input, long nrgLimit) {
+        byte[] result = new byte[1];
+
         if (COST > nrgLimit) {
-            return new ExecutionResult(ExecutionResult.ResultCode.OUT_OF_NRG, 0);
+            result[0] = (byte) 0;
+            return new ExecutionResult(ExecutionResult.ResultCode.OUT_OF_NRG, 0, result);
         }
         byte[] msg = new byte[32];
         byte[] sig = new byte[64];
         byte[] pubKey = new byte[32];
 
-        System.arraycopy(input, 0, msg, 0, 32);
-        System.arraycopy(input, 32, sig, 0, 64);
-        System.arraycopy(input, 96, pubKey, 0, 32);
-
-        //TODO: may need to remove after end-to-end test
         try {
-            System.out.println("EDVERIFY Message: " + Hex.toHexString(msg));
-            System.out.println("EDVERIFY Sig: " + Hex.toHexString(sig));
-            System.out.println("EDVERIFY PubKey: " + Hex.toHexString(pubKey));
+            System.arraycopy(input, 0, msg, 0, 32);
+            System.arraycopy(input, 32, sig, 0, 64);
+            System.arraycopy(input, 96, pubKey, 0, 32);
         } catch (Exception e) {
-            System.out.println("could not get hex string: " + e.getMessage());
+            System.out.println("Invalid input. Check if size is correct: " + e.getMessage());
+            result[0] = (byte) 0;
+            return new ExecutionResult(ExecutionResult.ResultCode.INTERNAL_ERROR, 0, result);
         }
 
         try {
             boolean verify = ECKeyEd25519.verify(msg, sig, pubKey);
-            byte[] result = new byte[1];
-            result[0] = verify ? (byte)1 : (byte)0;
+            result[0] = verify ? (byte) 1 : (byte) 0;
             return new ExecutionResult(ExecutionResult.ResultCode.SUCCESS, nrgLimit - COST, result);
         } catch (Throwable e) {
-            return new ExecutionResult(ExecutionResult.ResultCode.INTERNAL_ERROR, 0);
+            result[0] = (byte) 0;
+            return new ExecutionResult(ExecutionResult.ResultCode.FAILURE, 0, result);
         }
     }
 }

--- a/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
@@ -1,0 +1,116 @@
+package org.aion.precompiled.contracts;
+
+import org.aion.base.type.Address;
+import org.aion.base.type.IExecutionResult;
+import org.aion.crypto.ECKey;
+import org.aion.crypto.ECKeyFac;
+import org.aion.crypto.HashUtil;
+import org.aion.crypto.ISignature;
+import org.aion.mcf.vm.types.DataWord;
+import org.aion.precompiled.ContractFactory;
+import org.aion.vm.*;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class EDVerifyContractTest {
+
+    private byte[] txHash = RandomUtils.nextBytes(32);
+    private Address origin = Address.wrap(RandomUtils.nextBytes(32));
+    private Address caller = origin;
+
+    private Address blockCoinbase = Address.wrap(RandomUtils.nextBytes(32));
+    private long blockNumber = 1;
+    private long blockTimestamp = System.currentTimeMillis() / 1000;
+    private long blockNrgLimit = 5000000;
+    private DataWord blockDifficulty = new DataWord(0x100000000L);
+
+    private DataWord nrgPrice;
+    private long nrgLimit;
+    private DataWord callValue;
+    private byte[] callData;
+
+    private int depth = 0;
+    private int kind = ExecutionContext.CREATE;
+    private int flags = 0;
+
+    private TransactionResult txResult;
+
+    @Before
+    public void setup() {
+        nrgPrice = DataWord.ONE;
+        nrgLimit = 20000;
+        callValue = DataWord.ZERO;
+        callData = new byte[0];
+        txResult = new TransactionResult();
+    }
+
+    @Test
+    public void shouldReturnSuccessTestingWith256() {
+        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
+        ECKey ecKey = ECKeyFac.inst().create();
+        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+
+
+        byte[] pubKey = ecKey.getPubKey();
+
+        byte[] data = "Our first test in AION1234567890".getBytes();
+
+        HashUtil.setType(HashUtil.H256Type.KECCAK_256);
+        byte[] hashedMessage = HashUtil.h256(data);
+
+        ISignature signature = ecKey.sign(hashedMessage);
+
+        byte[] input = new byte[128];
+        System.arraycopy(hashedMessage, 0, input, 0, 32);
+        System.arraycopy(signature.getSignature(), 0, input, 32, 64);
+        System.arraycopy(pubKey, 0, input, 96, 32);
+
+
+        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
+                nrgLimit, callValue,
+                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
+                blockDifficulty);
+        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
+
+        IExecutionResult result = contract.execute(input, 21000L);
+        assertThat(result.getOutput()[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldFailIfNotEnoughEnergy() {
+        nrgPrice = DataWord.ONE;
+        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
+        ECKey ecKey = ECKeyFac.inst().create();
+        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+
+
+        byte[] pubKey = ecKey.getPubKey();
+
+        byte[] data = "Our first test in AION1234567890".getBytes();
+
+        HashUtil.setType(HashUtil.H256Type.KECCAK_256);
+        byte[] hashedMessage = HashUtil.h256(data);
+
+        ISignature signature = ecKey.sign(hashedMessage);
+
+        byte[] input = new byte[128];
+        System.arraycopy(hashedMessage, 0, input, 0, 32);
+        System.arraycopy(signature.getSignature(), 0, input, 32, 64);
+        System.arraycopy(pubKey, 0, input, 96, 32);
+
+
+        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
+                nrgLimit, callValue,
+                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
+                blockDifficulty);
+        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
+
+        IExecutionResult result = contract.execute(input, 10000L);
+        assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.OUT_OF_NRG.toInt());
+    }
+
+}

--- a/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
@@ -40,6 +40,7 @@ public class EDVerifyContractTest {
     private ECKey ecKey;
     private byte[] hashedMessage;
     private ISignature signature;
+    private IPrecompiledContract contract;
 
     @BeforeClass
     public static void beforeClass() {
@@ -55,9 +56,8 @@ public class EDVerifyContractTest {
     public void shouldReturnSuccessAnd1IfTheSignatureIsValid() {
         byte[] input = setupInput(INPUT_BUFFER_LENGTH);
 
-        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
-
         IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
+
         assertThat(result.getOutput()).isEqualTo(ecKey.getAddress());
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.SUCCESS.toInt());
     }
@@ -67,9 +67,8 @@ public class EDVerifyContractTest {
         byte[] input = setupInput(INPUT_BUFFER_LENGTH);
         input[33] = 0;
 
-        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
-
         IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
+
         assertThat(result.getOutput()).isEqualTo(Address.ZERO_ADDRESS().toBytes());
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.SUCCESS.toInt());
     }
@@ -78,9 +77,8 @@ public class EDVerifyContractTest {
     public void shouldFailureAnd0IfInputIsNotValid() {
         byte[] input = setupInput(127);
 
-        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
-
         IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
+
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.INTERNAL_ERROR.toInt());
         assertThat(result.getOutput()).isEqualTo(Address.ZERO_ADDRESS().toBytes());
     }
@@ -89,9 +87,8 @@ public class EDVerifyContractTest {
     public void shouldReturnOutOfEnergyAnd0IfNotEnoughEnergy() {
         byte[] input = setupInput(INPUT_BUFFER_LENGTH);
 
-        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
-
         IExecutionResult result = contract.execute(input, INVALID_NRG_LIMIT);
+
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.OUT_OF_NRG.toInt());
         assertThat(result.getOutput()).isEqualTo(Address.ZERO_ADDRESS().toBytes());
     }
@@ -110,6 +107,8 @@ public class EDVerifyContractTest {
                 nrgLimit, callValue,
                 callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
                 blockDifficulty);
+        ContractFactory factory = new ContractFactory();
+        contract = factory.getPrecompiledContract(ctx, null);
 
         ecKey = ECKeyFac.inst().create();
         ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426f" +

--- a/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
@@ -49,18 +49,15 @@ public class EDVerifyContractTest {
     }
 
     @Test
-    public void shouldReturnSuccessTestingWith256() {
+    public void shouldReturnSuccessAnd1IfTheSignatureIsValid() {
         ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
         ECKey ecKey = ECKeyFac.inst().create();
         ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
 
-
         byte[] pubKey = ecKey.getPubKey();
-
-        byte[] data = "Our first test in AION1234567890".getBytes();
-
-        HashUtil.setType(HashUtil.H256Type.KECCAK_256);
-        byte[] hashedMessage = HashUtil.h256(data);
+        String rawMessage = "This is a message from outer space";
+        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
+        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
 
         ISignature signature = ecKey.sign(hashedMessage);
 
@@ -68,7 +65,6 @@ public class EDVerifyContractTest {
         System.arraycopy(hashedMessage, 0, input, 0, 32);
         System.arraycopy(signature.getSignature(), 0, input, 32, 64);
         System.arraycopy(pubKey, 0, input, 96, 32);
-
 
         ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
                 nrgLimit, callValue,
@@ -81,19 +77,76 @@ public class EDVerifyContractTest {
     }
 
     @Test
-    public void shouldFailIfNotEnoughEnergy() {
+    public void shouldReturnSuccessAnd0IfSignatureIsNotValid() {
+        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
+        ECKey ecKey = ECKeyFac.inst().create();
+        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+
+        byte[] pubKey = ecKey.getPubKey();
+        String rawMessage = "This is a message from outer space";
+        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
+        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
+
+        ISignature signature = ecKey.sign(hashedMessage);
+
+        byte[] input = new byte[128];
+        System.arraycopy(hashedMessage, 0, input, 0, 32);
+        byte[] alteredSig = signature.getSignature();
+        alteredSig[0] = 1;
+        System.arraycopy(alteredSig, 0, input, 32, 64);
+        System.arraycopy(pubKey, 0, input, 96, 32);
+
+        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
+                nrgLimit, callValue,
+                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
+                blockDifficulty);
+        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
+
+        IExecutionResult result = contract.execute(input, 21000L);
+        assertThat(result.getOutput()[0]).isEqualTo(0);
+        assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.SUCCESS.toInt());
+    }
+
+    @Test
+    public void shouldFailureAnd0IfInputIsNotValid() {
+        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
+        ECKey ecKey = ECKeyFac.inst().create();
+        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+
+        byte[] pubKey = ecKey.getPubKey();
+        String rawMessage = "This is a message from outer space";
+        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
+        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
+
+        ISignature signature = ecKey.sign(hashedMessage);
+
+        byte[] input = new byte[127];
+        System.arraycopy(hashedMessage, 0, input, 0, 32);
+        System.arraycopy(signature.getSignature(), 0, input, 32, 63);
+        System.arraycopy(pubKey, 0, input, 95, 32);
+
+        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
+                nrgLimit, callValue,
+                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
+                blockDifficulty);
+        IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
+
+        IExecutionResult result = contract.execute(input, 21000L);
+        assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.INTERNAL_ERROR.toInt());
+        assertThat(result.getOutput()[0]).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnOutOfEnergyAnd0IfNotEnoughEnergy() {
         nrgPrice = DataWord.ONE;
         ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
         ECKey ecKey = ECKeyFac.inst().create();
         ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
 
-
         byte[] pubKey = ecKey.getPubKey();
-
-        byte[] data = "Our first test in AION1234567890".getBytes();
-
-        HashUtil.setType(HashUtil.H256Type.KECCAK_256);
-        byte[] hashedMessage = HashUtil.h256(data);
+        String rawMessage = "This is a message from outer space";
+        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
+        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
 
         ISignature signature = ecKey.sign(hashedMessage);
 
@@ -111,6 +164,7 @@ public class EDVerifyContractTest {
 
         IExecutionResult result = contract.execute(input, 10000L);
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.OUT_OF_NRG.toInt());
+        assertThat(result.getOutput()[0]).isEqualTo(0);
     }
 
 }

--- a/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
@@ -8,9 +8,13 @@ import org.aion.crypto.HashUtil;
 import org.aion.crypto.ISignature;
 import org.aion.mcf.vm.types.DataWord;
 import org.aion.precompiled.ContractFactory;
-import org.aion.vm.*;
+import org.aion.vm.ExecutionContext;
+import org.aion.vm.ExecutionResult;
+import org.aion.vm.IPrecompiledContract;
+import org.aion.vm.TransactionResult;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
@@ -18,153 +22,110 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class EDVerifyContractTest {
 
+    private static final long VALID_NRG_LIMIT = 21000L;
+    private static final long INVALID_NRG_LIMIT = 10000L;
+    private static final int INPUT_BUFFER_LENGTH = 128;
+
     private byte[] txHash = RandomUtils.nextBytes(32);
     private Address origin = Address.wrap(RandomUtils.nextBytes(32));
     private Address caller = origin;
 
     private Address blockCoinbase = Address.wrap(RandomUtils.nextBytes(32));
-    private long blockNumber = 1;
     private long blockTimestamp = System.currentTimeMillis() / 1000;
-    private long blockNrgLimit = 5000000;
     private DataWord blockDifficulty = new DataWord(0x100000000L);
 
-    private DataWord nrgPrice;
-    private long nrgLimit;
-    private DataWord callValue;
-    private byte[] callData;
-
-    private int depth = 0;
     private int kind = ExecutionContext.CREATE;
-    private int flags = 0;
 
-    private TransactionResult txResult;
+    private ExecutionContext ctx;
+
+    private ECKey ecKey;
+    private byte[] hashedMessage;
+    private ISignature signature;
+
+    @BeforeClass
+    public static void beforeClass() {
+        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
+    }
 
     @Before
     public void setup() {
-        nrgPrice = DataWord.ONE;
-        nrgLimit = 20000;
-        callValue = DataWord.ZERO;
-        callData = new byte[0];
-        txResult = new TransactionResult();
+        beforeEach();
     }
 
     @Test
     public void shouldReturnSuccessAnd1IfTheSignatureIsValid() {
-        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
-        ECKey ecKey = ECKeyFac.inst().create();
-        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+        byte[] input = setupInput(INPUT_BUFFER_LENGTH);
 
-        byte[] pubKey = ecKey.getPubKey();
-        String rawMessage = "This is a message from outer space";
-        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
-        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
-
-        ISignature signature = ecKey.sign(hashedMessage);
-
-        byte[] input = new byte[128];
-        System.arraycopy(hashedMessage, 0, input, 0, 32);
-        System.arraycopy(signature.getSignature(), 0, input, 32, 64);
-        System.arraycopy(pubKey, 0, input, 96, 32);
-
-        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
-                nrgLimit, callValue,
-                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
-                blockDifficulty);
         IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
 
-        IExecutionResult result = contract.execute(input, 21000L);
+        IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
         assertThat(result.getOutput()[0]).isEqualTo(1);
     }
 
     @Test
     public void shouldReturnSuccessAnd0IfSignatureIsNotValid() {
-        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
-        ECKey ecKey = ECKeyFac.inst().create();
-        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+        byte[] input = setupInput(INPUT_BUFFER_LENGTH);
+        input[33] = 0;
 
-        byte[] pubKey = ecKey.getPubKey();
-        String rawMessage = "This is a message from outer space";
-        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
-        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
-
-        ISignature signature = ecKey.sign(hashedMessage);
-
-        byte[] input = new byte[128];
-        System.arraycopy(hashedMessage, 0, input, 0, 32);
-        byte[] alteredSig = signature.getSignature();
-        alteredSig[0] = 1;
-        System.arraycopy(alteredSig, 0, input, 32, 64);
-        System.arraycopy(pubKey, 0, input, 96, 32);
-
-        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
-                nrgLimit, callValue,
-                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
-                blockDifficulty);
         IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
 
-        IExecutionResult result = contract.execute(input, 21000L);
+        IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
         assertThat(result.getOutput()[0]).isEqualTo(0);
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.SUCCESS.toInt());
     }
 
     @Test
     public void shouldFailureAnd0IfInputIsNotValid() {
-        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
-        ECKey ecKey = ECKeyFac.inst().create();
-        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+        byte[] input = setupInput(127);
 
-        byte[] pubKey = ecKey.getPubKey();
-        String rawMessage = "This is a message from outer space";
-        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
-        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
-
-        ISignature signature = ecKey.sign(hashedMessage);
-
-        byte[] input = new byte[127];
-        System.arraycopy(hashedMessage, 0, input, 0, 32);
-        System.arraycopy(signature.getSignature(), 0, input, 32, 63);
-        System.arraycopy(pubKey, 0, input, 95, 32);
-
-        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
-                nrgLimit, callValue,
-                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
-                blockDifficulty);
         IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
 
-        IExecutionResult result = contract.execute(input, 21000L);
+        IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.INTERNAL_ERROR.toInt());
         assertThat(result.getOutput()[0]).isEqualTo(0);
     }
 
     @Test
     public void shouldReturnOutOfEnergyAnd0IfNotEnoughEnergy() {
-        nrgPrice = DataWord.ONE;
-        ECKeyFac.setType(ECKeyFac.ECKeyType.ED25519);
-        ECKey ecKey = ECKeyFac.inst().create();
-        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426fff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+        byte[] input = setupInput(INPUT_BUFFER_LENGTH);
 
-        byte[] pubKey = ecKey.getPubKey();
-        String rawMessage = "This is a message from outer space";
-        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
-        byte[] hashedMessage = HashUtil.keccak256(message.getBytes());
-
-        ISignature signature = ecKey.sign(hashedMessage);
-
-        byte[] input = new byte[128];
-        System.arraycopy(hashedMessage, 0, input, 0, 32);
-        System.arraycopy(signature.getSignature(), 0, input, 32, 64);
-        System.arraycopy(pubKey, 0, input, 96, 32);
-
-
-        ExecutionContext ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
-                nrgLimit, callValue,
-                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
-                blockDifficulty);
         IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
 
-        IExecutionResult result = contract.execute(input, 10000L);
+        IExecutionResult result = contract.execute(input, INVALID_NRG_LIMIT);
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.OUT_OF_NRG.toInt());
         assertThat(result.getOutput()[0]).isEqualTo(0);
     }
 
+    private void beforeEach() {
+        DataWord nrgPrice = DataWord.ONE;
+        long nrgLimit = 20000;
+        DataWord callValue = DataWord.ZERO;
+        byte[] callData = new byte[0];
+
+        long blockNumber = 1;
+        long blockNrgLimit = 5000000;
+        int depth = 0;
+        int flags = 0;
+        ctx = new ExecutionContext(txHash, ContractFactory.getEdVerifyContractAddress(), origin, caller, nrgPrice,
+                nrgLimit, callValue,
+                callData, depth, kind, flags, blockCoinbase, blockNumber, blockTimestamp, blockNrgLimit,
+                blockDifficulty);
+
+        ecKey = ECKeyFac.inst().create();
+        ecKey = ecKey.fromPrivate(Hex.decode("5a90d8e67da5d1dfbf17916ae83bae04ef334f53ce8763932eba2c1116a62426f" +
+                "ff4317ae351bda5e4fa24352904a9366d3a89e38d1ffa51498ba9acfbc65724"));
+
+        String rawMessage = "This is a message from outer space";
+        String message = "\u0019Aion Signed Message:\n" + rawMessage.length() + rawMessage;
+        hashedMessage = HashUtil.keccak256(message.getBytes());
+        signature = ecKey.sign(hashedMessage);
+    }
+
+    private byte[] setupInput(int length) {
+        byte[] input = new byte[length];
+        System.arraycopy(hashedMessage, 0, input, 0, 32);
+        System.arraycopy(signature.getSignature(), 0, input, 32, 64);
+        System.arraycopy(ecKey.getPubKey(), 0, input, 96, (length == 128) ? 32 : 31);
+        return input;
+    }
 }

--- a/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
@@ -11,7 +11,6 @@ import org.aion.precompiled.ContractFactory;
 import org.aion.vm.ExecutionContext;
 import org.aion.vm.ExecutionResult;
 import org.aion.vm.IPrecompiledContract;
-import org.aion.vm.TransactionResult;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -59,7 +58,8 @@ public class EDVerifyContractTest {
         IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
 
         IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
-        assertThat(result.getOutput()[0]).isEqualTo(1);
+        assertThat(result.getOutput()).isEqualTo(ecKey.getAddress());
+        assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.SUCCESS.toInt());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class EDVerifyContractTest {
         IPrecompiledContract contract = ContractFactory.getPrecompiledContract(ctx, null);
 
         IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
-        assertThat(result.getOutput()[0]).isEqualTo(0);
+        assertThat(result.getOutput()).isEqualTo(Address.ZERO_ADDRESS().toBytes());
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.SUCCESS.toInt());
     }
 
@@ -82,7 +82,7 @@ public class EDVerifyContractTest {
 
         IExecutionResult result = contract.execute(input, VALID_NRG_LIMIT);
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.INTERNAL_ERROR.toInt());
-        assertThat(result.getOutput()[0]).isEqualTo(0);
+        assertThat(result.getOutput()).isEqualTo(Address.ZERO_ADDRESS().toBytes());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class EDVerifyContractTest {
 
         IExecutionResult result = contract.execute(input, INVALID_NRG_LIMIT);
         assertThat(result.getCode()).isEqualTo(ExecutionResult.ResultCode.OUT_OF_NRG.toInt());
-        assertThat(result.getOutput()[0]).isEqualTo(0);
+        assertThat(result.getOutput()).isEqualTo(Address.ZERO_ADDRESS().toBytes());
     }
 
     private void beforeEach() {
@@ -124,8 +124,8 @@ public class EDVerifyContractTest {
     private byte[] setupInput(int length) {
         byte[] input = new byte[length];
         System.arraycopy(hashedMessage, 0, input, 0, 32);
-        System.arraycopy(signature.getSignature(), 0, input, 32, 64);
-        System.arraycopy(ecKey.getPubKey(), 0, input, 96, (length == 128) ? 32 : 31);
+        System.arraycopy(ecKey.getPubKey(), 0, input, 32, 32);
+        System.arraycopy(signature.getSignature(), 0, input, 64, (length == 128) ? 64 : 63);
         return input;
     }
 }


### PR DESCRIPTION
## Description

This adds a new precompiled contract that validates a if a message was signed by a specific account.
```
     * input
     * |
     * | message hash (32 bytes) | public key (32 bytes) | signature bytes (64 bytes) |
     * <p>
     * where
     * - message hash = keccak 256 hashed message
     * - public key = public key of the ED25519 key pair
     * - signature = 64 bytes of the ED25519 signature
```
**Important**: There is **NO solidity** support for this functionality to be mapped to a function due to the limitations of the `aion_fastvm`.

## Type of change

- [ ] Bug fix.
- [x] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

* `EDVerifyContractTest.java`

## Verification

- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
