### PR TITLE
Config migration

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/config/CfgAion.java
+++ b/modAionImpl/src/org/aion/zero/impl/config/CfgAion.java
@@ -65,6 +65,7 @@ public final class CfgAion extends Cfg {
     public CfgAion() {
         this.mode = "aion";
         this.id = UUID.randomUUID().toString();
+        this.keystorePath = null;
         this.net = new CfgNet();
         this.consensus = new CfgConsensusPow();
         this.sync = new CfgSync();
@@ -139,10 +140,10 @@ public final class CfgAion extends Cfg {
         }
     }
 
-//    /** @implNote the default fork settings is looking for the fork config of the mainnet. */
-//    public void setForkProperties() {
-//        setForkProperties("mainnet", null);
-//    }
+    //    /** @implNote the default fork settings is looking for the fork config of the mainnet. */
+    //    public void setForkProperties() {
+    //        setForkProperties("mainnet", null);
+    //    }
 
     public void setForkProperties(String networkName, File forkFile) {
         Properties properties = new Properties();
@@ -172,9 +173,9 @@ public final class CfgAion extends Cfg {
         }
     }
 
-//    public void setForkProperties(String networkName) {
-//        setForkProperties(networkName, null);
-//    }
+    //    public void setForkProperties(String networkName) {
+    //        setForkProperties(networkName, null);
+    //    }
 
     public void dbFromXML() {
         File cfgFile = getInitialConfigFile();
@@ -307,6 +308,13 @@ public final class CfgAion extends Cfg {
             this.setLogDir(log);
         }
 
+        if (keystorePath != null) {
+            File ks = new File(keystorePath);
+            if (ks.isAbsolute()) {
+                this.setKeystoreDir(ks);
+            }
+        }
+
         return shouldWriteBackToFile;
     }
 
@@ -386,6 +394,13 @@ public final class CfgAion extends Cfg {
             sw.writeStartElement("id");
             sw.writeCharacters(this.getId());
             sw.writeEndElement();
+
+            if (keystorePath != null) {
+                sw.writeCharacters("\r\n\t");
+                sw.writeStartElement("keystore");
+                sw.writeCharacters(keystorePath);
+                sw.writeEndElement();
+            }
 
             sw.writeCharacters(this.getApi().toXML());
             sw.writeCharacters(this.getNet().toXML());

--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -191,14 +191,14 @@ public class Aion {
                         + filePath[3]
                         + "\n> Genesis write: "
                         + filePath[4]
-                        + "\n> Fork write: "
+                        + "\n> Fork write:    "
                         + filePath[5]
                         + "\n----------------------------------------------------------------------------"
                         + "\n> Config read:   "
                         + filePath[6]
                         + "\n> Genesis read:  "
                         + filePath[7]
-                        + "\n> Fork read:  "
+                        + "\n> Fork read:     "
                         + filePath[8]
                         + "\n----------------------------------------------------------------------------\n\n";
 

--- a/modMcf/src/org/aion/mcf/config/Cfg.java
+++ b/modMcf/src/org/aion/mcf/config/Cfg.java
@@ -266,10 +266,12 @@ public abstract class Cfg {
             // using absolute path for database
             absoluteDatabaseDir = true;
             databaseDir = new File(INITIAL_PATH, getDb().getPath());
+            getDb().setPath(databaseDir.getAbsolutePath());
 
             // using absolute path for log
             absoluteLogDir = true;
             logDir = new File(INITIAL_PATH, getLog().getLogPath());
+            getLog().setLogPath(logDir.getAbsolutePath());
 
             // using absolute path for keystore
             absoluteKeystoreDir = true;


### PR DESCRIPTION
## Description

Automatically migrates the old kernel configurations as follows:
1. check if `config/config.xml` exists:
2. if **no**, it's already a new kernel and no changes are necessary;
3. if **yes**:
    i. read the file located at `config/config.xml`;
    ii. check the network id in the config and match it to the available networks: `conquest`, `mainnet`, `mastery`, or `custom`;
    iii. delete `config/config.xml` and `config/genesis.json`;
    iv. overwrite `[network]/config/config.xml` with the read configuration;
    v.  set `database`, `log` and `keystore` to absolute path based on the location read from the old config.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite
- updated tests for new behavior
- manual checks to verify that the configuration files get correctly copied and deleted, the absolute path to the keystore is added and the paths to the database and logs are set to absolute.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
