### PR TITLE
Compact the state after slow block imports

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -544,6 +544,10 @@ public class AionBlockchainImpl implements IAionBlockchain {
         return tryToConnectInternal(block, System.currentTimeMillis() / THOUSAND_MS);
     }
 
+    public synchronized void compactState() {
+        repository.compactState();
+    }
+
     /**
      * Processes a new block and potentially appends it to the blockchain, thereby changing the
      * state of the world. Decoupled from wrapper function {@link #tryToConnect(AionBlock)} so we

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -793,4 +793,13 @@ public class AionRepositoryImpl
             rwLock.writeLock().unlock();
         }
     }
+
+    public void compactState() {
+        rwLock.writeLock().lock();
+        try {
+            this.stateDatabase.compact();
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -559,12 +559,13 @@ final class TaskImportBlocks implements Runnable {
         if (log.isDebugEnabled()) {
             // printing sync mode only when debug is enabled
             log.debug(
-                    "<import-status: node = {}, sync mode = {}, hash = {}, number = {}, txs = {}, result = {}, time elapsed = {} ms>",
+                    "<import-status: node = {}, sync mode = {}, hash = {}, number = {}, txs = {}, block time = {}, result = {}, time elapsed = {} ms>",
                     displayId,
                     (state != null ? state.getMode() : NORMAL),
                     b.getShortHash(),
                     b.getNumber(),
                     b.getTransactionsList().size(),
+                    b.getTimestamp(),
                     importResult,
                     t2 - t1);
         } else {
@@ -572,15 +573,22 @@ final class TaskImportBlocks implements Runnable {
             // a different message will be printed to indicate the storage of blocks
             if (!state.isInFastMode() || importResult != ImportResult.NO_PARENT) {
                 log.info(
-                        "<import-status: node = {}, hash = {}, number = {}, txs = {}, block time = {}, result = {}, time elapsed = {} ms>",
+                        "<import-status: node = {}, hash = {}, number = {}, txs = {}, result = {}, time elapsed = {} ms>",
                         displayId,
                         b.getShortHash(),
                         b.getNumber(),
                         b.getTransactionsList().size(),
-                        b.getTimestamp(),
                         importResult,
                         t2 - t1);
             }
+        }
+        // trigger compact when IO is slow
+        if (t2 - t1 > 100) {
+            t1 = System.currentTimeMillis();
+            this.chain.compactState();
+            t2 = System.currentTimeMillis();
+            log.info(
+                    "Compacting state databases due to slow IO time. Completed in {} ms.", t2 - t1);
         }
         return importResult;
     }

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -583,12 +583,11 @@ final class TaskImportBlocks implements Runnable {
             }
         }
         // trigger compact when IO is slow
-        if (t2 - t1 > 100) {
+        if (t2 - t1 > 400) {
             t1 = System.currentTimeMillis();
             this.chain.compactState();
             t2 = System.currentTimeMillis();
-            log.info(
-                    "Compacting state databases due to slow IO time. Completed in {} ms.", t2 - t1);
+            log.info("Compacting state database due to slow IO time. Completed in {} ms.", t2 - t1);
         }
         return importResult;
     }


### PR DESCRIPTION
## Description

The new sync strategy puts more pressure on the db by importing blocks significantly faster. To counterbalance this I've added functionality to call LevelDBs compaction process when block import times reach 100 milliseconds, which results in a speedup of subsequent imports.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
