### PR TITLE
Included the ip and port in computing the id hash

### DIFF
--- a/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ReqHandshake.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ReqHandshake.java
@@ -32,6 +32,7 @@ import org.aion.p2p.impl.comm.Act;
 /** @author chris */
 public class ReqHandshake extends Msg {
 
+    private byte[] uniqueId = null; // 48 bytes
     byte[] nodeId; // 36 bytes
 
     private int netId; // 4 bytes
@@ -64,6 +65,27 @@ public class ReqHandshake extends Msg {
 
     public int getPort() {
         return this.port;
+    }
+
+    /**
+     * Returns an unique identifier that contains the node identifier, IP and port number.
+     *
+     * @return an unique identifier that contains the node identifier, IP and port number
+     */
+    public byte[] getUniqueId() {
+        if (uniqueId == null) {
+            uniqueId = new byte[48];
+            if (nodeId != null) {
+                System.arraycopy(nodeId, 0, uniqueId, 0, nodeId.length);
+            }
+            if (ip != null) {
+                System.arraycopy(ip, 0, uniqueId, 36, ip.length);
+            }
+            for (int i = 0; i < 4; i++) {
+                uniqueId[47 - i] = (byte) (port >>> (i * 8));
+            }
+        }
+        return uniqueId;
     }
 
     /**

--- a/modP2pImpl/test/org/aion/p2p/impl/comm/NodeTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/comm/NodeTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.Arrays;
 import java.util.UUID;
@@ -136,7 +137,15 @@ public class NodeTest {
         validNode.setId(bId);
 
         assertEquals(bId, validNode.getId());
-        assertEquals(Arrays.hashCode(bId), validNode.getIdHash());
+
+        byte[] ip = validNode.getIp();
+        ByteBuffer buffer =
+                ByteBuffer.allocate(bId.length + ip.length + Integer.BYTES)
+                        .put(bId)
+                        .put(ip)
+                        .putInt(validPort);
+
+        assertEquals(Arrays.hashCode(buffer.array()), validNode.getIdHash());
 
         String idShort = new String(Arrays.copyOfRange(id.getBytes(), 0, 6));
         assertEquals(idShort, validNode.getIdShort());
@@ -159,8 +168,17 @@ public class NodeTest {
         validNode.setBinaryVersion(revision);
         assertEquals(revision, validNode.getBinaryVersion());
 
+        // test invalid (negative) port
+        validNode.setPort(-1);
+        assertEquals(0, validNode.getPort());
+
+        // test valid port
         validNode.setPort(12345);
         assertEquals(12345, validNode.getPort());
+
+        // test invalid (large) port
+        validNode.setPort(65536);
+        assertEquals(0, validNode.getPort());
     }
 
     @Test

--- a/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ReqHandshake1Test.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ReqHandshake1Test.java
@@ -136,6 +136,30 @@ public class ReqHandshake1Test {
     }
 
     @Test
+    public void testUniqueId() {
+        ReqHandshake1 req1 =
+                new ReqHandshake1(
+                        validNodeId,
+                        netId,
+                        Node.ipStrToBytes(randomIp),
+                        port,
+                        randomRevision,
+                        randomVersions);
+
+        byte[] uniqueID = req1.getUniqueId();
+
+        assertEquals(uniqueID.length, 48);
+        assertArrayEquals(Arrays.copyOfRange(uniqueID, 0, 36), req1.getNodeId());
+        assertArrayEquals(Arrays.copyOfRange(uniqueID, 36, 44), req1.getIp());
+        int myPort =
+                uniqueID[44] << 24
+                        | (uniqueID[45] & 0xFF) << 16
+                        | (uniqueID[46] & 0xFF) << 8
+                        | (uniqueID[47] & 0xFF);
+        assertEquals(myPort, req1.getPort());
+    }
+
+    @Test
     public void testRepeatEncodeDecode() {
 
         // Repeated Encode and Decode Units


### PR DESCRIPTION
## Description

Analyzing some execution logs I noticed that if multiple peers have the same id all but the first get rejected. This restriction is unnecessary and leads to a random selection in which peer gets to connect to a node.

This PR updates the computed id hash to include the IP and port number, ensuring unique kernel instances are considered separately as peers. Effectively it allows that if kernel A and kernel B have the same id, then a kernel C (using this implementation) can communicate with both A and B, whereas before it would have selected the first node it interacted with and rejected the other.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite + a few specific tests

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
