### PR TITLE
Add more granular control over which RPC APIs are available

### DIFF
--- a/modApiServer/src/org/aion/api/server/http/RpcServer.java
+++ b/modApiServer/src/org/aion/api/server/http/RpcServer.java
@@ -35,7 +35,9 @@ public abstract class RpcServer {
         corsOrigin = builder.corsOrigin;
 
         List<String> enabledEndpoints = Collections.unmodifiableList(Objects.requireNonNull(builder.enabledEndpoints));
-        rpcProcessor = new RpcProcessor(enabledEndpoints);
+        List<String> enabledMethods = Collections.unmodifiableList(Objects.requireNonNull(builder.enabledMethods));
+        List<String> disabledMethods = Collections.unmodifiableList(Objects.requireNonNull(builder.disabledMethods));
+        rpcProcessor = new RpcProcessor(enabledEndpoints, enabledMethods, disabledMethods);
 
         sslEnabled = builder.sslEnabled;
         if (sslEnabled) {

--- a/modApiServer/src/org/aion/api/server/http/RpcServerBuilder.java
+++ b/modApiServer/src/org/aion/api/server/http/RpcServerBuilder.java
@@ -22,6 +22,8 @@ public abstract class RpcServerBuilder<T extends RpcServerBuilder<T>> {
     String corsOrigin = "*";
 
     List<String> enabledEndpoints = new ArrayList<>();
+    List<String> enabledMethods = new ArrayList<>();
+    List<String> disabledMethods = new ArrayList<>();
 
     boolean sslEnabled = false;
     String sslCertPath;
@@ -54,6 +56,18 @@ public abstract class RpcServerBuilder<T extends RpcServerBuilder<T>> {
     public T enableEndpoints(List<String> enabledEndpoints) {
         // empty List is a valid input here.
         this.enabledEndpoints = Objects.requireNonNull(enabledEndpoints);
+        return self();
+    }
+
+    public T enableMethods(List<String> enabledMethods) {
+        // empty List is a valid input here.
+        this.enabledMethods = Objects.requireNonNullElse(enabledMethods, new ArrayList<>());
+        return self();
+    }
+
+    public T disableMethods(List<String> disabledMethods) {
+        // empty List is a valid input here.
+        this.disabledMethods = Objects.requireNonNullElse(disabledMethods, new ArrayList<>());
         return self();
     }
 

--- a/modApiServer/src/org/aion/api/server/http/RpcServerBuilder.java
+++ b/modApiServer/src/org/aion/api/server/http/RpcServerBuilder.java
@@ -60,13 +60,13 @@ public abstract class RpcServerBuilder<T extends RpcServerBuilder<T>> {
     }
 
     public T enableMethods(List<String> enabledMethods) {
-        // empty List is a valid input here.
+        // Empty List or null are valid input here.
         this.enabledMethods = Objects.requireNonNullElse(enabledMethods, new ArrayList<>());
         return self();
     }
 
     public T disableMethods(List<String> disabledMethods) {
-        // empty List is a valid input here.
+        // Empty List or null are valid input here.
         this.disabledMethods = Objects.requireNonNullElse(disabledMethods, new ArrayList<>());
         return self();
     }

--- a/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
@@ -18,13 +18,18 @@ public class RpcMethods {
     Map<String, RpcMethod> enabledEndpoints;
 
     /**
-     * Creates a new instance of the RpcMethods class with the intersection of the enabled groups and the explicit
-     * enabled methods inside of it
-     * @param enabledGroups
-     * @param enabledMethods
+     * Creates a new instance of the RpcMethods class with the intersection of the enabled groups
+     * and the explicit enabled methods inside of it
+     * @param enabledGroups     Groups of APIs which should be enabled.
+     * @param enabledMethods    API methods to explicitly enable in addition to the ones specified by
+     *                          the enabledGroups parameter
+     * @param disabledMethods   Methods which are explicitly disabled which will be removed from the
+     *                          combination of enabledGroups and enabledMethods
      */
     public RpcMethods(
-            final List<String> enabledGroups, final List<String> enabledMethods, final List<String> disabledMethods) {
+        final List<String> enabledGroups,
+        final List<String> enabledMethods,
+        final List<String> disabledMethods) {
 
         api = new ApiWeb3Aion(AionImpl.inst());
 
@@ -43,6 +48,8 @@ public class RpcMethods {
         );
 
         enabledEndpoints = composite(enabledGroups, enabledMethods, disabledMethods);
+
+        LOG.debug("Enabled the following apis: {}", (Object) enabledEndpoints.keySet());
     }
 
     public RpcMethod get(String name) {

--- a/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
@@ -5,7 +5,6 @@ import org.aion.log.LogEnum;
 import org.aion.zero.impl.blockchain.AionImpl;
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,27 +59,24 @@ public class RpcMethods {
         api.shutdown();
     }
 
-    private Map<String, RpcMethod> composite(List<String> groups,
+    private Map<String, RpcMethod> composite(final List<String> groups,
                                              final List<String> enabledMethods,
                                              final List<String> disabledMethods) {
 
         Map<String, RpcMethod> composite = new HashMap<>();
 
-        // add the ping endpoint by default
+        // Add the ping endpoint by default
         composite.putAll(ping);
 
         // Add all the methods which are defined by the groups
         for(String group : groups) {
-            Map<String, RpcMethod> g = null;
-            try {
-                g = groupMap.get(group.toLowerCase());
-            } catch (Exception e) {
-                LOG.debug("rpc-methods - unable to recognize api group name: " + group);
-                continue;
-            }
-            // ok to have overlapping method key strings (as long as they also map to the same function)
-            if (g != null)
+            Map<String, RpcMethod> g = groupMap.get(group.toLowerCase());
+            if (g == null) {
+                LOG.debug("rpc-methods - unable to recognize api group name: '{}'", group);
+            } else {
+                // ok to have overlapping method key strings (as long as they also map to the same function)
                 composite.putAll(g);
+            }
         }
 
         // Create a map combining all the available groups
@@ -94,7 +90,7 @@ public class RpcMethods {
             if (allMethods.containsKey(enabledMethod)) {
                 composite.put(enabledMethod, allMethods.get(enabledMethod));
             } else {
-                LOG.warn("Attempted to enable unknown RPC method '{}'", enabledMethod);
+                LOG.warn("rpc-methods - Attempted to enable unknown RPC method '{}'", enabledMethod);
             }
         }
 
@@ -105,14 +101,13 @@ public class RpcMethods {
                 composite.remove(disabledMethod);
             } else if (!allMethods.containsKey(disabledMethod)) {
                 // Log a warning if this RPC method is not known
-                LOG.warn("Attempted to disable unknown RPC method '{}'", disabledMethod);
+                LOG.warn("rpc-methods - Attempted to disable unknown RPC method '{}'", disabledMethod);
             }
         }
 
 
         return composite;
     }
-
 
     // jdk8 lambdas infer interface method, making our constant declaration pretty.
     public interface RpcMethod {

--- a/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
@@ -18,12 +18,12 @@ public class RpcMethods {
 
     /**
      * Creates a new instance of the RpcMethods class with the intersection of the enabled groups
-     * and the explicit enabled methods inside of it
+     * and the explicit enabled methods inside of it.
      * @param enabledGroups     Groups of APIs which should be enabled.
      * @param enabledMethods    API methods to explicitly enable in addition to the ones specified by
-     *                          the enabledGroups parameter
+     *                          the enabledGroups parameter.
      * @param disabledMethods   Methods which are explicitly disabled which will be removed from the
-     *                          combination of enabledGroups and enabledMethods
+     *                          combination of enabledGroups and enabledMethods.
      */
     public RpcMethods(
         final List<String> enabledGroups,

--- a/modApiServer/src/org/aion/api/server/rpc/RpcProcessor.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcProcessor.java
@@ -7,6 +7,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class RpcProcessor {
@@ -16,7 +17,7 @@ public class RpcProcessor {
     RpcMethods apiHolder;
 
     public RpcProcessor(List<String> enabled) {
-        this.apiHolder = new RpcMethods(enabled);
+        this.apiHolder = new RpcMethods(enabled, new ArrayList<>(), new ArrayList<>());
     }
 
     public String process(String _requestBody) {

--- a/modApiServer/src/org/aion/api/server/rpc/RpcProcessor.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcProcessor.java
@@ -16,8 +16,12 @@ public class RpcProcessor {
 
     RpcMethods apiHolder;
 
-    public RpcProcessor(List<String> enabled) {
-        this.apiHolder = new RpcMethods(enabled, new ArrayList<>(), new ArrayList<>());
+    public RpcProcessor(
+        final List<String> enabledGroups,
+        final List<String> enabledMethods,
+        final List<String> disabledMethods) {
+
+        this.apiHolder = new RpcMethods(enabledGroups, enabledMethods, disabledMethods);
     }
 
     public String process(String _requestBody) {

--- a/modApiServer/test/org/aion/api/server/rpc/RpcMethodsTest.java
+++ b/modApiServer/test/org/aion/api/server/rpc/RpcMethodsTest.java
@@ -31,10 +31,11 @@ public class RpcMethodsTest {
     private static final String NEW_ACCOUNT = "personal_newAccount";
     private static final String INVALID_GROUP = "foo";
     private static final String INVALID_METHOD_NAME = "foo_invalid_method_name";
+    private static final List<String> EMPTY = new ArrayList<>();
 
     @Test
     public void testEmpty() {
-        methods = new RpcMethods(new ArrayList<>());
+        methods = new RpcMethods(EMPTY, EMPTY, EMPTY);
 
         // ping should be the only thing available
         Assert.assertNotNull(methods.get(PING));
@@ -44,7 +45,7 @@ public class RpcMethodsTest {
     @Test
     public void testGroupsOnly() {
         List<String> enabledGroups = Arrays.asList(WEB3);
-        methods = new RpcMethods(enabledGroups);
+        methods = new RpcMethods(enabledGroups, EMPTY, EMPTY);
 
         // Make sure these methods are not available
         Assert.assertNull(methods.get("foo"));
@@ -59,7 +60,7 @@ public class RpcMethodsTest {
     @Test
     public void testInvalidGroup() {
         List<String> enabledGroups = Arrays.asList(INVALID_GROUP, WEB3);
-        methods = new RpcMethods(enabledGroups);
+        methods = new RpcMethods(enabledGroups, EMPTY, EMPTY);
 
         // Make sure that the other methods are still available
         Assert.assertNotNull(methods.get(CLIENT_VERSION));
@@ -69,7 +70,7 @@ public class RpcMethodsTest {
     @Test
     public void testEnableMethods() {
         List<String> enabledMethods = Arrays.asList(BLOCK_NUMBER, CLIENT_VERSION);
-        methods = new RpcMethods(new ArrayList<>(), enabledMethods, new ArrayList<>());
+        methods = new RpcMethods(EMPTY, enabledMethods, EMPTY);
 
         Assert.assertEquals(3, methods.enabledEndpoints.size());
         Assert.assertNotNull(methods.get(PING));
@@ -83,7 +84,7 @@ public class RpcMethodsTest {
     public void testDisableMethods() {
         List<String> enabledGroups = Arrays.asList(WEB3);
         List<String> disabledMethods = Arrays.asList(CLIENT_VERSION);
-        methods = new RpcMethods(enabledGroups, new ArrayList<>(), disabledMethods);
+        methods = new RpcMethods(enabledGroups, EMPTY, disabledMethods);
 
         // web3_clientVersion should be disbled
         Assert.assertNull(methods.get(CLIENT_VERSION));
@@ -95,7 +96,7 @@ public class RpcMethodsTest {
     @Test
     public void testDisablePing() {
         List<String> disabledMethods = Arrays.asList(PING);
-        methods = new RpcMethods(new ArrayList<>(), new ArrayList<>(), disabledMethods);
+        methods = new RpcMethods(EMPTY, EMPTY, disabledMethods);
 
         Assert.assertTrue(methods.enabledEndpoints.isEmpty());
     }
@@ -103,7 +104,7 @@ public class RpcMethodsTest {
     @Test
     public void testEnableInvalidMethod() {
         List<String> enabledMethods = Arrays.asList(CLIENT_VERSION, INVALID_METHOD_NAME);
-        methods = new RpcMethods(new ArrayList<>(), enabledMethods, new ArrayList<>());
+        methods = new RpcMethods(EMPTY, enabledMethods, EMPTY);
 
         Assert.assertNotNull(methods.get(CLIENT_VERSION));
         Assert.assertNull(methods.get(INVALID_METHOD_NAME));
@@ -113,7 +114,7 @@ public class RpcMethodsTest {
     public void testDisableInvalidMethod() {
         List<String> enabledGroups = Arrays.asList(WEB3);
         List<String> disabledMethods = Arrays.asList(INVALID_METHOD_NAME, CLIENT_VERSION);
-        methods = new RpcMethods(enabledGroups, new ArrayList<>(), disabledMethods);
+        methods = new RpcMethods(enabledGroups, EMPTY, disabledMethods);
 
         Assert.assertNull(methods.get(CLIENT_VERSION));
         Assert.assertNotNull(methods.get(SHA3));

--- a/modApiServer/test/org/aion/api/server/rpc/RpcMethodsTest.java
+++ b/modApiServer/test/org/aion/api/server/rpc/RpcMethodsTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class RpcMethodsTest {
     @BeforeClass
     public static void setup() {
-        // Initialize this instance at the start
+        // Initialize this instance at the start to make the tests run a little faster
         AionImpl.inst();
     }
 
@@ -86,7 +86,7 @@ public class RpcMethodsTest {
         List<String> disabledMethods = Arrays.asList(CLIENT_VERSION);
         methods = new RpcMethods(enabledGroups, EMPTY, disabledMethods);
 
-        // web3_clientVersion should be disbled
+        // web3_clientVersion should be disabled
         Assert.assertNull(methods.get(CLIENT_VERSION));
 
         // sha3 should still be around because it was added by the group

--- a/modApiServer/test/org/aion/api/server/rpc/RpcMethodsTest.java
+++ b/modApiServer/test/org/aion/api/server/rpc/RpcMethodsTest.java
@@ -1,0 +1,121 @@
+package org.aion.api.server.rpc;
+
+import org.aion.zero.impl.blockchain.AionImpl;
+import org.junit.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RpcMethodsTest {
+    @BeforeClass
+    public static void setup() {
+        // Initialize this instance at the start
+        AionImpl.inst();
+    }
+
+    @After
+    public void tearDown() {
+        if (methods != null) {
+            methods.shutdown();
+        }
+    }
+
+    private RpcMethods methods;
+
+    private static final String WEB3 = "web3";
+    private static final String BLOCK_NUMBER = "eth_blockNumber";
+    private static final String PING = "ping";
+    private static final String CLIENT_VERSION = "web3_clientVersion";
+    private static final String SHA3 = "web3_sha3";
+    private static final String NEW_ACCOUNT = "personal_newAccount";
+    private static final String INVALID_GROUP = "foo";
+    private static final String INVALID_METHOD_NAME = "foo_invalid_method_name";
+
+    @Test
+    public void testEmpty() {
+        methods = new RpcMethods(new ArrayList<>());
+
+        // ping should be the only thing available
+        Assert.assertNotNull(methods.get(PING));
+        Assert.assertEquals(1, methods.enabledEndpoints.size());
+    }
+
+    @Test
+    public void testGroupsOnly() {
+        List<String> enabledGroups = Arrays.asList(WEB3);
+        methods = new RpcMethods(enabledGroups);
+
+        // Make sure these methods are not available
+        Assert.assertNull(methods.get("foo"));
+        Assert.assertNull(methods.get(BLOCK_NUMBER));
+
+        // ping and web3 methods should be available
+        Assert.assertNotNull(methods.get(PING));
+        Assert.assertNotNull(methods.get(CLIENT_VERSION));
+        Assert.assertNotNull(methods.get(SHA3));
+    }
+
+    @Test
+    public void testInvalidGroup() {
+        List<String> enabledGroups = Arrays.asList(INVALID_GROUP, WEB3);
+        methods = new RpcMethods(enabledGroups);
+
+        // Make sure that the other methods are still available
+        Assert.assertNotNull(methods.get(CLIENT_VERSION));
+        Assert.assertNotNull(methods.get(SHA3));
+    }
+
+    @Test
+    public void testEnableMethods() {
+        List<String> enabledMethods = Arrays.asList(BLOCK_NUMBER, CLIENT_VERSION);
+        methods = new RpcMethods(new ArrayList<>(), enabledMethods, new ArrayList<>());
+
+        Assert.assertEquals(3, methods.enabledEndpoints.size());
+        Assert.assertNotNull(methods.get(PING));
+        Assert.assertNotNull(methods.get(CLIENT_VERSION));
+        Assert.assertNotNull(methods.get(BLOCK_NUMBER));
+
+        Assert.assertNull(methods.get(NEW_ACCOUNT));
+    }
+
+    @Test
+    public void testDisableMethods() {
+        List<String> enabledGroups = Arrays.asList(WEB3);
+        List<String> disabledMethods = Arrays.asList(CLIENT_VERSION);
+        methods = new RpcMethods(enabledGroups, new ArrayList<>(), disabledMethods);
+
+        // web3_clientVersion should be disbled
+        Assert.assertNull(methods.get(CLIENT_VERSION));
+
+        // sha3 should still be around because it was added by the group
+        Assert.assertNotNull(methods.get(SHA3));
+    }
+
+    @Test
+    public void testDisablePing() {
+        List<String> disabledMethods = Arrays.asList(PING);
+        methods = new RpcMethods(new ArrayList<>(), new ArrayList<>(), disabledMethods);
+
+        Assert.assertTrue(methods.enabledEndpoints.isEmpty());
+    }
+
+    @Test
+    public void testEnableInvalidMethod() {
+        List<String> enabledMethods = Arrays.asList(CLIENT_VERSION, INVALID_METHOD_NAME);
+        methods = new RpcMethods(new ArrayList<>(), enabledMethods, new ArrayList<>());
+
+        Assert.assertNotNull(methods.get(CLIENT_VERSION));
+        Assert.assertNull(methods.get(INVALID_METHOD_NAME));
+    }
+
+    @Test
+    public void testDisableInvalidMethod() {
+        List<String> enabledGroups = Arrays.asList(WEB3);
+        List<String> disabledMethods = Arrays.asList(INVALID_METHOD_NAME, CLIENT_VERSION);
+        methods = new RpcMethods(enabledGroups, new ArrayList<>(), disabledMethods);
+
+        Assert.assertNull(methods.get(CLIENT_VERSION));
+        Assert.assertNotNull(methods.get(SHA3));
+    }
+}

--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -214,6 +214,8 @@ public class Aion {
                 rpcBuilder.setUrl(rpcCfg.getIp(), rpcCfg.getPort());
                 rpcBuilder.setWorkerPoolSize(rpcCfg.getMaxthread());
                 rpcBuilder.enableEndpoints(rpcCfg.getEnabled());
+                rpcBuilder.enableMethods(rpcCfg.getEnabledMethods());
+                rpcBuilder.disableMethods(rpcCfg.getDisabledMethods());
 
                 if (rpcCfg.getCorsEnabled())
                     rpcBuilder.enableCorsWithOrigin(rpcCfg.getCorsOrigin());

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chris lin, ali sharif
@@ -105,7 +106,7 @@ public final class CfgApiRpc {
                         case "apis-enabled":
                             String cs = Cfg.readValue(sr).trim();
                             this.enabled = new ArrayList<>(
-                                    Stream.of(cs.split(","))
+                                    Stream.of(StringUtils.splitByWholeSeparator(cs,","))
                                     .map(String::trim)
                                     .collect(Collectors.toList())
                             );
@@ -113,7 +114,7 @@ public final class CfgApiRpc {
                         case "api-methods-enabled":
                             String enabledMethods = Cfg.readValue(sr).trim();
                             this.enabledMethods = new ArrayList<>(
-                                Stream.of(enabledMethods.split(","))
+                                Stream.of(StringUtils.splitByWholeSeparator(enabledMethods,","))
                                     .map(String::trim)
                                     .collect(Collectors.toList())
                             );
@@ -121,7 +122,7 @@ public final class CfgApiRpc {
                         case "api-methods-disabled":
                             String disabledMethods = Cfg.readValue(sr).trim();
                             this.disabledMethods = new ArrayList<>(
-                                Stream.of(disabledMethods.split(","))
+                                Stream.of(StringUtils.splitByWholeSeparator(disabledMethods,","))
                                     .map(String::trim)
                                     .collect(Collectors.toList())
                             );

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -63,6 +63,8 @@ public final class CfgApiRpc {
     private String ip;
     private int port;
     private List<String> enabled;
+    private List<String> enabledMethods;
+    private List<String> disabledMethods;
     private boolean corsEnabled;
     private String corsOrigin;
     private Integer maxthread;
@@ -104,6 +106,22 @@ public final class CfgApiRpc {
                             String cs = Cfg.readValue(sr).trim();
                             this.enabled = new ArrayList<>(
                                     Stream.of(cs.split(","))
+                                    .map(String::trim)
+                                    .collect(Collectors.toList())
+                            );
+                            break;
+                        case "api-methods-enabled":
+                            String enabledMethods = Cfg.readValue(sr).trim();
+                            this.enabledMethods = new ArrayList<>(
+                                Stream.of(enabledMethods.split(","))
+                                    .map(String::trim)
+                                    .collect(Collectors.toList())
+                            );
+                            break;
+                        case "api-methods-disabled":
+                            String disabledMethods = Cfg.readValue(sr).trim();
+                            this.disabledMethods = new ArrayList<>(
+                                Stream.of(disabledMethods.split(","))
                                     .map(String::trim)
                                     .collect(Collectors.toList())
                             );
@@ -181,6 +199,18 @@ public final class CfgApiRpc {
             xmlWriter.writeCharacters(String.join(",", this.getEnabled()));
             xmlWriter.writeEndElement();
 
+            if (this.getEnabledMethods() != null) {
+                xmlWriter.writeStartElement("api-methods-enabled");
+                xmlWriter.writeCharacters(String.join(",", this.getEnabledMethods()));
+                xmlWriter.writeEndElement();
+            }
+
+            if (this.getDisabledMethods() != null) {
+                xmlWriter.writeStartElement("api-methods-disabled");
+                xmlWriter.writeCharacters(String.join(",", this.getDisabledMethods()));
+                xmlWriter.writeEndElement();
+            }
+
             // don't write-back ssl. (keep it hidden for now)
             // xmlWriter.writeCharacters(this.ssl.toXML());
 
@@ -214,6 +244,8 @@ public final class CfgApiRpc {
     public List<String> getEnabled() {
         return enabled;
     }
+    public List<String> getEnabledMethods() { return enabledMethods; }
+    public List<String> getDisabledMethods() { return disabledMethods; }
     public Integer getMaxthread() { return maxthread; }
     public boolean isFiltersEnabled() {
         return filtersEnabled;

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -262,12 +262,14 @@ public final class CfgApiRpc {
                 maxthread == cfgApiRpc.maxthread &&
                 filtersEnabled == cfgApiRpc.filtersEnabled &&
                 Objects.equal(ip, cfgApiRpc.ip) &&
-                Objects.equal(enabled, cfgApiRpc.enabled);
+                Objects.equal(enabled, cfgApiRpc.enabled) &&
+                Objects.equals(enabledMethods, cfg.enabledMethods) &&
+                Objects.equals(disabledMethods, cfg.disabledMethods);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(active, ip, port, enabled, corsEnabled, maxthread, filtersEnabled);
+        return Objects.hashCode(active, ip, port, enabled, enabledMethods, disabledMethods, corsEnabled, maxthread, filtersEnabled);
     }
   
     public CfgSsl getSsl() { return this.ssl; }

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -34,10 +34,8 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author chris lin, ali sharif
@@ -106,24 +104,27 @@ public final class CfgApiRpc {
                         case "apis-enabled":
                             String cs = Cfg.readValue(sr).trim();
                             this.enabled = new ArrayList<>(
-                                    Stream.of(StringUtils.splitByWholeSeparator(cs,","))
+                                    Stream.of(cs.split(","))
                                     .map(String::trim)
+                                    .filter(s -> !s.isEmpty())
                                     .collect(Collectors.toList())
                             );
                             break;
                         case "api-methods-enabled":
                             String enabledMethods = Cfg.readValue(sr).trim();
                             this.enabledMethods = new ArrayList<>(
-                                Stream.of(StringUtils.splitByWholeSeparator(enabledMethods,","))
+                                Stream.of(enabledMethods.split(","))
                                     .map(String::trim)
+                                    .filter(s -> !s.isEmpty())
                                     .collect(Collectors.toList())
                             );
                             break;
                         case "api-methods-disabled":
                             String disabledMethods = Cfg.readValue(sr).trim();
                             this.disabledMethods = new ArrayList<>(
-                                Stream.of(StringUtils.splitByWholeSeparator(disabledMethods,","))
+                                Stream.of(disabledMethods.split(","))
                                     .map(String::trim)
+                                    .filter(s -> !s.isEmpty())
                                     .collect(Collectors.toList())
                             );
                             break;
@@ -264,8 +265,8 @@ public final class CfgApiRpc {
                 filtersEnabled == cfgApiRpc.filtersEnabled &&
                 Objects.equal(ip, cfgApiRpc.ip) &&
                 Objects.equal(enabled, cfgApiRpc.enabled) &&
-                Objects.equals(enabledMethods, cfg.enabledMethods) &&
-                Objects.equals(disabledMethods, cfg.disabledMethods);
+                Objects.equal(enabledMethods, cfgApiRpc.enabledMethods) &&
+                Objects.equal(disabledMethods, cfgApiRpc.disabledMethods);
     }
 
     @Override


### PR DESCRIPTION
## Description

This change adds configuration options to explicitly enable and disable RPC methods by name. Currently, the `aion.api.rpc.apis-enabled` config value defines groups of APIs which will be enabled. Each group contains several APIs and there is not any fine-grained control over explicit JSON RPC methods to expose. The API groups are defined in [RpcMethods.java](https://github.com/aionnetwork/aion/blob/7f1cb1aa0714971c43c8610a04db68a0d014f1b8/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java#L77).

To make add the more granular controls, I added 2 new optional configuration options: `api-methods-enabled` and `api-methods-disabled`. These elements expect comma delimited lists of method names to either enable in addition to the groups specified, or disable from the groups.

### Example Config

```xml
<rpc active="true" ip="127.0.0.1" port="8545">
  <!--comma-separated list, APIs available: web3,net,debug,personal,eth,stratum-->
  <apis-enabled>web3,personal</apis-enabled>
  <api-methods-enabled>eth_blockNumber,eth_syncing</api-methods-enabled>
  <api-methods-disabled>personal_unlockAccount</api-methods-disabled>
</rpc>
```

This example enables the `web3` and `personal` groups which include the `web3_clientVersion`, `web3_sha`, `personal_unlockAccount`, `personal_listAccounts`, `personal_lockAccount`, `personal_newAccount` methods. In addition to those, we add support for the `eth_blockNumber` and `eth_syncing` methods and disable the `personal_unlockAccount` method.

The final set of enabled methods will be: `web3_clientVersion`, `web3_sha`, `personal_listAccounts`, `personal_lockAccount`, `personal_newAccount`, `eth_blockNumber`, `eth_syncing`


## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [X] Enhancement.
- [X] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [X] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Added unit tests for RpcMethods
- Manual testing by changing the configuration xml to use the new enable-methods and disable-methods endpoints. Also tested using old config xml files to make sure they still worked correctly and the change was completely backwards compatible.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [X] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [X] New and existing tests pass locally with my changes.
- [X] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [X] My code generates no new warnings.
- [X] Any dependent changes have been made.
