### PR TITLE
Docker build script needs to be updated to call gradle instead of ant

### DIFF
--- a/script/pack_dev_docker.sh
+++ b/script/pack_dev_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # The dev build requires the binary to be build with ant. If you need to remote debug, add the `-Dcompile.debug=true` flag.
-ant pack_build -Dcompile.debug=true
+./gradlew build pack -Dcompile.debug=true
 
 docker-compose -f supporting-services.yml build
 


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- pack-dev-docker.sh calls `ant pack_build` -- this PR replaces it with the Gradle equivalent `./gradlew pack build` since we're migrating away from ant to Gradle

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Invoked the Gradle task that calls pack_dev_docker.sh: `./gradlew packDevDocker`
- Saw it build and deploy image to local Docker server
- Ran the docker image with `docker run`
- Saw that the kernel starts up correctly (at the moment, the Dockerfile is hardcoded to look for config/config.xml, which doesn't work anymore since the CLI change, but I think that fix should be a separate PR)

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
