### PR TITLE
Impoved messaging for lightning sync

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/PeerState.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/PeerState.java
@@ -105,6 +105,16 @@ public class PeerState {
         this.resetRepeated();
     }
 
+    /**
+     * Method for checking if the state is in one of the fast modes, namely {@link Mode#LIGHTNING}
+     * and {@link Mode#THUNDER}.
+     *
+     * @return {@code true} when the state is in one of the fast modes, {@code false} otherwise.
+     */
+    public boolean isInFastMode() {
+        return mode == Mode.LIGHTNING || mode == Mode.THUNDER;
+    }
+
     public long getBase() {
         return base;
     }

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -304,6 +304,17 @@ final class TaskImportBlocks implements Runnable {
                                 b.getShortHash(),
                                 b.getNumber(),
                                 displayId);
+                    } else {
+                        // message used instead of import NO_PARENT ones
+                        if (state.isInFastMode()) {
+                            log.info(
+                                    "<import-status: STORED {} blocks from node = {}, starting with hash = {}, number = {}, txs = {}>",
+                                    batch.size(),
+                                    displayId,
+                                    b.getShortHash(),
+                                    b.getNumber(),
+                                    b.getTransactionsList().size());
+                        }
                     }
 
                     switch (mode) {
@@ -560,14 +571,18 @@ final class TaskImportBlocks implements Runnable {
                     importResult,
                     t2 - t1);
         } else {
-            log.info(
-                    "<import-status: node = {}, hash = {}, number = {}, txs = {}, result = {}, time elapsed = {} ms>",
-                    displayId,
-                    b.getShortHash(),
-                    b.getNumber(),
-                    b.getTransactionsList().size(),
-                    importResult,
-                    t2 - t1);
+            // not printing this message when the state is in fast mode with no parent result
+            // a different message will be printed to indicate the storage of blocks
+            if (!state.isInFastMode() || importResult != ImportResult.NO_PARENT) {
+                log.info(
+                        "<import-status: node = {}, hash = {}, number = {}, txs = {}, result = {}, time elapsed = {} ms>",
+                        displayId,
+                        b.getShortHash(),
+                        b.getNumber(),
+                        b.getTransactionsList().size(),
+                        importResult,
+                        t2 - t1);
+            }
         }
         return importResult;
     }


### PR DESCRIPTION
## Description

The current messages displayed for the blocks requested ahead of time may cause confusion because they only show that the first block in the batch resulted in a NO_PARENT import.

This commit improves the message to explicitly state that these blocks are stored (for later use).

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
