### PR TITLE
reduce web3 default transaction energy limit to 90,000

### DIFF
--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -775,7 +775,7 @@ public abstract class ApiAion extends Api {
     }
 
     protected long getDefaultNrgLimit() {
-        return 2_000_000L;
+        return 90_000L;
     }
 
     protected void startES(String thName) {

--- a/modApiServer/test/org/aion/api/server/types/ArgTxCallTest.java
+++ b/modApiServer/test/org/aion/api/server/types/ArgTxCallTest.java
@@ -37,7 +37,7 @@ public class ArgTxCallTest {
 
     @Test
     public void testFromJsonDefaults() {
-        long nrgLimit = 2_000_000L;
+        long nrgLimit = 90_000L;
         long nrgPrice = 10L;
 
         JSONObject tx = new JSONObject();


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Reduce the default transaction energy limit in web3 from 2,000,000L  to 90,000L

Fixes Issue #689  .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [x] Any dependent changes have been made.
