### PR TITLE
jlink fix for undertow + suppress unnecessary warnings

### DIFF
--- a/aion.sh
+++ b/aion.sh
@@ -38,11 +38,15 @@ ARG=$@
 chmod +x ./rt/bin/*
 
 # prepare jvm params
-# use default xms if not set
+# default to minimum 4gb heap if Xms not set.
 JAVA_OPTS="$JAVA_OPTS"
 if [[ ! ${JAVA_OPTS} = *"-Xms"* ]]; then
-  JAVA_OPTS="-Xms4g"
+  JAVA_OPTS+=" -Xms4g"
 fi
+
+# to suppress illegal reflective access warning out of xnio
+# (we depend on xnio transitively via undertow-core)
+JAVA_OPTS+=" --add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
 
 ####### WATCHGUARD IMPLEMENTATION #######
 #				    	#

--- a/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
@@ -110,7 +110,7 @@ public class NanoRpcServer extends RpcServer {
 
             server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
 
-            LOG.info("<rpc-server - (NANO) started on {}:{}>", hostName, port);
+            LOG.info("<rpc-server - (NANO) started on {}://{}:{}>", sslEnabled ? "https" : "http", hostName, port);
         } catch (Exception e) {
             LOG.error("<rpc-server - failed bind on {}:{}>", hostName, port);
             LOG.error("<rpc-server - " + e.getMessage() + ">");

--- a/modApiServer/src/org/aion/api/server/http/undertow/UndertowRpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/UndertowRpcServer.java
@@ -155,7 +155,7 @@ public class UndertowRpcServer extends RpcServer {
             server = undertowBuilder.build();
             server.start();
 
-            LOG.info("<rpc-server - (UNDERTOW) started on {}:{}>", hostName, port);
+            LOG.info("<rpc-server - (UNDERTOW) started on {}://{}:{}>", sslEnabled ? "https" : "http", hostName, port);
         } catch (Exception e) {
             LOG.error("<rpc-server - failed bind on {}:{}>", hostName, port);
             LOG.error("<rpc-server - " + e.getMessage() + ">");

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -7,9 +7,7 @@
 			<!--boolean, enable/disable cross origin requests (browser enforced)-->
 			<cors-enabled>false</cors-enabled>
 			<!--comma-separated list, APIs available: web3,net,debug,personal,eth,stratum-->
-			<apis-enabled>web3,eth,personal,stratum</apis-enabled>
-			<!--size of thread pool allocated for rpc requests-->
-			<threads>1</threads>
+			<apis-enabled>web3,eth,personal,stratum,ops</apis-enabled>
 		</rpc>
 		<java active="true" ip="127.0.0.1" port="8547"></java>
 		<nrg-recommendation>
@@ -77,7 +75,7 @@
 		<log-file>true</log-file>
 		<!--Sets the physical location on disk where log files will be stored.-->
 		<log-path>log</log-path>
-		<ROOT>INFO</ROOT>
+		<ROOT>WARN</ROOT>
 		<GEN>INFO</GEN>
 		<VM>ERROR</VM>
 		<SYNC>INFO</SYNC>

--- a/modLogger/src/org/aion/log/AionLoggerFactory.java
+++ b/modLogger/src/org/aion/log/AionLoggerFactory.java
@@ -98,11 +98,11 @@ public class AionLoggerFactory {
             String modName = mod.name().toUpperCase();
             String modLevel = moduleToLevelMap.get(modName);
             if (modLevel != null) {
-                // if we can't translate log-level for some reason, default to INFO
-                Level level = Level.toLevel(modLevel, Level.INFO);
+                // if we can't translate log-level for some reason, default to WARN
+                Level level = Level.toLevel(modLevel, Level.WARN);
                 modules.put(mod, level);
             } else {
-                modules.put(mod, Level.INFO);
+                modules.put(mod, Level.WARN);
             }
         }
 

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -54,7 +54,7 @@ public final class CfgApiRpc {
         // using a strings here for the following 2 properties instead of referencing the associated enum value
         // since don't want to add dependency to modApiServer just for this
         this.vendor = "undertow";
-        this.enabled = new ArrayList<>(Arrays.asList("web3", "eth", "personal", "stratum"));
+        this.enabled = new ArrayList<>(Arrays.asList("web3", "eth", "personal", "stratum", "ops"));
 
         this.ssl = new CfgSsl();
     }

--- a/modMcf/src/org/aion/mcf/config/CfgLog.java
+++ b/modMcf/src/org/aion/mcf/config/CfgLog.java
@@ -44,7 +44,7 @@ public class CfgLog {
 
     public CfgLog() {
         modules = new HashMap<>();
-        modules.put(LogEnum.ROOT.name(), LogLevel.INFO.name());
+        modules.put(LogEnum.ROOT.name(), LogLevel.WARN.name());
         modules.put(LogEnum.CONS.name(), LogLevel.INFO.name());
         modules.put(LogEnum.GEN.name(), LogLevel.INFO.name());
         modules.put(LogEnum.VM.name(), LogLevel.ERROR.name());

--- a/script/prepack.sh
+++ b/script/prepack.sh
@@ -20,7 +20,7 @@ fi
 
 # generate aion runtime
 if [ ! -d "$JDK_RT" ]; then
-  $JDK_PATH/bin/jlink --module-path $JDK_PATH/jmods --add-modules java.base,java.xml,java.logging,java.management --output $JDK_RT
+  $JDK_PATH/bin/jlink --module-path $JDK_PATH/jmods --add-modules java.base,java.xml,java.logging,java.management,jdk.unsupported --output $JDK_RT
   cp $JDK_PATH/bin/jstack $JDK_RT/bin
 fi
 


### PR DESCRIPTION
## Description

* jlink fix for undertow: need to include jdk.unsupported to packaged jre
* turned down default log-level to WARN to reduce verbosity in logs
* added `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED` to suppress illegal access warn from XNIO

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Manual testing.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
