### PR TITLE
Expanded sync statistics

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -230,7 +230,7 @@ public class AionHub {
         boolean inSyncOnlyMode = cfg.getNet().getP2p().inSyncOnlyMode();
         cbs.add(new ReqBlocksHeadersHandler(syncLOG, blockchain, p2pMgr, inSyncOnlyMode));
         cbs.add(new ResBlocksHeadersHandler(syncLOG, syncMgr, p2pMgr));
-        cbs.add(new ReqBlocksBodiesHandler(syncLOG, blockchain, p2pMgr, inSyncOnlyMode));
+        cbs.add(new ReqBlocksBodiesHandler(syncLOG, blockchain, syncMgr, p2pMgr, inSyncOnlyMode));
         cbs.add(new ResBlocksBodiesHandler(syncLOG, syncMgr, p2pMgr));
         cbs.add(new BroadcastTxHandler(syncLOG, mempool, p2pMgr, inSyncOnlyMode));
         cbs.add(new BroadcastNewBlockHandler(syncLOG, propHandler, p2pMgr));

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -80,6 +80,7 @@ public final class SyncMgr {
     private AionBlockchainImpl chain;
     private IP2pMgr p2pMgr;
     private IEventMgr evtMgr;
+    private SyncStats stats;
     private AtomicBoolean start = new AtomicBoolean(true);
     // private ExecutorService workers = Executors.newFixedThreadPool(5);
     private ExecutorService workers =
@@ -178,7 +179,7 @@ public final class SyncMgr {
         blockHeaderValidator = new ChainConfiguration().createBlockHeaderValidator();
 
         long selfBest = chain.getBestBlock().getNumber();
-        SyncStats stats = new SyncStats(selfBest);
+        stats = new SyncStats(selfBest);
 
         syncGb =
                 new Thread(
@@ -203,7 +204,7 @@ public final class SyncMgr {
                                 log),
                         "sync-ib");
         syncIb.start();
-        syncGs = new Thread(new TaskGetStatus(start, p2pMgr, log), "sync-gs");
+        syncGs = new Thread(new TaskGetStatus(start, p2pMgr, stats, log), "sync-gs");
         syncGs.start();
 
         if (_showStatus) {
@@ -392,6 +393,10 @@ public final class SyncMgr {
 
     public Map<Integer, PeerState> getPeerStates() {
         return new HashMap<>(this.peerStates);
+    }
+
+    public SyncStats getSyncStats() {
+        return this.stats;
     }
 
     private static final class AionSyncMgrHolder {

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
@@ -101,9 +101,8 @@ public final class SyncStats {
      */
     synchronized Map<String, Float> getPercentageOfRequestsToPeers() {
         Map<String, Float> percentageReq = new HashMap<>();
-        Long totalReq = requestsToPeers.reduceValues(2, (val1, val2) -> val1 + val2);
-        requestsToPeers.forEachEntry(
-                2,
+        Long totalReq = requestsToPeers.values().stream().mapToLong(l -> l).sum();
+        requestsToPeers.entrySet().stream().forEach(
                 entry -> {
                     percentageReq.put(
                             entry.getKey(), entry.getValue().floatValue() / totalReq.floatValue());

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
@@ -23,8 +23,18 @@
 
 package org.aion.zero.impl.sync;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 /** @author chris */
-final class SyncStats {
+public final class SyncStats {
 
     private long start;
 
@@ -32,18 +42,239 @@ final class SyncStats {
 
     private double avgBlocksPerSec;
 
+    private final ConcurrentHashMap<String, Long> requestsToPeers = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, Long> blocksByPeer = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, Long> blockRequestsByPeer = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, LinkedList> statusRequestTimeByPeers =
+            new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, LinkedList> statusResponseTimeByPeers =
+            new ConcurrentHashMap<>();
+
+    private Long overallAvgPeerResponseTime;
+
     SyncStats(long _startBlock) {
         this.start = System.currentTimeMillis();
         this.startBlock = _startBlock;
         this.avgBlocksPerSec = 0;
+        this.overallAvgPeerResponseTime = 0L;
     }
 
-    synchronized void update(long _blockNumber) {
+    /**
+     * Update statistics based on peer nodeId, total imported blocks, and best block number
+     *
+     * @param _nodeId peer node display Id
+     * @param _totalBlocks total imported blocks in batch
+     * @param _blockNumber best block number
+     */
+    synchronized void update(String _nodeId, int _totalBlocks, long _blockNumber) {
         avgBlocksPerSec =
                 (double) (_blockNumber - startBlock) * 1000 / (System.currentTimeMillis() - start);
+        updateTotalRequestsToPeer(_nodeId);
+        updatePeerTotalBlocks(_nodeId, _totalBlocks);
     }
 
     synchronized double getAvgBlocksPerSec() {
         return this.avgBlocksPerSec;
+    }
+
+    /**
+     * Updates the total requests made to a pear
+     *
+     * @param _nodeId peer node display Id
+     */
+    private void updateTotalRequestsToPeer(String _nodeId) {
+        if (requestsToPeers.putIfAbsent(_nodeId, 1L) != null) {
+            requestsToPeers.computeIfPresent(_nodeId, (key, value) -> value + 1L);
+        }
+    }
+
+    /**
+     * Calculates the percentage of requests made to each peer with respect to the total number of
+     * requests made.
+     *
+     * @return a hash map in descending order containing peers with underlying percentage of
+     * requests made by the node
+     */
+    synchronized Map<String, Float> getPercentageOfRequestsToPeers() {
+        Map<String, Float> percentageReq = new HashMap<>();
+        Long totalReq = requestsToPeers.reduceValues(2, (val1, val2) -> val1 + val2);
+        requestsToPeers.forEachEntry(
+                2,
+                entry -> {
+                    percentageReq.put(
+                            entry.getKey(), entry.getValue().floatValue() / totalReq.floatValue());
+                });
+        return percentageReq
+                .entrySet()
+                .stream()
+                .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
+                .collect(
+                        Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue,
+                                (e1, e2) -> e2,
+                                LinkedHashMap::new));
+    }
+
+    /**
+     * Updates the total number of blocks received from each seed peer
+     *
+     * @param _nodeId peer node display Id
+     * @param _totalBlocks total number of blocks received
+     */
+    private void updatePeerTotalBlocks(String _nodeId, int _totalBlocks) {
+        long blocks = Integer.valueOf(_totalBlocks).longValue();
+        if (blocksByPeer.putIfAbsent(_nodeId, blocks) != null) {
+            blocksByPeer.computeIfPresent(_nodeId, (key, value) -> value + blocks);
+        }
+    }
+
+    /**
+     * Obtains a map of seed peers ordered by the total number of imported blocks
+     *
+     * @return map of total imported blocks by peer and sorted in descending order
+     */
+    synchronized Map<String, Long> getTotalBlocksByPeer() {
+        return blocksByPeer
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() > 0)
+                .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
+                .collect(
+                        Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue,
+                                (e1, e2) -> e2,
+                                LinkedHashMap::new));
+    }
+
+    /**
+     * Updates the total block requests made by a pear
+     *
+     * @param _nodeId peer node display Id
+     */
+    public synchronized void updateTotalBlockRequestsByPeer(String _nodeId) {
+        if (blockRequestsByPeer.putIfAbsent(_nodeId, 1L) != null) {
+            blockRequestsByPeer.computeIfPresent(_nodeId, (key, value) -> value + 1L);
+        }
+    }
+
+    /**
+     * Obtains a map of peers ordered by the total number of requested blocks to the node
+     *
+     * @return map of total requested blocks by peer and sorted in descending order
+     */
+    synchronized Map<String, Long> getTotalBlockRequestsByPeer() {
+        return blockRequestsByPeer
+                .entrySet()
+                .stream()
+                .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
+                .collect(
+                        Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue,
+                                (e1, e2) -> e2,
+                                LinkedHashMap::new));
+    }
+
+    /**
+     * Logs the time of status request to an active peer node
+     *
+     * @param _nodeId peer node display Id
+     */
+    public synchronized void addPeerRequestTime(String _nodeId) {
+        LinkedList requestStartTimes =
+                statusRequestTimeByPeers.containsKey(_nodeId)
+                        ? statusRequestTimeByPeers.get(_nodeId)
+                        : new LinkedList();
+        requestStartTimes.add(System.currentTimeMillis());
+        statusRequestTimeByPeers.put(_nodeId, requestStartTimes);
+    }
+
+    /**
+     * Log the time of status response received from an active peer node
+     *
+     * @param _nodeId peer node display Id
+     */
+    public synchronized void addPeerResponseTime(String _nodeId) {
+        LinkedList requestStartTimes =
+                statusResponseTimeByPeers.containsKey(_nodeId)
+                        ? statusResponseTimeByPeers.get(_nodeId)
+                        : new LinkedList();
+        requestStartTimes.add(System.currentTimeMillis());
+        statusResponseTimeByPeers.put(_nodeId, requestStartTimes);
+    }
+
+    /**
+     * Obtains the average response time by each active peer node
+     *
+     * @return map of average response time by peer node
+     */
+    synchronized Map<String, Double> getAverageResponseTimeByPeers() {
+        Map<String, Double> avgResponseTimeByPeers =
+                statusRequestTimeByPeers
+                    .entrySet()
+                    .stream()
+                    .collect(
+                        Collectors.toMap( // collect a map of average response times by peer
+                            Map.Entry::getKey, // node display Id
+                            entry -> { // calculate the average response time
+
+                                String _nodeId = entry.getKey();
+                                final List requestTimes = entry.getValue();
+                                final List responseTimes =
+                                        statusResponseTimeByPeers.getOrDefault(
+                                                _nodeId, new LinkedList());
+                                Double average =
+                                    Math.ceil( // truncates average value
+                                        IntStream.range( // calculates the status response time
+                                            0,
+                                            Math.min(requestTimes.size(), responseTimes.size()))
+                                                .mapToLong( // subtract (response - request) time
+                                                    i ->
+                                                        ((Long)responseTimes.get(i)).longValue()
+                                                        - ((Long)requestTimes.get(i)).longValue()
+                                                )
+                                                // averaged over all requests
+                                                .average().orElse(0));
+                                return average;
+                            }));
+        
+        overallAvgPeerResponseTime =
+                statusRequestTimeByPeers.isEmpty()
+                        ? overallAvgPeerResponseTime
+                        : Double.valueOf(
+                                Math.ceil(
+                                        avgResponseTimeByPeers
+                                                .entrySet()
+                                                .stream()
+                                                .mapToDouble(entry -> entry.getValue())
+                                                .average()
+                                                .getAsDouble()))
+                                                .longValue();
+
+        return avgResponseTimeByPeers
+                .entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByValue())
+                .collect(
+                        Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue,
+                                (e1, e2) -> e2,
+                                LinkedHashMap::new));
+    }
+
+    /**
+     * Obtains the overall average response time from all active peer nodes
+     *
+     * @return overall average response time
+     */
+    synchronized Long getOverallAveragePeerResponseTime() {
+        return overallAvgPeerResponseTime;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
@@ -127,7 +127,7 @@ public final class SyncStats {
      * @param _totalBlocks total number of blocks received
      */
     private void updatePeerTotalBlocks(String _nodeId, int _totalBlocks) {
-        long blocks = Integer.valueOf(_totalBlocks).longValue();
+        long blocks = (long) _totalBlocks;
         if (blocksByPeer.putIfAbsent(_nodeId, blocks) != null) {
             blocksByPeer.computeIfPresent(_nodeId, (key, value) -> value + blocks);
         }
@@ -157,9 +157,10 @@ public final class SyncStats {
      *
      * @param _nodeId peer node display Id
      */
-    public synchronized void updateTotalBlockRequestsByPeer(String _nodeId) {
-        if (blockRequestsByPeer.putIfAbsent(_nodeId, 1L) != null) {
-            blockRequestsByPeer.computeIfPresent(_nodeId, (key, value) -> value + 1L);
+    public synchronized void updateTotalBlockRequestsByPeer(String _nodeId, int _totalBlocks) {
+        long blocks = (long) _totalBlocks;
+        if (blockRequestsByPeer.putIfAbsent(_nodeId, blocks) != null) {
+            blockRequestsByPeer.computeIfPresent(_nodeId, (key, value) -> value + blocks);
         }
     }
 
@@ -186,12 +187,12 @@ public final class SyncStats {
      *
      * @param _nodeId peer node display Id
      */
-    public synchronized void addPeerRequestTime(String _nodeId) {
-        LinkedList requestStartTimes =
+    public synchronized void addPeerRequestTime(String _nodeId, long _requestTime) {
+        LinkedList<Long> requestStartTimes =
                 statusRequestTimeByPeers.containsKey(_nodeId)
                         ? statusRequestTimeByPeers.get(_nodeId)
-                        : new LinkedList();
-        requestStartTimes.add(System.currentTimeMillis());
+                        : new LinkedList<>();
+        requestStartTimes.add(_requestTime);
         statusRequestTimeByPeers.put(_nodeId, requestStartTimes);
     }
 
@@ -200,12 +201,12 @@ public final class SyncStats {
      *
      * @param _nodeId peer node display Id
      */
-    public synchronized void addPeerResponseTime(String _nodeId) {
-        LinkedList requestStartTimes =
+    public synchronized void addPeerResponseTime(String _nodeId, long _requestTime) {
+        LinkedList<Long> requestStartTimes =
                 statusResponseTimeByPeers.containsKey(_nodeId)
                         ? statusResponseTimeByPeers.get(_nodeId)
-                        : new LinkedList();
-        requestStartTimes.add(System.currentTimeMillis());
+                        : new LinkedList<>();
+        requestStartTimes.add(_requestTime);
         statusResponseTimeByPeers.put(_nodeId, requestStartTimes);
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetStatus.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetStatus.java
@@ -68,7 +68,7 @@ final class TaskGetStatus implements Runnable {
                 for (INode n : p2p.getActiveNodes().values()) {
                     // System.out.println("requesting-status from-node=" + n.getIdShort());
                     p2p.send(n.getIdHash(), n.getIdShort(), reqStatus);
-                    stats.addPeerRequestTime(n.getIdShort());
+                    stats.addPeerRequestTime(n.getIdShort(), System.currentTimeMillis());
                 }
                 Thread.sleep(interval);
             } catch (Exception e) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetStatus.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetStatus.java
@@ -40,6 +40,8 @@ final class TaskGetStatus implements Runnable {
 
     private final IP2pMgr p2p;
 
+    private final SyncStats stats;
+
     private final Logger log;
 
     /**
@@ -47,9 +49,14 @@ final class TaskGetStatus implements Runnable {
      * @param _p2p IP2pMgr
      * @param _log Logger
      */
-    TaskGetStatus(final AtomicBoolean _run, final IP2pMgr _p2p, final Logger _log) {
+    TaskGetStatus(
+            final AtomicBoolean _run,
+            final IP2pMgr _p2p,
+            final SyncStats _stats,
+            final Logger _log) {
         this.run = _run;
         this.p2p = _p2p;
+        this.stats = _stats;
         this.log = _log;
     }
 
@@ -61,6 +68,7 @@ final class TaskGetStatus implements Runnable {
                 for (INode n : p2p.getActiveNodes().values()) {
                     // System.out.println("requesting-status from-node=" + n.getIdShort());
                     p2p.send(n.getIdHash(), n.getIdShort(), reqStatus);
+                    stats.addPeerRequestTime(n.getIdShort());
                 }
                 Thread.sleep(interval);
             } catch (Exception e) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -145,7 +145,7 @@ final class TaskImportBlocks implements Runnable {
                             peerState.getBase());
                 }
 
-                stats.update(getBestBlockNumber());
+                stats.update(bw.getDisplayId(), bw.getBlocks().size(), getBestBlockNumber());
             }
         }
         if (log.isDebugEnabled()) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
@@ -117,6 +117,7 @@ final class TaskShowStatus implements Runnable {
 
             if (p2pLOG.isDebugEnabled()) {
                 String s = dumpPeerStateInfo(p2p.getActiveNodes().values());
+                s += dumpPeerStatsInfo();
                 if (!s.isEmpty()) {
                     p2pLOG.debug(s);
                 }
@@ -150,6 +151,89 @@ final class TaskShowStatus implements Runnable {
         }
     }
 
+    /**
+     * Obtain log stream containing statistics about requests and blocks processed by/from peer
+     * nodes.
+     *
+     * @return log stream with peers statistical data
+     */
+    public String dumpPeerStatsInfo() {
+        Map<String, Float> reqToPeers = this.stats.getPercentageOfRequestsToPeers();
+        Map<String, Long> totalBlockReqByPeer = this.stats.getTotalBlockRequestsByPeer();
+        Map<String, Long> totalBlocksByPeer = this.stats.getTotalBlocksByPeer();
+        Map<String, Double> avgResponseTimeByPeers = this.stats.getAverageResponseTimeByPeers();
+
+        StringBuilder sb = new StringBuilder();
+
+        if (!reqToPeers.isEmpty()) {
+
+            sb.append(
+                    String.format(
+                            "=================================================================== sync-requests-to-peers ===================================================================\n"));
+
+            sb.append(String.format("%9s %10s\n", "id", "% requests"));
+
+            reqToPeers.forEach(
+                    (nodeId, percReq) -> {
+                        sb.append(
+                                String.format(
+                                        "id:%6s %10s\n",
+                                        nodeId, String.format("%.2f", percReq * 100) + " %"));
+                    });
+        }
+
+        if (!totalBlocksByPeer.isEmpty()) {
+
+            sb.append(
+                    String.format(
+                            "==================================================================== sync-blocks-by-peer =====================================================================\n"));
+
+            sb.append(String.format("%9s %18s\n", "id", "Total blocks"));
+
+            totalBlocksByPeer.forEach(
+                    (nodeId, totalBlocks) -> {
+                        sb.append(String.format("id:%6s %18s\n", nodeId, totalBlocks));
+                    });
+        }
+
+        if (!totalBlockReqByPeer.isEmpty()) {
+
+            sb.append(
+                    String.format(
+                            "================================================================= sync-block-requests-by-peer ================================================================\n"));
+
+            sb.append(String.format("%9s %18s\n", "id", "Total blocks"));
+
+            totalBlockReqByPeer.forEach(
+                    (nodeId, totalBlocks) -> {
+                        sb.append(String.format("id:%6s %18s\n", nodeId, totalBlocks));
+                    });
+        }
+
+        if (!avgResponseTimeByPeers.isEmpty()) {
+
+            Long overallAvgResponse = this.stats.getOverallAveragePeerResponseTime();
+
+            sb.append(
+                    String.format(
+                            "================================================================= sync-avg-response-by-peer ==================================================================\n"));
+
+            sb.append(String.format("%9s %13s\n", "id", "Avg. Response"));
+            sb.append(String.format("==Overall %10s ms\n", overallAvgResponse));
+
+            avgResponseTimeByPeers.forEach(
+                    (nodeId, avgResponse) -> {
+                        sb.append(
+                                String.format(
+                                        "id:%6s %10s ms\n",
+                                        nodeId, String.format("%.0f", avgResponse)));
+                    });
+        }
+
+        return sb.toString();
+    }
+
+    public String dumpPeerStateInfo(Collection<INode> filtered) {
     private String dumpPeerStateInfo(Collection<INode> filtered) {
         List<NodeState> sorted = new ArrayList<>();
         for (INode n : filtered) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
@@ -157,7 +157,7 @@ final class TaskShowStatus implements Runnable {
      *
      * @return log stream with peers statistical data
      */
-    public String dumpPeerStatsInfo() {
+    private String dumpPeerStatsInfo() {
         Map<String, Float> reqToPeers = this.stats.getPercentageOfRequestsToPeers();
         Map<String, Long> totalBlockReqByPeer = this.stats.getTotalBlockRequestsByPeer();
         Map<String, Long> totalBlocksByPeer = this.stats.getTotalBlocksByPeer();
@@ -233,7 +233,6 @@ final class TaskShowStatus implements Runnable {
         return sb.toString();
     }
 
-    public String dumpPeerStateInfo(Collection<INode> filtered) {
     private String dumpPeerStateInfo(Collection<INode> filtered) {
         List<NodeState> sorted = new ArrayList<>();
         for (INode n : filtered) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqBlocksBodiesHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ReqBlocksBodiesHandler.java
@@ -48,6 +48,7 @@ import org.aion.p2p.P2pConstant;
 import org.aion.p2p.Ver;
 import org.aion.zero.impl.core.IAionBlockchain;
 import org.aion.zero.impl.sync.Act;
+import org.aion.zero.impl.sync.SyncMgr;
 import org.aion.zero.impl.sync.msg.ReqBlocksBodies;
 import org.aion.zero.impl.sync.msg.ResBlocksBodies;
 import org.aion.zero.impl.types.AionBlock;
@@ -63,6 +64,8 @@ public final class ReqBlocksBodiesHandler extends Handler {
 
     private final IAionBlockchain blockchain;
 
+    private final SyncMgr syncMgr;
+
     private final IP2pMgr p2pMgr;
 
     private final Map<ByteArrayWrapper, byte[]> cache =
@@ -73,11 +76,13 @@ public final class ReqBlocksBodiesHandler extends Handler {
     public ReqBlocksBodiesHandler(
             final Logger _log,
             final IAionBlockchain _blockchain,
+            final SyncMgr _syncMgr,
             final IP2pMgr _p2pMgr,
             final boolean isSyncOnlyNode) {
         super(Ver.V0, Ctrl.SYNC, Act.REQ_BLOCKS_BODIES);
         this.log = _log;
         this.blockchain = _blockchain;
+        this.syncMgr = _syncMgr;
         this.p2pMgr = _p2pMgr;
         this.isSyncOnlyNode = isSyncOnlyNode;
     }
@@ -135,6 +140,7 @@ public final class ReqBlocksBodiesHandler extends Handler {
             }
 
             this.p2pMgr.send(_nodeIdHashcode, _displayId, new ResBlocksBodies(blockBodies));
+            this.syncMgr.getSyncStats().updateTotalBlockRequestsByPeer(_displayId, blockBodies.size());
 
             if (log.isDebugEnabled()) {
                 this.log.debug(

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
@@ -80,6 +80,7 @@ public final class ResBlocksBodiesHandler extends Handler {
                 log.error("<res-bodies-empty node={}>", _displayId);
             } else {
                 syncMgr.validateAndAddBlocks(_nodeIdHashcode, _displayId, bodies);
+                syncMgr.getSyncStats().updateTotalBlockRequestsByPeer(_displayId);
             }
         }
     }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
@@ -80,7 +80,7 @@ public final class ResBlocksBodiesHandler extends Handler {
                 log.error("<res-bodies-empty node={}>", _displayId);
             } else {
                 syncMgr.validateAndAddBlocks(_nodeIdHashcode, _displayId, bodies);
-                syncMgr.getSyncStats().updateTotalBlockRequestsByPeer(_displayId);
+                syncMgr.getSyncStats().updateTotalBlockRequestsByPeer(_displayId, bodies.size());
             }
         }
     }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
@@ -80,7 +80,6 @@ public final class ResBlocksBodiesHandler extends Handler {
                 log.error("<res-bodies-empty node={}>", _displayId);
             } else {
                 syncMgr.validateAndAddBlocks(_nodeIdHashcode, _displayId, bodies);
-                syncMgr.getSyncStats().updateTotalBlockRequestsByPeer(_displayId, bodies.size());
             }
         }
     }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
@@ -76,7 +76,7 @@ public final class ResStatusHandler extends Handler {
             }
         }
 
-        this.syncMgr.getSyncStats().addPeerResponseTime(_displayId);
+        this.syncMgr.getSyncStats().addPeerResponseTime(_displayId, System.currentTimeMillis());
         INode node = this.p2pMgr.getActiveNodes().get(_nodeIdHashcode);
         if (node != null && rs != null) {
             if (log.isDebugEnabled()) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
@@ -76,6 +76,7 @@ public final class ResStatusHandler extends Handler {
             }
         }
 
+        this.syncMgr.getSyncStats().addPeerResponseTime(_displayId);
         INode node = this.p2pMgr.getActiveNodes().get(_nodeIdHashcode);
         if (node != null && rs != null) {
             if (log.isDebugEnabled()) {

--- a/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
@@ -1,0 +1,175 @@
+package org.aion.zero.impl.sync;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.aion.zero.impl.BlockchainTestUtils.generateAccounts;
+import static org.aion.zero.impl.BlockchainTestUtils.generateNewBlock;
+import static org.aion.zero.impl.BlockchainTestUtils.generateRandomChain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.aion.crypto.ECKey;
+import org.aion.mcf.core.ImportResult;
+import org.aion.zero.impl.StandaloneBlockchain;
+import org.aion.zero.impl.types.AionBlock;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SyncStatsTest {
+
+    private static final List<ECKey> accounts = generateAccounts(10);
+    private final StandaloneBlockchain.Bundle bundle = new StandaloneBlockchain.Builder()
+            .withValidatorConfiguration("simple")
+            .withDefaultAccounts(accounts)
+            .build();
+
+    private static final List<String> peers = new ArrayList<>();
+
+    @BeforeClass
+    public static void setup() {
+        // mock some peer Ids
+        peers.add(UUID.randomUUID().toString().substring(0, 6));
+        peers.add(UUID.randomUUID().toString().substring(0, 6));
+        peers.add(UUID.randomUUID().toString().substring(0, 6));
+    }
+
+    @Test
+    public void testAvgBlocksPerSecStat() {
+
+        StandaloneBlockchain chain = bundle.bc;
+        generateRandomChain(chain, 1, 1, accounts, 10);
+
+        SyncStats stats = new SyncStats(chain.getBestBlock().getNumber());
+
+        for(int totalBlocks = 1; totalBlocks <= 3; totalBlocks++) {
+                int count = 0;
+                while(count < totalBlocks) {
+                        AionBlock current = generateNewBlock(chain, chain.getBestBlock(), accounts, 10);
+                        assertThat(chain.tryToConnect(current)).isEqualTo(ImportResult.IMPORTED_BEST);
+                        count++;
+                }
+                stats.update(peers.get(0), totalBlocks, chain.getBestBlock().getNumber());
+                try {
+                        Thread.sleep(1000);
+                } catch(InterruptedException e) {
+
+                }
+        }
+
+        assertThat(stats.getAvgBlocksPerSec()  <= 3.).isTrue();
+    }
+
+    @Test
+    public void testTotalRequestsToPeersStat() {
+
+        StandaloneBlockchain chain = bundle.bc;
+        generateRandomChain(chain, 1, 1, accounts, 10);
+
+        SyncStats stats = new SyncStats(chain.getBestBlock().getNumber());
+
+        int peerNo = 0;
+        int processedBlocks = 0;
+
+        for(int totalBlocks = peers.size(); totalBlocks > 0; totalBlocks--) {
+                int blocks = totalBlocks;
+                processedBlocks += totalBlocks;
+                while(blocks > 0) {
+                        AionBlock current = generateNewBlock(chain, chain.getBestBlock(), accounts, 10);
+                        assertThat(chain.tryToConnect(current)).isEqualTo(ImportResult.IMPORTED_BEST);
+                        stats.update(peers.get(peerNo), blocks, chain.getBestBlock().getNumber());
+                        blocks--;
+                }
+                peerNo++;
+        }
+
+        Map<String, Float> reqToPeers = stats.getPercentageOfRequestsToPeers();
+        Map<String, Long> totalBlockReqByPeer = stats.getTotalBlocksByPeer();
+
+        assertThat(reqToPeers.size() == peers.size()).isTrue();
+        assertThat(totalBlockReqByPeer.size() == peers.size()).isTrue();
+
+        int blocks = 3;
+
+        float lastPercentage = (float) 1;
+        float diffThreshold = (float) 0.01;
+
+        long lastTotalBlocks = processedBlocks;
+
+        for(String nodeId:reqToPeers.keySet()) {
+                float percentageReq = reqToPeers.get(nodeId);
+                // ensures desc order
+                assertThat(lastPercentage >= percentageReq).isTrue();
+                lastPercentage = percentageReq;
+                assertThat(percentageReq - (1. * blocks/processedBlocks) < diffThreshold).isTrue();
+                // ensures desc order
+                assertThat(lastTotalBlocks >= totalBlockReqByPeer.get(nodeId)).isTrue();
+                lastTotalBlocks = totalBlockReqByPeer.get(nodeId);
+                assertThat(totalBlockReqByPeer.get(nodeId).compareTo(Long.valueOf(blocks)) == 0);
+                blocks--;
+        }
+    }
+
+    @Test
+    public void testTotalBlockRequestsByPeerStats() {
+
+        StandaloneBlockchain chain = bundle.bc;
+        generateRandomChain(chain, 1, 1, accounts, 10);
+
+        SyncStats stats = new SyncStats(chain.getBestBlock().getNumber());
+
+        int blocks = 3;
+        for(String nodeId:peers) {
+            int count = 0;
+            while(count < blocks) {
+                stats.updateTotalBlockRequestsByPeer(nodeId);
+                count++;
+            }
+            blocks--;
+        }
+
+        Map<String, Long> totalBlocksByPeer = stats.getTotalBlockRequestsByPeer();
+        assertThat(totalBlocksByPeer.size() == peers.size()).isTrue();
+
+        Long lastTotalBlocks = (long) peers.size();
+        for(String nodeId:totalBlocksByPeer.keySet()) {
+            // ensures desc order
+            assertThat(lastTotalBlocks >= totalBlocksByPeer.get(nodeId)).isTrue();
+            lastTotalBlocks = totalBlocksByPeer.get(nodeId);
+        }
+    }
+
+    @Test
+    public void testAverageResponseTimeByPeersStats() {
+
+        StandaloneBlockchain chain = bundle.bc;
+        generateRandomChain(chain, 1, 1, accounts, 10);
+
+        SyncStats stats = new SyncStats(chain.getBestBlock().getNumber());
+
+        int requests = 3;
+        for(String nodeId:peers) {
+            int count = requests;
+            while(count > 0) {
+                stats.addPeerRequestTime(nodeId);
+                try {
+                    Thread.sleep(100 * count);
+                } catch(InterruptedException e) {
+                }
+                stats.addPeerResponseTime(nodeId);
+                count--;
+            }
+            requests--;
+        }
+
+        Map<String, Double> avgResponseTimeByPeers = stats.getAverageResponseTimeByPeers();
+        assertThat(avgResponseTimeByPeers.size() == peers.size()).isTrue();
+
+        Double lastAvgResponseTime = Double.MIN_VALUE;
+        for(String nodeId:avgResponseTimeByPeers.keySet()) {
+            // ensures asc order
+            assertThat(avgResponseTimeByPeers.get(nodeId) > lastAvgResponseTime).isTrue();
+            lastAvgResponseTime = avgResponseTimeByPeers.get(nodeId);
+        }
+    }
+}

--- a/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
@@ -192,7 +192,7 @@ public class SyncStatsTest {
         int i = 0;
         for (String nodeId : avgResponseTimeByPeers.keySet()) {
             // ensures asc order
-            if(i == 0) {
+            if(i++ == 0) {
                 // First record correspond to the overall average response time by all peers
                 assertThat(((Long)avgResponseTimeByPeers.get(nodeId).longValue())
                     .compareTo(stats.getOverallAveragePeerResponseTime()));


### PR DESCRIPTION
## Description

Expands sync statistics for the Aion Kernel to produce a more comprehensive set that helps users and developers better monitor the Kernel. This PR covers feature requirements defined on issue #661:

- The percentage of requests made to each peer with respect to the total number of requests made.
- A list of peers ordered by the total number of blocks received from each peer.
- A list of peers ordered by the total number of blocks requested by each peer.
- Average response time between sending requests out and that peer responding shown for each peer and averaged for all peers.
- Methods have to be implemented in `SyncStats.java`, while information should be printed in `TaskShowStatus.java` under debug logging.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [X] New feature.
- [ ] Enhancement.
- [X] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Unit tests for each method implemented in `SyncStats.java` that return stats summaries were implemented in class `org.aion.zero.impl.sync.SyncStatsTest.java`. They can be run locally using the following commands:

```bash
$ cd modAionImpl/
$ ../gradlew test --tests org.aion.zero.impl.sync.SyncStatsTest --info
```

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [X] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [X] New and existing tests pass locally with my changes.
- [X] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [X] My code generates no new warnings.
- [X] Any dependent changes have been made.
