### PR TITLE
Gradle pack task needs to always run compileNative task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,6 +231,7 @@ task pack(type: Tar) {
     dependsOn build
     dependsOn prePack
     dependsOn collectDependentJars 
+    dependsOn compileNative 
     finalizedBy(postPack)
 
     archiveName = 'aion.tar.bz2'


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- if you run `./gradlew pack` after checking out aion repo without running any other gradle tasks, the .bz2 is missing equihash.so, resulting in this error at the end of the pack task:

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: Can't load library: /home/sergiu/temp_aion/pack/aion/native/linux/equihash/equiMiner.so
        at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2614)
        at java.base/java.lang.Runtime.load0(Runtime.java:814)
        at java.base/java.lang.System.load(System.java:1838)
        at org.aion.base.util.NativeLoader.loadLibrary(NativeLoader.java:105)
        at org.aion.utils.NativeLibrary.checkNativeLibrariesLoaded(NativeLibrary.java:30)
        at org.aion.Aion.main(Aion.java:79)
```

- this PR fixes that issue by declaring a dependency on compileNative for pack

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- cloned aion repo, ran `./gradlew pack` and got the UnsatisfiedLinkError
- deleted and cloned again, used the updated build.gradle file, ran `./gradlew pack` and this time it completes successfully without the UnsatisfiedLinkError 

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
