### PR TITLE
aion_gui.sh script bug fix

### DIFF
--- a/aion_gui.sh
+++ b/aion_gui.sh
@@ -1,7 +1,15 @@
 #!/bin/bash 
+JAVA_CMD=java
+if [ -d "./rt" ]; then
+        JAVA_CMD="./rt/bin/java"
+elif [ -d "./pack/rt" ]; then
+        JAVA_CMD="./pack/rt/bin/java"
+elif [ -d "$JAVA_HOME" ]; then
+        JAVA_CMD="$JAVA_HOME/bin/java"
+fi
 
 STORAGE_DIR=${HOME}/.aion
-env EVMJIT="-cache=1" java -Xms4g \
+env EVMJIT="-cache=1" $JAVA_CMD -Xms4g \
     --add-opens=javafx.graphics/javafx.scene.text=ALL-UNNAMED \
     --add-opens=javafx.graphics/com.sun.javafx.text=ALL-UNNAMED \
     --add-opens=java.base/java.nio=ALL-UNNAMED \

--- a/script/prepack.sh
+++ b/script/prepack.sh
@@ -21,7 +21,7 @@ fi
 
 # generate aion runtime
 if [ ! -d "$JDK_RT" ]; then
-  $JDK_PATH/bin/jlink --module-path $JDK_PATH/jmods --add-modules java.base,java.xml,java.logging,java.management,jdk.unsupported,javafx.graphics --output $JDK_RT
+  $JDK_PATH/bin/jlink --module-path $JDK_PATH/jmods --add-modules java.base,java.xml,java.logging,java.management,jdk.unsupported,javafx.graphics,javafx.controls,javafx.base,jdk.sctp,javafx.fxml --output $JDK_RT
   cp $JDK_PATH/bin/jstack $JDK_RT/bin
 fi
 


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Fix the issue of aion_gui.sh using `java` in $PATH instead of in rt/bin
- Also, the jlink command in prepack.sh was missing some of the modules needed by GUI, so fix that too

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Removed JDK 10 from my $PATH so that `java` goes to Ubuntu 16.04's default Java
- Use pack_build to produce the tar.bz2 pack; extract it into a separate directory
- Call aion_gui.sh with -x to get shell debug msgs to see that it picks the correct java (from rt) and that GUI launches

Result: 
```
sergiu@aion-XPS-8930:~/aion-pack/aion$ which java
/usr/bin/java
sergiu@aion-XPS-8930:~/aion-pack/aion$ java -version
openjdk version "1.8.0_181"
OpenJDK Runtime Environment (build 1.8.0_181-8u181-b13-0ubuntu0.16.04.1-b13)
OpenJDK 64-Bit Server VM (build 25.181-b13, mixed mode)
sergiu@aion-XPS-8930:~/aion-pack/aion$ bash -x ./aion_gui.sh 
+ JAVA_CMD=java
+ '[' -d ./rt ']'
+ JAVA_CMD=./rt/bin/java
+ STORAGE_DIR=/home/sergiu/.aion
+ env EVMJIT=-cache=1 ./rt/bin/java -Xms4g --add-opens=javafx.graphics/javafx.scene.text=ALL-UNNAMED --add-opens=javafx.graphics/com.sun.javafx.text=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED -cp './lib/*:./lib/libminiupnp/*:./mod/*:aion_api/pack/modAionApi.jar:aion_api/lib/*' -Dlocal.storage.dir=/home/sergiu/.aion org.aion.AionGraphicalFrontEnd
Starting Aion Kernel GUI v0.1.0
Logger disabled; to enable please check log settings in config.xml

Logger disabled; to enable please check log settings in config.xml

18-08-17 17:03:23.565 INFO  GUI  [api]: Starting UI

```

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
