### PR TITLE
replace contract address generate mechanism

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "aion_fastvm"]
     path = aion_fastvm
     url = https://github.com/aionnetwork/aion_fastvm
-    branch = master 
+    branch = contractAddrgen 
 [submodule "aion_api"]
     path = aion_api
     url = https://github.com/aionnetwork/aion_api

--- a/modAion/src/org/aion/zero/types/AionTransaction.java
+++ b/modAion/src/org/aion/zero/types/AionTransaction.java
@@ -286,7 +286,7 @@ public class AionTransaction extends AbstractTransaction {
         }
 
         try {
-            return Address.wrap(HashUtil.calcNewAddr(from.toBytes(), this.getNonce()));
+            return Address.wrap(HashUtil.calcNewAddr(from.toBytes(), this.getNonce(), this.getHash()));
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
             return null;

--- a/modCrypto/src/org/aion/crypto/HashUtil.java
+++ b/modCrypto/src/org/aion/crypto/HashUtil.java
@@ -293,14 +293,15 @@ public class HashUtil {
     }
 
     /** Calculates the address as per the QA2 definitions */
-    public static byte[] calcNewAddr(byte[] addr, byte[] nonce) {
+    public static byte[] calcNewAddr(byte[] addr, byte[] nonce, byte[] hash) {
         ByteBuffer buf = ByteBuffer.allocate(32);
         buf.put(AddressSpecs.A0_IDENTIFIER);
 
         byte[] encSender = RLP.encodeElement(addr);
         byte[] encNonce = RLP.encodeBigInteger(new BigInteger(1, nonce));
+        byte[] encHash = RLP.encodeElement(hash);
 
-        buf.put(h256(RLP.encodeList(encSender, encNonce)), 1, 31);
+        buf.put(h256(RLP.encodeList(encSender, encNonce, encHash)), 1, 31);
         return buf.array();
     }
 


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- currently, the contract address decided by hash of the caller's address and caller's nonce. therefore the address is very easy been predicted and then attacking the address. We introduce the mechanism to hash one more argument input, that's is txhash of the transaction. 

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
