### PR TITLE
Sync: Enhanced TaskImportBlocks

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskDropImportedBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskDropImportedBlocks.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contributors:
+ *     Aion foundation.
+ */
+
+package org.aion.zero.impl.sync;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.zero.impl.AionBlockchainImpl;
+import org.aion.zero.impl.types.AionBlock;
+import org.slf4j.Logger;
+
+/**
+ * Deletes a batch of blocks that was already imported from storage.
+ *
+ * @author Alexandra Roatis
+ */
+final class TaskDropImportedBlocks implements Runnable {
+
+    private final AionBlockchainImpl chain;
+    private final long level;
+    private final List<ByteArrayWrapper> importedQueues;
+    private final Map<ByteArrayWrapper, List<AionBlock>> levelFromDisk;
+
+    private final Logger log;
+
+    TaskDropImportedBlocks(
+            final AionBlockchainImpl _chain,
+            final long _level,
+            final List<ByteArrayWrapper> _importedQueues,
+            final Map<ByteArrayWrapper, List<AionBlock>> _levelFromDisk,
+            final Logger _log) {
+        this.chain = _chain;
+        this.level = _level;
+        this.importedQueues = _importedQueues;
+        this.levelFromDisk = _levelFromDisk;
+        this.log = _log;
+    }
+
+    @Override
+    public void run() {
+        Thread.currentThread().setPriority(Thread.NORM_PRIORITY + 1);
+        Thread.currentThread().setName("sync-drop:" + level);
+
+        chain.dropImported(level, importedQueues, levelFromDisk);
+
+        // log operation
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Dropped from storage level = {} with queues = {}.",
+                    level,
+                    Arrays.toString(importedQueues.toArray()));
+        }
+    }
+}

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -693,7 +693,8 @@ final class TaskImportBlocks implements Runnable {
             }
 
             // remove imported data from storage
-            chain.dropImported(level, importedQueues, levelFromDisk);
+            executors.submit(
+                    new TaskDropImportedBlocks(chain, level, importedQueues, levelFromDisk, log));
 
             // increment level
             level++;

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskStorePendingBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskStorePendingBlocks.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contributors:
+ *     Aion foundation.
+ */
+
+package org.aion.zero.impl.sync;
+
+import java.util.List;
+import org.aion.zero.impl.AionBlockchainImpl;
+import org.aion.zero.impl.types.AionBlock;
+import org.slf4j.Logger;
+
+/**
+ * Places a batch of blocks into storage for later imports.
+ *
+ * @author Alexandra Roatis
+ */
+final class TaskStorePendingBlocks implements Runnable {
+
+    private final AionBlockchainImpl chain;
+    private final List<AionBlock> batch;
+    private final String displayId;
+
+    private final Logger log;
+
+    TaskStorePendingBlocks(
+            final AionBlockchainImpl _chain,
+            final List<AionBlock> _batch,
+            final String _displayId,
+            final Logger _log) {
+        this.chain = _chain;
+        this.batch = _batch;
+        this.displayId = _displayId;
+        this.log = _log;
+    }
+
+    @Override
+    public void run() {
+        Thread.currentThread().setPriority(Thread.MAX_PRIORITY - 1);
+        AionBlock first = batch.get(0);
+        Thread.currentThread().setName("sync-save:" + first.getNumber());
+
+        int stored = chain.storePendingBlockRange(batch);
+
+        // log operation
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Stored {} out of {} blocks starting at hash = {}, number = {} from node = {}.",
+                    stored,
+                    batch.size(),
+                    first.getShortHash(),
+                    first.getNumber(),
+                    displayId);
+        }
+    }
+}


### PR DESCRIPTION
## Description

* Improves the `TaskImportBlocks` functionality by delegating some storage operations to parallel threads.
* Optimized locks for the `PendingBlockStore`.
* Corrected the circumstances under which blocks are skipped by the import functionality.

Continued work on Issue #27.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite and running the kernel

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
