### PR TITLE
Rpc Server Reliability Upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /.idea/
 /mod*/.idea/
 /mod*/*.iml
+ij-execution.out
 
 # build
 /build/

--- a/modApiServer/src/org/aion/api/server/http/RpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/RpcServer.java
@@ -1,10 +1,12 @@
 package org.aion.api.server.http;
 
 import org.aion.api.server.rpc.RpcProcessor;
-import org.aion.zero.impl.config.CfgAion;
 
 import java.io.File;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public abstract class RpcServer {
 
@@ -20,8 +22,15 @@ public abstract class RpcServer {
     protected String sslCertCanonicalPath;
     protected char[] sslCertPass;
 
-    // want to explicitly force user of this class to check for null value here.
+    protected boolean stuckThreadDetectorEnabled;
+
+    /**
+     * to explicitly force any subclasses to check for null values, access to the following variables is
+     * restricted through protected accessor methods
+     */
     private Integer workerPoolSize;
+    private Integer ioPoolSize;
+    private Integer requestQueueSize;
 
     protected RpcServer(RpcServerBuilder<?> builder) {
         // everything exposed by the builder is immutable, except for the List<String> & char[] sslCertPass
@@ -51,12 +60,18 @@ public abstract class RpcServer {
             //we want to mutate it later ourselves, so store original reference
             sslCertPass = Objects.requireNonNull(builder.sslCertPass);
         }
-        // if worker pool size is null => select best size based on system
+
+        // if worker & io pool size is null => select best size based on system
         workerPoolSize = builder.workerPoolSize;
+        ioPoolSize = builder.ioPoolSize;
+        requestQueueSize = builder.requestQueueSize;
+        stuckThreadDetectorEnabled = builder.stuckThreadDetectorEnabled;
     }
 
-    // want to explicitly force user of this class to check for null value here.
+    // want to explicitly force user of this class to check for null values here.
     protected Optional<Integer> getWorkerPoolSize() { return Optional.ofNullable(workerPoolSize); }
+    protected Optional<Integer> getIoPoolSize() { return Optional.ofNullable(ioPoolSize); }
+    protected Optional<Integer> getRequestQueueSize() { return Optional.ofNullable(requestQueueSize); }
 
     public abstract void start();
     public abstract void stop();

--- a/modApiServer/src/org/aion/api/server/http/RpcServerBuilder.java
+++ b/modApiServer/src/org/aion/api/server/http/RpcServerBuilder.java
@@ -9,6 +9,7 @@ import java.util.Objects;
  * 1. It assumes that false is a reasonable default for sslEnabled and corsEnabled.
  * 2. It assumes empty array for enabledEndpoints is a reasonable default
  * 3. It assumes "*" is a reasonable default for corsOrigin
+ * 4. Any "unset" objects get initialized to null
  */
 public abstract class RpcServerBuilder<T extends RpcServerBuilder<T>> {
 
@@ -27,7 +28,10 @@ public abstract class RpcServerBuilder<T extends RpcServerBuilder<T>> {
     String sslCertPath;
     char[] sslCertPass;
 
-    Integer workerPoolSize;
+    Integer workerPoolSize = null;
+    Integer ioPoolSize = null;
+    Integer requestQueueSize = null;
+    boolean stuckThreadDetectorEnabled = false;
 
     public T setUrl(String hostName, int port) {
         this.hostName = Objects.requireNonNull(hostName);
@@ -67,7 +71,21 @@ public abstract class RpcServerBuilder<T extends RpcServerBuilder<T>> {
 
     public T setWorkerPoolSize(Integer workerPoolSize) {
         this.workerPoolSize = workerPoolSize;
+        return self();
+    }
 
+    public T setIoPoolSize(Integer x) {
+        this.ioPoolSize = x;
+        return self();
+    }
+
+    public T setRequestQueueSize(Integer x) {
+        this.requestQueueSize = x;
+        return self();
+    }
+
+    public T setStuckThreadDetectorEnabled(boolean x) {
+        this.stuckThreadDetectorEnabled = x;
         return self();
     }
 

--- a/modApiServer/src/org/aion/api/server/http/nano/AionHttpd.java
+++ b/modApiServer/src/org/aion/api/server/http/nano/AionHttpd.java
@@ -6,9 +6,7 @@ import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.slf4j.Logger;
 
-import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class AionHttpd extends NanoHTTPD {

--- a/modApiServer/src/org/aion/api/server/http/nano/BoundRunner.java
+++ b/modApiServer/src/org/aion/api/server/http/nano/BoundRunner.java
@@ -1,17 +1,23 @@
 package org.aion.api.server.http.nano;
 
 import fi.iki.elonen.NanoHTTPD;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * Default threading strategy for NanoHTTPD launches a new thread every time.
  * Override that here so we can put an upper limit on the number of active threads using a thread pool.
  */
 public class BoundRunner implements NanoHTTPD.AsyncRunner {
+    private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
+
     private ExecutorService es;
     private final List<NanoHTTPD.ClientHandler> running = Collections.synchronizedList(new ArrayList<>());
 
@@ -34,7 +40,14 @@ public class BoundRunner implements NanoHTTPD.AsyncRunner {
 
     @Override
     public void exec(NanoHTTPD.ClientHandler clientHandler) {
-        es.submit(clientHandler);
-        this.running.add(clientHandler);
+        try {
+            es.submit(clientHandler);
+            this.running.add(clientHandler);
+        } catch (RejectedExecutionException e) {
+            LOG.error("<rpc-server: Could not enqueue task to NANO RPC thread pool due to QUEUE FULL>", e);
+
+            closed(clientHandler);
+            clientHandler.close();
+        }
     }
 }

--- a/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
@@ -33,8 +33,10 @@ import javax.net.ssl.KeyManagerFactory;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class NanoRpcServer extends RpcServer {
     private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
@@ -90,7 +92,7 @@ public class NanoRpcServer extends RpcServer {
     @Override
     public void start() {
         try {
-            /**
+            /*
              * default to cpu_count * 8 threads. java http servers, particularly with the servlet-type processing model
              * (jetty, tomcat, etc.) generally default to 200-1000 count thread pools
              *

--- a/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
@@ -33,23 +33,20 @@ import javax.net.ssl.KeyManagerFactory;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.Optional;
+import java.util.concurrent.*;
 
 public class NanoRpcServer extends RpcServer {
     private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
 
     private AionHttpd server;
     private ExecutorService workers;
-    private static final int REQ_QUEUE_CAPACITY = 200;
 
     private final Map<String, String> CORS_HEADERS = Map.of(
             "Access-Control-Allow-Origin", corsOrigin,
             "Access-Control-Allow-Headers", "origin,accept,content-type",
             "Access-Control-Allow-Credentials", "true",
-            "Access-Control-Allow-Methods", "POST",
+            "Access-Control-Allow-Methods", "POST,OPTIONS",
             "Access-Control-Max-Age", "86400"
     );
 
@@ -93,24 +90,42 @@ public class NanoRpcServer extends RpcServer {
     @Override
     public void start() {
         try {
-            // default to 1 thread to minimize resource consumption by nano http
-            int tCount = 1;
+            /**
+             * default to cpu_count * 8 threads. java http servers, particularly with the servlet-type processing model
+             * (jetty, tomcat, etc.) generally default to 200-1000 count thread pools
+             *
+             * rationale: if the user want's to restrict the worker pool size, they can manually override it
+             */
+            int tCount;
             if (getWorkerPoolSize().isPresent())
                 tCount = getWorkerPoolSize().get();
+            else
+                tCount = Math.max(Runtime.getRuntime().availableProcessors(), 2) * 8;
 
-            // create fixed thread pool of size defined by user
-            workers = new ThreadPoolExecutor(tCount, tCount, 1, TimeUnit.MINUTES,
-                    new ArrayBlockingQueue<>(REQ_QUEUE_CAPACITY), new AionHttpdThreadFactory());
+            // For unbounded queues, LinkedBlockingQueue is ideal, due to it's linked-list based impl.
+            workers = new ThreadPoolExecutor(tCount, tCount, 10, TimeUnit.SECONDS,
+                    new LinkedBlockingQueue<>(), new AionHttpdThreadFactory());
 
             server = new AionHttpd(hostName, port, rpcProcessor, corsEnabled, CORS_HEADERS);
             server.setAsyncRunner(new BoundRunner(workers));
-
+            
             if (this.sslEnabled)
                 makeSecure();
 
             server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
 
             LOG.info("<rpc-server - (NANO) started on {}://{}:{}>", sslEnabled ? "https" : "http", hostName, port);
+
+            LOG.debug("------------------------------------");
+            LOG.debug("NANO RPC Server Started with Options");
+            LOG.debug("------------------------------------");
+            LOG.debug("SSL: {}", sslEnabled ? "Enabled; Certificate = "+sslCertCanonicalPath : "Not Enabled");
+            LOG.debug("CORS: {}", corsEnabled ? "Enabled; Allowed Origins = \""+corsOrigin+"\"" : "Not Enabled");
+            LOG.debug("Worker Thread Count: {}", tCount);
+            LOG.debug("I/O Thread Count: Not Applicable");
+            LOG.debug("Request Queue Size: Unbounded");
+            LOG.debug("------------------------------------");
+
         } catch (Exception e) {
             LOG.error("<rpc-server - failed bind on {}:{}>", hostName, port);
             LOG.error("<rpc-server - " + e.getMessage() + ">");

--- a/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/nano/NanoRpcServer.java
@@ -66,7 +66,7 @@ public class NanoRpcServer extends RpcServer {
         super(builder);
     }
 
-    public void makeSecure() throws Exception {
+    private void makeSecure() throws Exception {
         if (server == null)
             throw new IllegalStateException("Server not instantiated; valid instance required to enable ssl.");
 

--- a/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRootHandler.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRootHandler.java
@@ -6,17 +6,9 @@ import io.undertow.server.handlers.BlockingHandler;
 import io.undertow.server.handlers.RequestDumpingHandler;
 import io.undertow.server.handlers.RequestLimitingHandler;
 import io.undertow.server.handlers.StuckThreadDetectionHandler;
-import io.undertow.util.Headers;
-import io.undertow.util.HttpString;
-import io.undertow.util.Methods;
-import io.undertow.util.StatusCodes;
-import org.aion.api.server.rpc.RpcProcessor;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.slf4j.Logger;
-
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * Created this handler to "collect" all handlers in the chain in one place.

--- a/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRootHandler.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRootHandler.java
@@ -1,0 +1,90 @@
+package org.aion.api.server.http.undertow;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.BlockingHandler;
+import io.undertow.server.handlers.RequestDumpingHandler;
+import io.undertow.server.handlers.RequestLimitingHandler;
+import io.undertow.server.handlers.StuckThreadDetectionHandler;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import org.aion.api.server.rpc.RpcProcessor;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.slf4j.Logger;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Created this handler to "collect" all handlers in the chain in one place.
+ * This is the classical approach to server design (filter request through a bunch of objects that can choose
+ * to either pass the request object to the next handler or respond to the request itself)
+ *
+ * @implNote a possible optimization here would be to use the RequestBufferingHandler
+ *
+ * According to Stuart Douglas (http://lists.jboss.org/pipermail/undertow-dev/2018-July/002224.html):
+ *
+ * "The advantage [of RequestBufferingHandler] is that if you are going to
+ * dispatch to a worker thread then the dispatch does not happen until the
+ * request has been read, thus reducing the amount of time a worker spends
+ * processing the request. Essentially this allows you to take advantage of
+ * non-blocking IO even for applications that use blocking IO, but at the
+ * expense of memory for buffering."
+ *
+ */
+public class AionUndertowRootHandler implements HttpHandler {
+    private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
+
+    // the root handler stores the first reference in the chain of handler references
+    // (therefore we don't have to hold all the downstream references)
+    private final HttpHandler rootHandler;
+
+    public AionUndertowRootHandler(AionUndertowRpcHandler rpcHandler,
+                                   RequestLimitingConfiguration requestLimiting,
+                                   StuckThreadDetectorConfiguration stuckThreadDetector) {
+        /**
+         * Opinion: StuckThreadDetectionHandler should be enabled by default, since in the grand-scheme of things, it's
+         * performance overhead is not too great and it could potentially help us catch implementation bugs in the API.
+         *
+         * See Impl: github.com/undertow-io/undertow/blob/master/core/src/main/java/io/undertow/server/handlers/StuckThreadDetectionHandler.java
+         */
+        HttpHandler thirdHandler;
+        if (stuckThreadDetector.isEnabled()) {
+            thirdHandler = new StuckThreadDetectionHandler(stuckThreadDetector.getTimeoutSeconds(), rpcHandler);
+        } else {
+            thirdHandler = rpcHandler;
+        }
+
+        // Only enable request dumping in TRACE mode
+        HttpHandler secondHandler;
+        if (LOG.isTraceEnabled()) {
+            secondHandler = new RequestDumpingHandler(thirdHandler);
+        } else {
+            secondHandler = thirdHandler;
+        }
+
+        HttpHandler firstHandler;
+        if (requestLimiting.isEnabled()) {
+            /**
+             * @implNote rationale for doing this: request limiting handler is really a last resort for someone
+             * trying to protect their kernel from being dos-ed by limiting compute resources the RPC server can consume.
+             * The maximumConcurrentRequests in this case, are effectively the number of worker threads available.
+             */
+            firstHandler = new RequestLimitingHandler(requestLimiting.getMaxConcurrentConnections(),
+                    requestLimiting.getQueueSize(), secondHandler);
+        } else {
+            firstHandler = secondHandler;
+        }
+
+        // first thing we need to do is dispatch this http request to a worker thread (off the io thread)
+        rootHandler = new BlockingHandler(firstHandler);
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange httpServerExchange) throws Exception {
+        rootHandler.handleRequest(httpServerExchange);
+    }
+}

--- a/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRpcHandler.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRpcHandler.java
@@ -28,7 +28,7 @@ class AionUndertowRpcHandler implements HttpHandler {
     }
 
     @Override
-    public void handleRequest(HttpServerExchange exchange) throws Exception {
+    public void handleRequest(HttpServerExchange exchange) {
         boolean isPost = Methods.POST.equals(exchange.getRequestMethod());
         boolean isOptions = Methods.OPTIONS.equals(exchange.getRequestMethod());
 

--- a/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRpcHandler.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/AionUndertowRpcHandler.java
@@ -1,0 +1,59 @@
+package org.aion.api.server.http.undertow;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import org.aion.api.server.rpc.RpcProcessor;
+
+import java.util.Map;
+
+class AionUndertowRpcHandler implements HttpHandler {
+    private final boolean corsEnabled;
+    private final Map<HttpString, String> corsHeaders;
+    private final RpcProcessor rpcProcessor;
+
+    public AionUndertowRpcHandler(boolean corsEnabled, Map<HttpString, String> corsHeaders, RpcProcessor rpcProcessor) {
+        this.corsEnabled = corsEnabled;
+        this.corsHeaders = corsHeaders;
+        this.rpcProcessor = rpcProcessor;
+    }
+
+    private void addCorsHeaders(HttpServerExchange exchange) {
+        for (Map.Entry<HttpString, String> header: corsHeaders.entrySet()) {
+            exchange.getResponseHeaders().put(header.getKey(), header.getValue());
+        }
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        boolean isPost = Methods.POST.equals(exchange.getRequestMethod());
+        boolean isOptions = Methods.OPTIONS.equals(exchange.getRequestMethod());
+
+        // only support POST & OPTIONS requests
+        if (!isPost && !isOptions) {
+            exchange.setStatusCode(StatusCodes.METHOD_NOT_ALLOWED);
+            exchange.setPersistent(false); // don't need to keep-alive connection in case of error.
+            exchange.endExchange();
+            return;
+        }
+
+        // respond to cors-preflight request
+        if (corsEnabled && isOptions) {
+            addCorsHeaders(exchange);
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+            exchange.getResponseHeaders().put(Headers.CONTENT_LENGTH, "0");
+            exchange.getResponseSender().send("");
+            return;
+        }
+
+        /** respond to rpc call; {@link io.Undertow.BlockingReceiverImpl#receiveFullString} */
+        exchange.getRequestReceiver().receiveFullString((_exchange, body) -> {
+            if (corsEnabled) addCorsHeaders(_exchange);
+            _exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+            _exchange.getResponseSender().send(rpcProcessor.process(body));
+        });
+    }
+}

--- a/modApiServer/src/org/aion/api/server/http/undertow/RequestLimitingConfiguration.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/RequestLimitingConfiguration.java
@@ -1,0 +1,17 @@
+package org.aion.api.server.http.undertow;
+
+public class RequestLimitingConfiguration {
+    private final boolean enabled;
+    private final int maxConcurrentConnections;
+    private final int queueSize;
+
+    public RequestLimitingConfiguration(boolean enabled, int maxConcurrentConnections, int queueSize) {
+        this.enabled = enabled;
+        this.maxConcurrentConnections = maxConcurrentConnections;
+        this.queueSize = queueSize;
+    }
+
+    public boolean isEnabled() { return enabled; }
+    public int getMaxConcurrentConnections() { return maxConcurrentConnections; }
+    public int getQueueSize() { return queueSize; }
+}

--- a/modApiServer/src/org/aion/api/server/http/undertow/StuckThreadDetectorConfiguration.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/StuckThreadDetectorConfiguration.java
@@ -1,0 +1,14 @@
+package org.aion.api.server.http.undertow;
+
+public class StuckThreadDetectorConfiguration {
+    private final boolean enabled;
+    private final int timeoutSeconds;
+
+    public StuckThreadDetectorConfiguration(boolean enabled, int timeoutSeconds) {
+        this.enabled = enabled;
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public boolean isEnabled() { return enabled; }
+    public int getTimeoutSeconds() { return timeoutSeconds; }
+}

--- a/modApiServer/src/org/aion/api/server/http/undertow/UndertowRpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/UndertowRpcServer.java
@@ -4,16 +4,14 @@ import io.undertow.Undertow;
 import io.undertow.io.Receiver;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.server.handlers.BlockingHandler;
-import io.undertow.server.handlers.RequestBufferingHandler;
-import io.undertow.server.handlers.RequestDumpingHandler;
-import io.undertow.server.handlers.StuckThreadDetectionHandler;
+import io.undertow.server.handlers.*;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.StatusCodes;
 import org.aion.api.server.http.RpcServer;
 import org.aion.api.server.http.RpcServerBuilder;
+import org.aion.api.server.rpc.RpcProcessor;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.slf4j.Logger;
@@ -24,18 +22,20 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.util.Map;
+import java.util.Optional;
 
 public class UndertowRpcServer extends RpcServer {
+
     private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
+    private static final int STUCK_THREAD_TIMEOUT_SECONDS = 600; // 10 min
 
     Undertow server;
 
-    private final int STUCK_THREAD_TIMEOUT_SECONDS = 600; // 10 min
     private final Map<HttpString, String> CORS_HEADERS = Map.of(
             HttpString.tryFromString("Access-Control-Allow-Origin"), corsOrigin,
             HttpString.tryFromString("Access-Control-Allow-Headers"), "origin,accept,content-type",
             HttpString.tryFromString("Access-Control-Allow-Credentials"), "true",
-            HttpString.tryFromString("Access-Control-Allow-Methods"), "POST",
+            HttpString.tryFromString("Access-Control-Allow-Methods"), "POST,OPTIONS",
             HttpString.tryFromString("Access-Control-Max-Age"), "86400"
     );
 
@@ -55,59 +55,6 @@ public class UndertowRpcServer extends RpcServer {
         // hook up all the possible loggers defined (now and in future) by this library
         // through our logback logger; this risks missing potentially important debug information from the library
         System.setProperty("org.jboss.logging.provider", "slf4j");
-    }
-
-    private void addCorsHeaders(HttpServerExchange exchange) {
-        if (corsEnabled) {
-            for (Map.Entry<HttpString, String> header: CORS_HEADERS.entrySet()) {
-                exchange.getResponseHeaders().put(header.getKey(), header.getValue());
-            }
-        }
-    }
-
-    private void handleRequest(HttpServerExchange ex0) throws Exception {
-        Receiver.FullStringCallback rpcHandler = (ex3, body) -> {
-            // only support post requests
-            if (!Methods.POST.equals(ex3.getRequestMethod())) {
-                ex3.setStatusCode(StatusCodes.METHOD_NOT_ALLOWED);
-                ex3.endExchange();
-                return;
-            }
-
-            ex3.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
-            addCorsHeaders(ex3);
-            ex3.getResponseSender().send(rpcProcessor.process(body));
-        };
-        HttpHandler corsPreflightHandler = ex1 -> {
-            if (corsEnabled && Methods.OPTIONS.equals(ex1.getRequestMethod())) {
-                ex1.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
-                ex1.getResponseHeaders().put(Headers.CONTENT_LENGTH, "0");
-                addCorsHeaders(ex1);
-                ex1.getResponseSender().send("");
-            } else {
-                new RequestBufferingHandler(ex2 -> ex2.getRequestReceiver().receiveFullString(rpcHandler), 10)
-                        .handleRequest(ex1);
-            }
-        };
-        /**
-         * Opinion: StuckThreadDetectionHandler should be enabled by default, since in the grand-scheme of things, it's
-         * performance overhead is not too great and it could potentially help us catch implementation bugs in the API.
-         * Alternative: Allow the user to enable this from the config?
-         * See Impl:
-         * github.com/undertow-io/undertow/blob/master/core/src/main/java/io/undertow/server/handlers/StuckThreadDetectionHandler.java
-         */
-        StuckThreadDetectionHandler stuckThreadDetectionHandler = new StuckThreadDetectionHandler(STUCK_THREAD_TIMEOUT_SECONDS, corsPreflightHandler);
-
-        // Only enabled if API is in TRACE mode
-        RequestDumpingHandler requestDumpingHandler = new RequestDumpingHandler(stuckThreadDetectionHandler);
-
-        HttpHandler firstHandler;
-        if (LOG.isTraceEnabled()) firstHandler = requestDumpingHandler;
-        else firstHandler = stuckThreadDetectionHandler;
-
-        BlockingHandler blockingHandler = new BlockingHandler(firstHandler);
-
-        blockingHandler.handleRequest(ex0);
     }
 
     private SSLContext sslContext() throws Exception {
@@ -145,17 +92,68 @@ public class UndertowRpcServer extends RpcServer {
             else
                 undertowBuilder.addHttpListener(port, hostName);
 
-            undertowBuilder.setHandler(this::handleRequest);
+            int effectiveIoThreadCount;
+
+            if (getIoPoolSize().isPresent()) {
+                LOG.info("<rpc-server - setting io thread count manually not recommended. recommended io thread pool size: {}>",
+                        Math.max(Runtime.getRuntime().availableProcessors(), 2));
+                undertowBuilder.setIoThreads(getIoPoolSize().get());
+
+                effectiveIoThreadCount = getIoPoolSize().get();
+            } else {
+                /** this number comes from {@link io.undertow.Undertow.Builder#Builder()} */
+                effectiveIoThreadCount = Math.max(Runtime.getRuntime().availableProcessors(), 2);
+            }
+
+            /** used to "remember" Undertow worker-thread count, since no getter exposed in {@link Undertow}. */
+            int effectiveWorkerThreadCount;
 
             if (getWorkerPoolSize().isPresent()) {
-                LOG.info("<rpc-server - setting worker thread count manually not recommended. recommended worker thread-pool size: {}>",
+                LOG.info("<rpc-server - setting worker thread count manually not recommended. recommended worker thread pool size: {}>",
                         Math.max(Runtime.getRuntime().availableProcessors(), 2) * 8);
                 undertowBuilder.setWorkerThreads(getWorkerPoolSize().get());
+
+                effectiveWorkerThreadCount = getWorkerPoolSize().get();
+            } else {
+                /** this number comes from {@link io.undertow.Undertow.Builder#Builder()} */
+                effectiveWorkerThreadCount = Math.max(Runtime.getRuntime().availableProcessors(), 2) * 8;
             }
+
+            StuckThreadDetectorConfiguration stuckThreadDetector =
+                    new StuckThreadDetectorConfiguration(false, STUCK_THREAD_TIMEOUT_SECONDS);
+            if (stuckThreadDetectorEnabled) {
+                stuckThreadDetector =
+                        new StuckThreadDetectorConfiguration(true, STUCK_THREAD_TIMEOUT_SECONDS);
+            }
+
+            RequestLimitingConfiguration requestLimiting =
+                    new RequestLimitingConfiguration(false, -1, 1);
+            boolean isQueueBounded = getRequestQueueSize().isPresent() && getRequestQueueSize().get() > 0;
+            if (isQueueBounded) {
+                requestLimiting = new RequestLimitingConfiguration(true, effectiveWorkerThreadCount,
+                        getRequestQueueSize().get());
+            }
+
+            AionUndertowRpcHandler rpcHandler = new AionUndertowRpcHandler(corsEnabled, CORS_HEADERS, rpcProcessor);
+
+            undertowBuilder.setHandler(new AionUndertowRootHandler(rpcHandler, requestLimiting, stuckThreadDetector));
+
+
             server = undertowBuilder.build();
             server.start();
 
             LOG.info("<rpc-server - (UNDERTOW) started on {}://{}:{}>", sslEnabled ? "https" : "http", hostName, port);
+
+            LOG.debug("----------------------------------------");
+            LOG.debug("UNDERTOW RPC Server Started with Options");
+            LOG.debug("----------------------------------------");
+            LOG.debug("SSL: {}", sslEnabled ? "Enabled; Certificate = "+sslCertCanonicalPath : "Not Enabled");
+            LOG.debug("CORS: {}", corsEnabled ? "Enabled; Allowed Origins = \""+corsOrigin+"\"" : "Not Enabled");
+            LOG.debug("Worker Thread Count: {}", effectiveWorkerThreadCount);
+            LOG.debug("I/O Thread Count: {}", effectiveIoThreadCount);
+            LOG.debug("Request Queue Size: {}", isQueueBounded ? getRequestQueueSize().get() : "Unbounded");
+            LOG.debug("----------------------------------------");
+
         } catch (Exception e) {
             LOG.error("<rpc-server - failed bind on {}:{}>", hostName, port);
             LOG.error("<rpc-server - " + e.getMessage() + ">");

--- a/modApiServer/src/org/aion/api/server/http/undertow/UndertowRpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/undertow/UndertowRpcServer.java
@@ -1,17 +1,9 @@
 package org.aion.api.server.http.undertow;
 
 import io.undertow.Undertow;
-import io.undertow.io.Receiver;
-import io.undertow.server.HttpHandler;
-import io.undertow.server.HttpServerExchange;
-import io.undertow.server.handlers.*;
-import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
-import io.undertow.util.Methods;
-import io.undertow.util.StatusCodes;
 import org.aion.api.server.http.RpcServer;
 import org.aion.api.server.http.RpcServerBuilder;
-import org.aion.api.server.rpc.RpcProcessor;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.slf4j.Logger;
@@ -22,7 +14,6 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.util.Map;
-import java.util.Optional;
 
 public class UndertowRpcServer extends RpcServer {
 

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -65,8 +65,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.aion.api.server.ApiAion;
-import org.aion.api.server.rpc.RpcError;
-import org.aion.api.server.rpc.RpcMsg;
 import org.aion.api.server.types.ArgFltr;
 import org.aion.api.server.types.ArgTxCall;
 import org.aion.api.server.types.Blk;
@@ -314,6 +312,7 @@ public class ApiWeb3Aion extends ApiAion {
     private AionBlock getBlockRaw(int bn) {
         // long bn = this.parseBnOrId(_bnOrId);
         AionBlock nb = this.ac.getBlockchain().getBlockByNumber(bn);
+
         if (nb == null) {
             if (LOG.isDebugEnabled()) LOG.debug("<get-block-raw bn={} err=not-found>", bn);
             return null;
@@ -439,19 +438,20 @@ public class ApiWeb3Aion extends ApiAion {
         String bnOrId = "latest";
         if (!JSONObject.NULL.equals(_bnOrId))
             bnOrId = _bnOrId + "";
-
+        /*
         if (!bnOrId.equalsIgnoreCase("latest")) {
             return new RpcMsg(
                     null,
                     RpcError.INVALID_PARAMS,
                     "Default block parameter temporarily unsupported");
-        }
-        /*
+        }*/
+
         IRepository repo = getRepoByJsonBlockId(bnOrId);
         if (repo == null) // invalid bnOrId
-            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found.");
-        */
-        IRepository repo = this.ac.getRepository();
+            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found for id / block number: "+bnOrId+". " +
+                    "State may have been pruned; please check your db pruning settings in the configuration file.");
+
+        //IRepository repo = this.ac.getRepository();
 
         BigInteger balance = repo.getBalance(address);
         return new RpcMsg(TypeConverter.toJsonHex(balance));
@@ -489,19 +489,20 @@ public class ApiWeb3Aion extends ApiAion {
             return new RpcMsg(
                     null, RpcError.INVALID_PARAMS, "Invalid storageIndex. Must be <= 16 bytes.");
         }
-
+        /*
         if (!bnOrId.equalsIgnoreCase("latest")) {
             return new RpcMsg(
                     null,
                     RpcError.INVALID_PARAMS,
                     "Default block parameter temporarily unsupported");
-        }
-        /*
+        }*/
+
         IRepository repo = getRepoByJsonBlockId(bnOrId);
         if (repo == null) // invalid bnOrId
-            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found.");
-        */
-        IRepository repo = this.ac.getRepository();
+            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found for id / block number: "+bnOrId+". " +
+                    "State may have been pruned; please check your db pruning settings in the configuration file.");
+
+        //IRepository repo = this.ac.getRepository();
 
         @SuppressWarnings("unchecked")
         IDataWord storageValue = repo.getStorageValue(address, key);
@@ -528,19 +529,20 @@ public class ApiWeb3Aion extends ApiAion {
         String bnOrId = "latest";
         if (!JSONObject.NULL.equals(_bnOrId))
             bnOrId = _bnOrId + "";
-
+        /*
         if (!bnOrId.equalsIgnoreCase("latest")) {
             return new RpcMsg(
                     null,
                     RpcError.INVALID_PARAMS,
                     "Default block parameter temporarily unsupported");
-        }
-        /*
+        }*/
+
         IRepository repo = getRepoByJsonBlockId(bnOrId);
         if (repo == null) // invalid bnOrId
-            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found.");
-        */
-        IRepository repo = this.ac.getRepository();
+            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found for id / block number: "+bnOrId+". " +
+                    "State may have been pruned; please check your db pruning settings in the configuration file.");
+
+        //IRepository repo = this.ac.getRepository();
 
         return new RpcMsg(TypeConverter.toJsonHex(repo.getNonce(address)));
     }
@@ -609,20 +611,21 @@ public class ApiWeb3Aion extends ApiAion {
         String bnOrId = "latest";
         if (!JSONObject.NULL.equals(_bnOrId))
             bnOrId = _bnOrId + "";
-
+        /*
         if (!bnOrId.equalsIgnoreCase("latest")) {
             return new RpcMsg(
                     null,
                     RpcError.INVALID_PARAMS,
                     "Default block parameter temporarily unsupported");
-        }
-        /*
+        }*/
+
         IRepository repo = getRepoByJsonBlockId(bnOrId);
         if (repo == null) // invalid bnOrId
-            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found.");
-        */
+            return new RpcMsg(null, RpcError.EXECUTION_ERROR, "Block not found for id / block number: "+bnOrId+". " +
+                    "State may have been pruned; please check your db pruning settings in the configuration file.");
 
-        IRepository repo = this.ac.getRepository();
+        //IRepository repo = this.ac.getRepository();
+
         byte[] code = repo.getCode(address);
         return new RpcMsg(TypeConverter.toJsonHex(code));
     }
@@ -1598,9 +1601,9 @@ public class ApiWeb3Aion extends ApiAion {
         JSONObject rpc = new JSONObject();
         rpc.put("ip", rpcConfig.getIp());
         rpc.put("port", rpcConfig.getPort());
-        rpc.put("corsEnabled", rpcConfig.getCorsEnabled());
-        rpc.put("active", rpcConfig.getActive());
-        rpc.put("maxThread", rpcConfig.getMaxthread());
+        rpc.put("corsEnabled", rpcConfig.isCorsEnabled());
+        rpc.put("active", rpcConfig.isActive());
+        rpc.put("maxThread", rpcConfig.getWorkerThreads());
         rpc.put("sslEnabled", sslConfig.getEnabled());
         rpc.put("sslCert", sslConfig.getCert());
         rpc.put("sslPass", sslConfig.getPass());
@@ -2560,7 +2563,7 @@ public class ApiWeb3Aion extends ApiAion {
     // --------------------------------------------------------------------
     // Helper Functions
     // --------------------------------------------------------------------
-    /*
+
     // potential bug introduced by .getSnapshotTo()
     // comment out until resolved
     private IRepository getRepoByJsonBlockId(String _bnOrId) {
@@ -2573,7 +2576,7 @@ public class ApiWeb3Aion extends ApiAion {
 
         return ac.getRepository().getSnapshotTo(b.getStateRoot());
     }
-    */
+
     private Long parseBnOrId(String _bnOrId) {
         if (_bnOrId == null) return null;
 

--- a/modApiServer/src/org/aion/api/server/rpc/RpcProcessor.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcProcessor.java
@@ -1,5 +1,6 @@
 package org.aion.api.server.rpc;
 
+import com.google.common.base.Stopwatch;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.apache.commons.lang3.StringUtils;
@@ -8,6 +9,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class RpcProcessor {
 
@@ -79,23 +81,17 @@ public class RpcProcessor {
                 else
                     LOG.debug("<request mth=[{}]>", method);
 
-                /**
-                 * Note about using System.nanoTime():
-                 * It's slower (~5x) than using System.currentTimeMillis() based on emperical tests across machines
-                 * and operating systems. But since this only runs in debug mode, it's probably OK?
-                 */
+                // Delegating timing request to Guava's Stopwatch
                 boolean shouldTime = LOG.isDebugEnabled();
-                long t0 = 0L;
-                if (shouldTime) t0 = System.nanoTime();
+                Stopwatch timer = null;
+                if (shouldTime) timer = Stopwatch.createStarted();
                 RpcMsg response = rpc.call(params);
                 if (shouldTime) {
-                    long t1 = System.nanoTime();
-                    LOG.debug("<request mth=[{}] rpc-process time: {}ms>", method, (t1 - t0) / 10e6f);
+                    timer.stop();
+                    LOG.debug("<request mth=[{}] rpc-process time: [{}]>", method, timer.toString());
                 }
 
                 return response.setId(id).toJson();
-
-
 
             } catch (Exception e) {
                 LOG.debug("<rpc-server - internal error [2]>", e);

--- a/modBoot/resource/config.xml
+++ b/modBoot/resource/config.xml
@@ -3,8 +3,8 @@
 	<mode>aion</mode>
 	<id>[NODE-ID-PLACEHOLDER]</id>
 	<api>
+		<!-- rpc config docs: https://github.com/aionnetwork/aion/wiki/JSON-RPC-API-Docs -->
 		<rpc active="true" ip="127.0.0.1" port="8545">
-			<!--boolean, enable/disable cross origin requests (browser enforced)-->
 			<cors-enabled>false</cors-enabled>
 			<!--comma-separated list, APIs available: web3,net,debug,personal,eth,stratum-->
 			<apis-enabled>web3,eth,personal,stratum,ops</apis-enabled>

--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -22,11 +22,6 @@
  */
 package org.aion;
 
-import java.io.Console;
-import java.util.Optional;
-import java.util.ServiceLoader;
-import java.util.function.Consumer;
-
 import org.aion.api.server.http.RpcServer;
 import org.aion.api.server.http.RpcServerBuilder;
 import org.aion.api.server.http.RpcServerVendor;
@@ -50,7 +45,9 @@ import org.aion.zero.impl.cli.Cli;
 import org.aion.zero.impl.config.CfgAion;
 import org.slf4j.Logger;
 
+import java.io.Console;
 import java.util.ServiceLoader;
+import java.util.function.Consumer;
 
 import static org.aion.crypto.ECKeyFac.ECKeyType.ED25519;
 import static org.aion.crypto.HashUtil.H256Type.BLAKE2B_256;
@@ -177,15 +174,19 @@ public class Aion {
         }
 
         RpcServer rpcServer = null;
-        if(cfg.getApi().getRpc().getActive()) {
+        if(cfg.getApi().getRpc().isActive()) {
             CfgApiRpc rpcCfg =  cfg.getApi().getRpc();
 
             Consumer<RpcServerBuilder<? extends RpcServerBuilder<?>>> commonRpcConfig = (rpcBuilder) -> {
                 rpcBuilder.setUrl(rpcCfg.getIp(), rpcCfg.getPort());
-                rpcBuilder.setWorkerPoolSize(rpcCfg.getMaxthread());
                 rpcBuilder.enableEndpoints(rpcCfg.getEnabled());
 
-                if (rpcCfg.getCorsEnabled())
+                rpcBuilder.setWorkerPoolSize(rpcCfg.getWorkerThreads());
+                rpcBuilder.setIoPoolSize(rpcCfg.getIoThreads());
+                rpcBuilder.setRequestQueueSize(rpcCfg.getRequestQueueSize());
+                rpcBuilder.setStuckThreadDetectorEnabled(rpcCfg.isStuckThreadDetectorEnabled());
+
+                if (rpcCfg.isCorsEnabled())
                     rpcBuilder.enableCorsWithOrigin(rpcCfg.getCorsOrigin());
 
                 CfgSsl cfgSsl = rpcCfg.getSsl();

--- a/modLogger/src/org/aion/log/LogEnum.java
+++ b/modLogger/src/org/aion/log/LogEnum.java
@@ -31,10 +31,11 @@ public enum LogEnum {
     GEN, CONS, SYNC, API, VM, NET, DB, EVTMGR, TXPOOL, TX, P2P, ROOT, GUI;
 
     public static boolean contains(String _module) {
-        for (LogEnum module : values())
-            // maybe use equalsIgnoreCase here?
-            if (module.name().equals(_module))
+        for (LogEnum module : values()) {
+            if (module.name().equalsIgnoreCase(_module))
                 return true;
+        }
+
         return false;
     }
 }

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -206,6 +206,10 @@ public final class CfgApiRpc {
 
             Writer strWriter = new StringWriter();
             xmlWriter = output.createXMLStreamWriter(strWriter);
+
+            xmlWriter.writeCharacters("\r\n\t\t");
+            xmlWriter.writeComment("rpc config docs: https://github.com/aionnetwork/aion/wiki/JSON-RPC-API-Docs");
+
             xmlWriter.writeCharacters("\r\n\t\t");
             xmlWriter.writeStartElement("rpc");
 
@@ -213,8 +217,6 @@ public final class CfgApiRpc {
             xmlWriter.writeAttribute("ip", this.ip);
             xmlWriter.writeAttribute("port", this.port + "");
 
-            xmlWriter.writeCharacters("\r\n\t\t\t");
-            xmlWriter.writeComment("boolean, enable/disable cross origin requests (browser enforced)");
             xmlWriter.writeCharacters("\r\n\t\t\t");
             xmlWriter.writeStartElement("cors-enabled");
             xmlWriter.writeCharacters(String.valueOf(this.isCorsEnabled()));

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -22,8 +22,6 @@
  */
 package org.aion.mcf.config;
 
-import com.google.common.base.Objects;
-
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -34,7 +32,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -49,12 +47,18 @@ public final class CfgApiRpc {
         this.port = 8545;
         this.corsEnabled = false;
         this.corsOrigin = "*";
-        this.maxthread = null;
         this.filtersEnabled = true;
         // using a strings here for the following 2 properties instead of referencing the associated enum value
         // since don't want to add dependency to modApiServer just for this
         this.vendor = "undertow";
         this.enabled = new ArrayList<>(Arrays.asList("web3", "eth", "personal", "stratum", "ops"));
+
+        // nulls for the following properties indicates to consumer of these properties
+        // to "choose reasonable defaults"
+        this.workerThreads = null;
+        this.ioThreads = null;
+        this.requestQueueSize = null; // null = unbounded queue size
+        this.stuckThreadDetectorEnabled = true;
 
         this.ssl = new CfgSsl();
     }
@@ -65,10 +69,14 @@ public final class CfgApiRpc {
     private List<String> enabled;
     private boolean corsEnabled;
     private String corsOrigin;
-    private Integer maxthread;
     private boolean filtersEnabled;
     private CfgSsl ssl;
     private String vendor;
+
+    private Integer workerThreads;
+    private Integer ioThreads;
+    private Integer requestQueueSize;
+    private boolean stuckThreadDetectorEnabled;
 
     public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
         // get the attributes
@@ -115,25 +123,63 @@ public final class CfgApiRpc {
                                 e.printStackTrace();
                             }
                             break;
-                        case "threads":
+                        case "worker-threads": {
                             try {
                                 int t = Integer.parseInt(Cfg.readValue(sr));
                                 // filter out negative counts
-                                if (t > 0) this.maxthread = t;
+                                if (t > 0) this.workerThreads = t;
                                 // otherwise, accept default set in constructor
                             } catch (Exception e) {
+                                System.out.println("Illegal value for aion.api.rpc.worker-threads; will select reasonable defaults.");
                                 e.printStackTrace();
                             }
 
                             break;
-                        case "filters-enabled":
+                        }
+                        case "io-threads": {
                             try {
-                                filtersEnabled = Boolean.parseBoolean(Cfg.readValue(sr));
+                                int t = Integer.parseInt(Cfg.readValue(sr));
+                                // filter out negative counts
+                                if (t > 0) this.ioThreads = t;
+                                // otherwise, accept default set in constructor
                             } catch (Exception e) {
-                                System.out.println("failed to read config node: aion.api.rpc.filters-enabled; using preset: " + this.filtersEnabled);
+                                System.out.println("Illegal value for aion.api.rpc.io-threads; will select reasonable defaults.");
+                                e.printStackTrace();
+                            }
+
+                            break;
+                        }
+                        case "request-queue-size": {
+                            try {
+                                int t = Integer.parseInt(Cfg.readValue(sr));
+                                // filter out negative counts
+                                if (t > 0) this.requestQueueSize = t;
+                                // otherwise, accept default set in constructor
+                            } catch (Exception e) {
+                                System.out.println("Illegal value for aion.api.rpc.request-queue-size; will select reasonable defaults.");
+                                e.printStackTrace();
+                            }
+
+                            break;
+                        }
+                        case "stuck-thread-detector-enabled": {
+                            try {
+                                stuckThreadDetectorEnabled = Boolean.parseBoolean(Cfg.readValue(sr));
+                            } catch (Exception e) {
+                                System.out.println("failed to read config node: aion.api.rpc.stuckThreadDetectorEnabled; using preset: " + stuckThreadDetectorEnabled);
                                 e.printStackTrace();
                             }
                             break;
+                        }
+                        case "filters-enabled": {
+                            try {
+                                filtersEnabled = Boolean.parseBoolean(Cfg.readValue(sr));
+                            } catch (Exception e) {
+                                System.out.println("failed to read config node: aion.api.rpc.filters-enabled; using preset: " + filtersEnabled);
+                                e.printStackTrace();
+                            }
+                            break;
+                        }
                         case "ssl":
                             this.ssl.fromXML(sr);
                             break;
@@ -171,7 +217,7 @@ public final class CfgApiRpc {
             xmlWriter.writeComment("boolean, enable/disable cross origin requests (browser enforced)");
             xmlWriter.writeCharacters("\r\n\t\t\t");
             xmlWriter.writeStartElement("cors-enabled");
-            xmlWriter.writeCharacters(String.valueOf(this.getCorsEnabled()));
+            xmlWriter.writeCharacters(String.valueOf(this.isCorsEnabled()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeCharacters("\r\n\t\t\t");
@@ -198,46 +244,65 @@ public final class CfgApiRpc {
         }
     }
 
-    public boolean getActive() {
-        return this.active;
-    }
-    public String getIp() {
-        return this.ip;
-    }
-    public int getPort() {
-        return this.port;
-    }
-    public boolean getCorsEnabled() {
-        return corsEnabled;
-    }
+    public boolean isActive() { return this.active; }
+    public String getIp() { return this.ip; }
+    public int getPort() { return this.port; }
+    public boolean isCorsEnabled() { return corsEnabled; }
     public String getCorsOrigin() { return corsOrigin; }
-    public List<String> getEnabled() {
-        return enabled;
-    }
-    public Integer getMaxthread() { return maxthread; }
-    public boolean isFiltersEnabled() {
-        return filtersEnabled;
-    }
+    public List<String> getEnabled() { return enabled; }
+    public boolean isFiltersEnabled() { return filtersEnabled; }
+    public CfgSsl getSsl() { return this.ssl; }
+    public String getVendor() { return vendor; }
+    public Integer getWorkerThreads() { return workerThreads; }
+    public Integer getIoThreads() { return ioThreads; }
+    public Integer getRequestQueueSize() { return requestQueueSize; }
+    public boolean isStuckThreadDetectorEnabled() { return stuckThreadDetectorEnabled; }
 
+    /**
+     * @implNote this should theoretically work, but should be tested for correctness by any future consumer
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        CfgApiRpc cfgApiRpc = (CfgApiRpc) o;
-        return active == cfgApiRpc.active &&
-                port == cfgApiRpc.port &&
-                corsEnabled == cfgApiRpc.corsEnabled &&
-                maxthread == cfgApiRpc.maxthread &&
-                filtersEnabled == cfgApiRpc.filtersEnabled &&
-                Objects.equal(ip, cfgApiRpc.ip) &&
-                Objects.equal(enabled, cfgApiRpc.enabled);
+        CfgApiRpc cfg = (CfgApiRpc) o;
+
+        return active == cfg.active &&
+                Objects.equals(ip, cfg.ip) &&
+                port == cfg.port &&
+                Objects.equals(enabled, cfg.enabled) &&
+                corsEnabled == cfg.corsEnabled &&
+                Objects.equals(corsOrigin, cfg.corsOrigin) &&
+                filtersEnabled == cfg.filtersEnabled &&
+                Objects.equals(ssl, cfg.ssl) &&
+                Objects.equals(vendor, cfg.vendor) &&
+                Objects.equals(workerThreads, cfg.workerThreads) &&
+                Objects.equals(ioThreads, cfg.ioThreads) &&
+                Objects.equals(requestQueueSize, cfg.requestQueueSize) &&
+                stuckThreadDetectorEnabled == cfg.stuckThreadDetectorEnabled;
     }
 
+    /**
+     * @implNote this should theoretically work, but should be tested for correctness by any future consumer
+     *
+     * @implNote computationally slowest implementation O(n). there are faster ways of doing this if
+     * this function call ends up on a critical path (probably not)
+     */
     @Override
     public int hashCode() {
-        return Objects.hashCode(active, ip, port, enabled, corsEnabled, maxthread, filtersEnabled);
+        return java.util.Objects.hash(
+            active,
+            ip,
+            port,
+            enabled,
+            corsEnabled,
+            corsOrigin,
+            filtersEnabled,
+            ssl,
+            vendor,
+            workerThreads,
+            ioThreads,
+            requestQueueSize,
+            stuckThreadDetectorEnabled);
     }
-  
-    public CfgSsl getSsl() { return this.ssl; }
-    public String getVendor() { return vendor; }
 }

--- a/modMcf/src/org/aion/mcf/config/CfgLog.java
+++ b/modMcf/src/org/aion/mcf/config/CfgLog.java
@@ -65,8 +65,7 @@ public class CfgLog {
         while (sr.hasNext()) {
             int eventType = sr.next();
             switch (eventType) {
-                case XMLStreamReader.START_ELEMENT:
-
+                case XMLStreamReader.START_ELEMENT: {
                     /* XML - Takes the input in config.xml and parse as T/F */
                     String elementName = sr.getLocalName().toLowerCase();
                     switch (elementName) {
@@ -77,17 +76,15 @@ public class CfgLog {
                             this.logPath = Cfg.readValue(sr);
                             break;
                         default:
+                            if (LogEnum.contains(elementName))
+                                this.modules.put(elementName, Cfg.readValue(sr).toUpperCase());
                             break;
                     }
-
-                    elementName = sr.getLocalName().toUpperCase();
-                    if (LogEnum.contains(elementName))
-                        this.modules.put(elementName, Cfg.readValue(sr).toUpperCase());
                     break;
+                }
                 case XMLStreamReader.END_ELEMENT:
                     break loop;
                 default:
-                    // Cfg.skipElement(sr);
                     break;
             }
         }

--- a/modMcf/src/org/aion/mcf/config/CfgSsl.java
+++ b/modMcf/src/org/aion/mcf/config/CfgSsl.java
@@ -25,6 +25,8 @@ package org.aion.mcf.config;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Arrays;
+import java.util.Objects;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -136,4 +138,26 @@ public class CfgSsl {
     public boolean getEnabled() { return this.enabled; }
     public String getCert() { return this.cert; }
     public char[] getPass() { return this.pass; }
+
+    /**
+     * @implNote this should theoretically work, but should be tested for correctness by any future consumer
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CfgSsl cfgSsl = (CfgSsl) o;
+
+        return enabled == cfgSsl.enabled &&
+                Objects.equals(cert, cfgSsl.cert) &&
+                Arrays.equals(pass, cfgSsl.pass);
+    }
+
+    /**
+     * @implNote this should theoretically work, but should be tested for correctness by any future consumer
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, cert, pass);
+    }
 }


### PR DESCRIPTION
## 1. Description

> **Note**: PR contingent upon @AlexandraRoatis testing and green light the usage of `Repository.getSnapshotTo(StateRoot)` in `ApiWeb3Aion.java`. 

* Bug Fix: Fixes inapproprate use of `RequestBufferingHandler` which was causing the following error (and subsequent server shutdown) from Undertow: 
   ```
   18-08-25 10:34:06.554 ERROR io.undertow.request [XNIO-1 I/O-1]: UT005071: Undertow request failed HttpServerExchange{ POST / request {Accept=[*/*], Postman-Token=[], Accept-Language=[zh-CN,zh;q=0.9], Cache-Control=[no-cache], Accept-Encoding=[gzip, deflate], Origin=[chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop], User-Agent=[Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36], Connection=[keep-alive], Content-Length=[341], Content-Type=[application/json], Host=[]} response {}}
   java.lang.IllegalStateException: UT000126: Attempted to do blocking IO from the IO thread. This is prohibited as it may result in deadlocks
	at io.undertow.io.UndertowInputStream.read(UndertowInputStream.java:84)
	at io.undertow.io.BlockingReceiverImpl.receiveFullString(BlockingReceiverImpl.java:124)
	at io.undertow.io.BlockingReceiverImpl.receiveFullString(BlockingReceiverImpl.java:76)
	at org.aion.api.server.http.undertow.UndertowRpcServer.lambda$handleRequest$1(Unknown Source)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:360)
	at io.undertow.server.handlers.RequestBufferingHandler$1.handleEvent(RequestBufferingHandler.java:99)
	at io.undertow.server.handlers.RequestBufferingHandler$1.handleEvent(RequestBufferingHandler.java:78)
	at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
	at io.undertow.channels.DetachableStreamSourceChannel$SetterDelegatingListener.handleEvent(DetachableStreamSourceChannel.java:231)
	at io.undertow.channels.DetachableStreamSourceChannel$SetterDelegatingListener.handleEvent(DetachableStreamSourceChannel.java:218)
	at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
	at org.xnio.conduits.ReadReadyHandler$ChannelListenerHandler.readReady(ReadReadyHandler.java:66)
	at org.xnio.nio.NioSocketConduit.handleReady(NioSocketConduit.java:88)
	at org.xnio.nio.WorkerThread.run(WorkerThread.java:561)
   ```
 * Added configuration options to set `worker-threads`, `io-threads` & `request-queue-size` in the configuration. 
* Fixed mis-reporting of rpc-request timing by delegating request timing to Guava. 
* Generated extensive documentation for users of the RPC server: https://github.com/ali-sharif/aion/wiki/JSON-RPC-API-Documentation (will be committed to the Aion wiki when this PR goes through) 
* Re-enabled retrieving state-snapshots at particular block numbers (ie. get account balance at particular block number, etc) via the [default block parameter](https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter) for the functions:
   * eth_getBalance
   * eth_getCode
   * eth_getTransactionCount
   * eth_getStorageAt
   * eth_call
* Made NanoHttpd request queue unbounded due to no good graceful request close API exposed by the library at that point in request lifecycle (only ungraceful socket-shutdown available at that point in request lifecycle).

## 2. Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [x] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [x] Requires documentation update.

## 3. Testing

* Added testcase to javascript rpc-server testbench in aion_qa to test changes to eth_getBalance
* Manually tested new configuration settings.
* Load test result extract below (detailed report: https://github.com/ali-sharif/aion/wiki/JSON-RPC-API-Load-Test-Details)

### 3.1 Resource Constrained Test
 
* worker threads = 4
* io threads = 1 (undertow only)
* request queue size = 200 (undertow only)

||c=1, r=1000|c=20, r=1000|c=500, r=1000|
|---|---|---|---|
|Undertow| 812.38 / 100% | 1134.18 / 100% | 908.69 / 100% |
|NanoHttpd| 22.58 / 100% | 55.69 / 98% | 84.62 / 55% ** |

**Legend: [avg requests per sec processed / success rate %]**

** requests fail due to a combination of resource-busy due to blocking architecture & aggresive (2s) client timeout, but RPC server survives

## 4. Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
