### PR TITLE
[#634] Added eth_signTransaction implementation and tests

### DIFF
--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -594,6 +594,40 @@ public abstract class ApiAion extends Api {
         return tx.getHash();
     }
 
+    protected AionTransaction signTransaction(ArgTxCall _params, ECKey key) {
+        if (key == null) {
+            LOG.error("<sign-transaction msg=account-not-found>");
+            return null;
+        }
+
+        try {
+            synchronized (pendingState) {
+                byte[] nonce =
+                    (!_params.getNonce().equals(BigInteger.ZERO))
+                        ? _params.getNonce().toByteArray()
+                        : pendingState
+                            .bestPendingStateNonce(Address.wrap(key.getAddress()))
+                            .toByteArray();
+
+                AionTransaction tx =
+                    new AionTransaction(
+                        nonce,
+                        _params.getTo(),
+                        _params.getValue().toByteArray(),
+                        _params.getData(),
+                        _params.getNrg(),
+                        _params.getNrgPrice());
+                tx.sign(key);
+
+                return tx;
+            }
+        } catch (Exception ex) {
+            if(LOG.isDebugEnabled())
+                LOG.debug("Failed to sign the transaction");
+            return null;
+        }
+    }
+
     // --Commented out by Inspection START (02/02/18 6:58 PM):
     // public String getNodeId() {
     // return CfgAion.inst().getId();

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -594,9 +594,18 @@ public abstract class ApiAion extends Api {
         return tx.getHash();
     }
 
-    protected AionTransaction signTransaction(ArgTxCall _params, ECKey key) {
+    protected AionTransaction signTransaction(ArgTxCall _params, String _address) {
+        Address address = null;
+        if (_address == null || _address.isEmpty()) {
+            LOG.error("<sign-transaction msg=invalid-signing-address>");
+            return null;
+        } else {
+            address = Address.wrap(_address);
+        }
+
+        ECKey key = getAccountKey(address.toString());
         if (key == null) {
-            LOG.error("<sign-transaction msg=account-not-found>");
+            LOG.error("<sign-transaction msg=account-not-unlocked>");
             return null;
         }
 

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -661,16 +661,7 @@ public class ApiWeb3Aion extends ApiAion {
             return new RpcMsg(
                 null, RpcError.INVALID_PARAMS, "Please check your transaction object.");
 
-        Address address = null;
-        if(_address == null || _address.trim().length() == 0)
-            return new RpcMsg(null, RpcError.INVALID_PARAMS, "Address cannot be null");
-        else
-            address = Address.wrap(_address);
-
-        ECKey key = getAccountKey(address.toString());
-        if (key == null) return new RpcMsg(null, RpcError.NOT_ALLOWED, "Account not unlocked.");
-
-        AionTransaction tx = signTransaction(txParams, key);
+        AionTransaction tx = signTransaction(txParams, _address);
         if(tx != null) {
             JSONObject obj = new JSONObject();
             obj.put("raw", TypeConverter.toJsonHex(tx.getEncoded()));
@@ -681,6 +672,7 @@ public class ApiWeb3Aion extends ApiAion {
             txObj.put("nrgPrice", TypeConverter.toJsonHex(tx.getNrgPrice()));
             txObj.put("gas", TypeConverter.toJsonHex(tx.getNrg()));
             txObj.put("nrg", TypeConverter.toJsonHex(tx.getNrg()));
+            txObj.put("from", TypeConverter.toJsonHex(tx.getFrom().toString()));
             txObj.put("to", TypeConverter.toJsonHex(tx.getTo().toString()));
             txObj.put("value", TypeConverter.toJsonHex(tx.getValue()));
             txObj.put("input", TypeConverter.toJsonHex(tx.getData()));

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -672,7 +672,6 @@ public class ApiWeb3Aion extends ApiAion {
             txObj.put("nrgPrice", TypeConverter.toJsonHex(tx.getNrgPrice()));
             txObj.put("gas", TypeConverter.toJsonHex(tx.getNrg()));
             txObj.put("nrg", TypeConverter.toJsonHex(tx.getNrg()));
-            txObj.put("from", TypeConverter.toJsonHex(tx.getFrom().toString()));
             txObj.put("to", TypeConverter.toJsonHex(tx.getTo().toString()));
             txObj.put("value", TypeConverter.toJsonHex(tx.getValue()));
             txObj.put("input", TypeConverter.toJsonHex(tx.getData()));

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -635,6 +635,66 @@ public class ApiWeb3Aion extends ApiAion {
         return new RpcMsg(TypeConverter.toJsonHex(key.sign(messageHash).getSignature()));
     }
 
+    /**
+     * Sign a transaction. This account needs to be unlocked.
+     * @param _params
+     * @return
+     */
+    public RpcMsg eth_signTransaction(Object _params) {
+        JSONObject _tx;
+        //Address to sign with
+        String _address = null;
+        if (_params instanceof JSONArray) {
+            _tx = ((JSONArray) _params).getJSONObject(0);
+
+            if(((JSONArray) _params).length() > 1)
+                _address = ((JSONArray) _params).get(1) + "";
+        } else if (_params instanceof JSONObject) {
+            _tx = ((JSONObject) _params).getJSONObject("transaction");
+            _address = ((JSONObject) _params).get("address") + "";
+        } else {
+            return new RpcMsg(null, RpcError.INVALID_PARAMS, "Invalid parameters");
+        }
+
+        ArgTxCall txParams = ArgTxCall.fromJSON(_tx, getNrgOracle(), getDefaultNrgLimit());
+        if (txParams == null)
+            return new RpcMsg(
+                null, RpcError.INVALID_PARAMS, "Please check your transaction object.");
+
+        Address address = null;
+        if(_address == null || _address.trim().length() == 0)
+            return new RpcMsg(null, RpcError.INVALID_PARAMS, "Address cannot be null");
+        else
+            address = Address.wrap(_address);
+
+        ECKey key = getAccountKey(address.toString());
+        if (key == null) return new RpcMsg(null, RpcError.NOT_ALLOWED, "Account not unlocked.");
+
+        AionTransaction tx = signTransaction(txParams, key);
+        if(tx != null) {
+            JSONObject obj = new JSONObject();
+            obj.put("raw", TypeConverter.toJsonHex(tx.getEncoded()));
+
+            JSONObject txObj = new JSONObject();
+            txObj.put("nonce", TypeConverter.toJsonHex(tx.getNonce()));
+            txObj.put("gasPrice", TypeConverter.toJsonHex(tx.getNrgPrice()));
+            txObj.put("nrgPrice", TypeConverter.toJsonHex(tx.getNrgPrice()));
+            txObj.put("gas", TypeConverter.toJsonHex(tx.getNrg()));
+            txObj.put("nrg", TypeConverter.toJsonHex(tx.getNrg()));
+            txObj.put("to", TypeConverter.toJsonHex(tx.getTo().toString()));
+            txObj.put("value", TypeConverter.toJsonHex(tx.getValue()));
+            txObj.put("input", TypeConverter.toJsonHex(tx.getData()));
+            txObj.put("hash", TypeConverter.toJsonHex(tx.getHash()));
+
+            obj.put("tx", txObj);
+            return new RpcMsg(obj);
+        } else {
+            if(LOG.isDebugEnabled())
+                LOG.debug("Transaction signing failed");
+            return new RpcMsg(null, RpcError.INTERNAL_ERROR, "Error in singing the transaction.");
+        }
+    }
+
     public RpcMsg eth_sendTransaction(Object _params) {
         JSONObject _tx;
         if (_params instanceof JSONArray) {

--- a/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
@@ -206,6 +206,7 @@ public class RpcMethods {
             Map.entry("eth_submitHashrate", (params) -> api.eth_submitHashrate(params)),
             Map.entry("eth_gasPrice", (params) -> api.eth_gasPrice()),
             Map.entry("eth_sign", (params) -> api.eth_sign(params)),
+            Map.entry("eth_signTransaction", (params) -> api.eth_signTransaction(params)),
             Map.entry("eth_getStorageAt", (params) -> api.eth_getStorageAt(params)),
 
             Map.entry("eth_newFilter", (params) -> api.eth_newFilter(params)),

--- a/modApiServer/test/org/aion/api/server/ApiAionTest.java
+++ b/modApiServer/test/org/aion/api/server/ApiAionTest.java
@@ -461,7 +461,6 @@ public class ApiAionTest {
         assertNotNull(raw);
         assertNotNull(tx);
 
-        assertEquals(tx.get("from"), outTx.get("from"));
         assertEquals(tx.get("to"), outTx.get("to"));
         assertEquals(tx.get("value").toString(),
             TypeConverter.StringHexToBigInteger(outTx.get("value").toString()).toString());


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

This pull request implements the missing eth.signTransaction method in kernel. This method is part of web3js 1.0.
ApiWeb3Aion.java is changed to add eth_signTransaction method.
ApiAion.java is changed to add a new method signTransaction() which is called from eth_signTransaction()

A separate pull request will be created to fix aion_web3 module for this new method.
-

Fixes Issue #634  .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing
New test cases added in ApiAionTest.java
-

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
