### PR TITLE
making the db tests less verbose

### DIFF
--- a/modDbImpl/test/org/aion/db/impl/AccessWithExceptionTest.java
+++ b/modDbImpl/test/org/aion/db/impl/AccessWithExceptionTest.java
@@ -58,7 +58,7 @@ public class AccessWithExceptionTest {
     public static void setup() {
         // logging to see errors
         Map<String, String> cfg = new HashMap<>();
-        cfg.put("DB", "TRACE");
+        cfg.put("DB", "WARN");
 
         AionLoggerFactory.init(cfg);
     }

--- a/modDbImpl/test/org/aion/db/impl/ConcurrencyTest.java
+++ b/modDbImpl/test/org/aion/db/impl/ConcurrencyTest.java
@@ -68,7 +68,7 @@ public class ConcurrencyTest {
     public static void setup() {
         // logging to see errors
         Map<String, String> cfg = new HashMap<>();
-        cfg.put("DB", "TRACE");
+        cfg.put("DB", "WARN");
 
         AionLoggerFactory.init(cfg);
     }

--- a/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
@@ -200,7 +200,7 @@ public class DriverBaseTest {
 
         // logging to see errors
         Map<String, String> cfg = new HashMap<>();
-        cfg.put("DB", "TRACE");
+        cfg.put("DB", "WARN");
 
         AionLoggerFactory.init(cfg);
 

--- a/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
+++ b/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
@@ -64,7 +64,7 @@ public class JournalPruneDataSourceTest {
     public static void setup() {
         // logging to see errors
         Map<String, String> cfg = new HashMap<>();
-        cfg.put("DB", "INFO");
+        cfg.put("DB", "WARN");
 
         AionLoggerFactory.init(cfg);
     }


### PR DESCRIPTION
## Description

Using the `trace` and `info` logging levels makes some of the tests very verbose. Reducing this by setting the logging level to `warn` that will also show any errors. Higher levels can be temporarily enabled when tests fail to see the details.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing unit tests

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
