### PR TITLE
Put Zero address if no from address supplied

### DIFF
--- a/modAion/src/org/aion/zero/types/AionTransaction.java
+++ b/modAion/src/org/aion/zero/types/AionTransaction.java
@@ -284,7 +284,7 @@ public class AionTransaction extends AbstractTransaction {
         if (!parsed) {
             rlpParse();
         }
-        return (this.to == null || this.to.equals(Address.EMPTY_ADDRESS()));
+        return (this.to == null || this.to.isEmptyAddress());
     }
 
     @Override

--- a/modAionBase/src/org/aion/base/type/Address.java
+++ b/modAionBase/src/org/aion/base/type/Address.java
@@ -174,4 +174,8 @@ public final class Address implements Comparable<Address>, Bytesable<Address>, C
     public static final Address EMPTY_ADDRESS() {
         return emptyAddr;
     }
+
+    public final boolean isEmptyAddress() { return this.equals(emptyAddr); }
+
+    public final boolean isZeroAddress() { return this.equals(zeroAddr); }
 }

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -237,7 +237,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
 
         this.minerCoinbase = this.config.getMinerCoinbase();
 
-        if (minerCoinbase.equals(Address.EMPTY_ADDRESS())) {
+        if (minerCoinbase.isEmptyAddress()) {
             LOG.warn("No miner Coinbase!");
         }
 

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
@@ -104,7 +104,7 @@ public class AionImpl implements IChainInstancePOW {
 
         Address minerCoinbase = Address.wrap(this.cfg.getConsensus().getMinerAddress());
 
-        if (minerCoinbase.equals(Address.EMPTY_ADDRESS())) {
+        if (minerCoinbase.isEmptyAddress()) {
             LOG_GEN.info("Miner address is not set");
             return null;
         }

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -462,8 +462,10 @@ public abstract class ApiAion extends Api {
     }
 
     protected long estimateNrg(ArgTxCall params) {
-        AionTransaction tx = new AionTransaction(params.getNonce().toByteArray(), params.getFrom(), params.getTo(),
+        Address fromAddr = (params.getFrom().equals(Address.EMPTY_ADDRESS())) ? Address.ZERO_ADDRESS() : params.getFrom();
+        AionTransaction tx = new AionTransaction(params.getNonce().toByteArray(), fromAddr, params.getTo(),
                 params.getValue().toByteArray(), params.getData(), params.getNrg(), params.getNrgPrice());
+
         AionTxReceipt receipt = this.ac.callConstant(tx, this.ac.getAionHub().getBlockchain().getBestBlock());
         return receipt.getEnergyUsed();
     }

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -462,7 +462,7 @@ public abstract class ApiAion extends Api {
     }
 
     protected long estimateNrg(ArgTxCall params) {
-        Address fromAddr = (params.getFrom().equals(Address.EMPTY_ADDRESS())) ? Address.ZERO_ADDRESS() : params.getFrom();
+        Address fromAddr = (params.getFrom().isEmptyAddress()) ? Address.ZERO_ADDRESS() : params.getFrom();
         AionTransaction tx = new AionTransaction(params.getNonce().toByteArray(), fromAddr, params.getTo(),
                 params.getValue().toByteArray(), params.getData(), params.getNrg(), params.getNrgPrice());
 

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -474,7 +474,7 @@ public abstract class ApiAion extends Api {
 
         Address from = _params.getFrom();
 
-        if (from == null || from.equals(Address.EMPTY_ADDRESS())) {
+        if (from == null || from.isEmptyAddress()) {
             return null;
         }
 
@@ -540,7 +540,7 @@ public abstract class ApiAion extends Api {
 
         Address from = _params.getFrom();
 
-        if (from == null || from.equals(Address.EMPTY_ADDRESS())) {
+        if (from == null || from.isEmptyAddress()) {
             LOG.error("<send-transaction msg=invalid-from-address>");
             return null;
         }

--- a/modPrecompiled/src/org/aion/precompiled/contracts/AionAuctionContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/AionAuctionContract.java
@@ -617,7 +617,7 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();
             }
-            if (!parentAddr.equals(Address.ZERO_ADDRESS())) {
+            if (!parentAddr.isZeroAddress()) {
                 if (isActiveDomain(parentAddr)) return true;
             }
         }

--- a/modPrecompiled/src/org/aion/precompiled/contracts/AionNameServiceContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/AionNameServiceContract.java
@@ -655,7 +655,7 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
         byte[] addressFirstPart = this.track.getStorageValue(registeredDomainNameAddress, new DataWord(blake128(domainName.getBytes()))).getData();
         byte[] addressSecondPart = this.track.getStorageValue(registeredDomainNameAddress, new DataWord(blake128(blake128(domainName.getBytes())))).getData();
         Address domainAddress = Address.wrap(combineTwoBytes(addressFirstPart, addressSecondPart));
-        if (domainAddress.equals(Address.ZERO_ADDRESS()))
+        if (domainAddress.isZeroAddress())
             return null;
         return domainAddress;
     }


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

If the API's estimateGas function is called without a from address, the VM uses the wrong offset when serialising. The fix is to simply use the Zero Address instead.

Fixes Issue #642 

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

All existing tests pass

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
