### PR TITLE
Clean up transaction result code

### DIFF
--- a/modPrecompiled/src/org/aion/precompiled/contracts/AionAuctionContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/AionAuctionContract.java
@@ -163,24 +163,24 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
         // check length for both operations
         if (input.length < 131) {
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - COST, "incorrect input length".getBytes());
+                    ResultCode.FAILURE, nrg - COST, "incorrect input length".getBytes());
         }
 
         int domainNameLength = input[0];
         if (domainNameLength < 0)
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - COST, "incorrect input length".getBytes());
+                    ResultCode.FAILURE, nrg - COST, "incorrect input length".getBytes());
 
         // check if input is too short for extension function
         if (input.length < 130 + domainNameLength)
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - COST, "incorrect input length".getBytes());
+                    ResultCode.FAILURE, nrg - COST, "incorrect input length".getBytes());
         int balanceLength = input[129 + domainNameLength];
 
         if (balanceLength > 0) {
             if (input.length < 130 + domainNameLength + balanceLength) {
                 return new ExecutionResult(
-                        ResultCode.INTERNAL_ERROR, nrg - COST, "incorrect input length".getBytes());
+                        ResultCode.FAILURE, nrg - COST, "incorrect input length".getBytes());
             }
         }
 
@@ -206,14 +206,14 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
         // check if the domain name already has active parent domain
         if (hasActiveParentDomain(domainNameRaw))
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     nrg - COST,
                     "the given domain name has a parent that is already active".getBytes());
 
         // check if the domain name is valid to register
         if (!isValidDomainName(domainNameRaw))
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - COST, "domain name is invalid".getBytes());
+                    ResultCode.FAILURE, nrg - COST, "domain name is invalid".getBytes());
 
         // add zeros for storing
         byte[] domainNameInBytesWithZeros = addLeadingZeros(domainNameInBytes);
@@ -232,12 +232,12 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
         // verify public key matches owner
         if (!b) {
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - COST, "incorrect signature".getBytes());
+                    ResultCode.FAILURE, nrg - COST, "incorrect signature".getBytes());
         }
 
         if (!bidderAddress.equals(Address.wrap(sig.getAddress()))) {
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - COST, "incorrect key".getBytes());
+                    ResultCode.FAILURE, nrg - COST, "incorrect key".getBytes());
         }
 
         // if this domain name does not have an callerAddress
@@ -263,17 +263,17 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
         // check if bidValue is valid (greater than 0)
         if (bidValue.compareTo(new BigInteger("0")) < 0)
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - COST, "negative bid value".getBytes());
+                    ResultCode.FAILURE, nrg - COST, "negative bid value".getBytes());
 
         // check bidder addr and its balance
         if (this.track.hasAccountState(bidderAddress)) {
             if (this.track.getAccountState(bidderAddress).getBalance().compareTo(bidValue) < 0) {
                 return new ExecutionResult(
-                        ResultCode.INTERNAL_ERROR, nrg - COST, "insufficient balance".getBytes());
+                        ResultCode.FAILURE, nrg - COST, "insufficient balance".getBytes());
             }
         } else
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     nrg - COST,
                     "bidder account does not exist".getBytes());
 
@@ -341,7 +341,7 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
         if (expireDateFromStorage.getTime() < currentDate.getTime()
                 || difference > ACTIVE_TIME.intValue()) {
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, COST - nrg, "already been extended".getBytes());
+                    ResultCode.FAILURE, COST - nrg, "already been extended".getBytes());
         }
 
         // add the new expire date

--- a/modPrecompiled/src/org/aion/precompiled/contracts/AionNameServiceContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/AionNameServiceContract.java
@@ -146,7 +146,7 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
     public ExecutionResult execute(byte[] input, long nrg) {
         // check for correct input length
         if (input.length != 130 && input.length != 226)
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
 
         // declare variables for parsing the byte[] input and storing each value
         byte[] addressFirstPart = new byte[16];
@@ -185,12 +185,12 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
                 subdomainName = new String(trimmedSubdomainNameInBytes, "UTF-8");
 
                 if (!isValidDomainName(this.domainName)) {
-                    return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                    return new ExecutionResult(ResultCode.FAILURE, 0);
                 }
 
                 domains.put(this.domainName, this.address);
             } catch (UnsupportedEncodingException a) {
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                return new ExecutionResult(ResultCode.FAILURE, 0);
             }
         }
 
@@ -201,12 +201,12 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
 
         boolean b = ECKeyEd25519.verify(data, sig.getSignature(), sig.getPubkey(null));
         if (!b) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // verify public key matches owner
         if (!this.ownerAddress.equals(Address.wrap(sig.getAddress()))) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // operation: {1-setResolver, 2-setTTL, 3-transferOwnership, 4-transferSubdomainOwnership}
@@ -237,7 +237,7 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
                         addressSecondPart,
                         subdomainName);
             default:
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, nrg); // unsupported operation
+                return new ExecutionResult(ResultCode.FAILURE, nrg); // unsupported operation
         }
     }
 
@@ -275,7 +275,7 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
         if (nrg < TRANSFER_COST) return new ExecutionResult(ResultCode.OUT_OF_NRG, 0);
 
         if (!isValidOwnerAddress(Address.wrap(combineTwoBytes(addr1, addr2))))
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, nrg);
+            return new ExecutionResult(ResultCode.FAILURE, nrg);
 
         Address.wrap(combineTwoBytes(addr1, addr2));
         storeResult(hash1, hash2, addr1, addr2);
@@ -299,7 +299,7 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
         if (nrg < TRANSFER_COST) return new ExecutionResult(ResultCode.OUT_OF_NRG, 0);
 
         if (!isValidOwnerAddress(Address.wrap(combineTwoBytes(addr1, addr2))))
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, nrg);
+            return new ExecutionResult(ResultCode.FAILURE, nrg);
 
         Address sdAddress = Address.wrap(subdomainAddress);
 
@@ -308,7 +308,7 @@ public class AionNameServiceContract extends StatefulPrecompiledContract {
             this.track.addStorageRow(sdAddress, new DataWord(hash2), new DataWord(addr2));
             return new ExecutionResult(ResultCode.SUCCESS, nrg - TRANSFER_COST);
         }
-        return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+        return new ExecutionResult(ResultCode.FAILURE, 0);
     }
 
     /**

--- a/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/EDVerifyContract.java
@@ -67,7 +67,7 @@ public class EDVerifyContract implements IPrecompiledContract {
             result[0] = verify ? (byte) 1 : (byte) 0;
             return new ExecutionResult(ExecutionResult.ResultCode.SUCCESS, nrgLimit - COST, result);
         } catch (Exception e) {
-            return new ExecutionResult(ExecutionResult.ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ExecutionResult.ResultCode.FAILURE, 0);
         }
     }
 }

--- a/modPrecompiled/src/org/aion/precompiled/contracts/KeccakHash.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/KeccakHash.java
@@ -49,7 +49,7 @@ public class KeccakHash implements IPrecompiledContract {
         // check length
         if (input.length < 1)
             return new ExecutionResult(
-                    ResultCode.INTERNAL_ERROR, nrg - DEFAULT_COST, "input too short".getBytes());
+                    ResultCode.FAILURE, nrg - DEFAULT_COST, "input too short".getBytes());
 
         byte[] hash = keccak256(input);
         return new ExecutionResult(ResultCode.SUCCESS, nrg - DEFAULT_COST - additionalNRG, hash);

--- a/modPrecompiled/src/org/aion/precompiled/contracts/TRS/TRSqueryContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/TRS/TRSqueryContract.java
@@ -180,10 +180,10 @@ public final class TRSqueryContract extends AbstractTRS {
     @Override
     public ExecutionResult execute(byte[] input, long nrgLimit) {
         if (input == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
         if (input.length == 0) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
         if (nrgLimit < COST) {
             return new ExecutionResult(ResultCode.OUT_OF_NRG, 0);
@@ -207,7 +207,7 @@ public final class TRSqueryContract extends AbstractTRS {
             case 5:
                 return availableForWithdrawalAt(input, nrgLimit);
             default:
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                return new ExecutionResult(ResultCode.FAILURE, 0);
         }
     }
 
@@ -232,7 +232,7 @@ public final class TRSqueryContract extends AbstractTRS {
         final int len = 33;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         byte[] result = new byte[1];
@@ -264,7 +264,7 @@ public final class TRSqueryContract extends AbstractTRS {
         final int len = 33;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         byte[] result = new byte[1];
@@ -297,7 +297,7 @@ public final class TRSqueryContract extends AbstractTRS {
         final int len = 33;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         byte[] result = new byte[1];
@@ -337,7 +337,7 @@ public final class TRSqueryContract extends AbstractTRS {
         final int len = 33;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Grab the contract address and block number and determine the period.
@@ -375,7 +375,7 @@ public final class TRSqueryContract extends AbstractTRS {
         final int len = 41;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Grab the contract address and block number and determine the period.
@@ -387,7 +387,7 @@ public final class TRSqueryContract extends AbstractTRS {
         long blockNum = blockBuf.getLong();
 
         if (blockNum <= 0) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         return determinePeriod(contract, blockchain.getBlockByNumber(blockNum), nrgLimit);
@@ -420,13 +420,13 @@ public final class TRSqueryContract extends AbstractTRS {
         final int len = 41;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexContract, indexTimestamp));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // If a contract has its funds open then the fraction is always 1.
@@ -440,7 +440,7 @@ public final class TRSqueryContract extends AbstractTRS {
         // This operation is only well-defined when the contract has a start time. Thus the contract
         // must be in the following state: live.
         if (!isContractLive(contract)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
@@ -500,7 +500,7 @@ public final class TRSqueryContract extends AbstractTRS {
 
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // If contract is not yet live we are in period 0.
@@ -511,7 +511,7 @@ public final class TRSqueryContract extends AbstractTRS {
 
         // Grab the timestamp of block number blockNum and calculate the period the contract is in.
         if (block == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         long blockTime = block.getTimestamp();

--- a/modPrecompiled/src/org/aion/precompiled/contracts/TRS/TRSuseContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/TRS/TRSuseContract.java
@@ -212,10 +212,10 @@ public final class TRSuseContract extends AbstractTRS {
     @Override
     public ExecutionResult execute(byte[] input, long nrgLimit) {
         if (input == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
         if (input.length == 0) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
         if (nrgLimit < COST) {
             return new ExecutionResult(ResultCode.OUT_OF_NRG, 0);
@@ -241,7 +241,7 @@ public final class TRSuseContract extends AbstractTRS {
             case 6:
                 return addExtraFunds(input, nrgLimit);
             default:
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                return new ExecutionResult(ResultCode.FAILURE, 0);
         }
     }
 
@@ -272,26 +272,26 @@ public final class TRSuseContract extends AbstractTRS {
         final int len = 161;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexAddress, indexAmount));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A deposit operation can only execute if direct depositing is enabled or caller is owner.
         Address owner = getContractOwner(contract);
         if (!caller.equals(owner) && !isDirDepositsEnabled(contract)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A deposit operation can only execute if the current state of the TRS contract is:
         // contract is unlocked (and obviously not live -- check this for sanity) and funds are not
         // open.
         if (isContractLocked(contract) || isContractLive(contract) || isOpenFunds(contract)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Put amount in a byte array one byte larger with an empty initial byte so it is unsigned.
@@ -333,24 +333,24 @@ public final class TRSuseContract extends AbstractTRS {
         final int len = 33;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexAddress, len));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A withdraw operation can only execute if the current state of the TRS contract is:
         // contract is live (and obviously locked -- check this for sanity) or contract funds are
         // open.
         if (!isOpenFunds(contract) && (!isContractLocked(contract) || !isContractLive(contract))) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         if (!makeWithdrawal(contract, caller)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         track.flush();
@@ -391,27 +391,27 @@ public final class TRSuseContract extends AbstractTRS {
         // that the entries portion has a length that is a multiple of an entry length.
         int len = input.length;
         if ((len < indexEntries + entryLen) || (len > indexEntries + (entryLen * maxEntries))) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         } else if ((len - indexEntries) % entryLen != 0) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexContract, indexEntries));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A bulk-deposit-for operation can only execute if the caller is the owner of the contract.
         if (!getContractOwner(contract).equals(caller)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A bulkDepositFor operation can only execute if the current state of the TRS contract is:
         // contract is unlocked (and obviously not live -- check this for sanity) and funds are not
         // open.
         if (isContractLocked(contract) || isContractLive(contract) || isOpenFunds(contract)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Iterate over every entry in the entries list and attempt to deposit for them.
@@ -430,7 +430,7 @@ public final class TRSuseContract extends AbstractTRS {
 
             // Verify the account is an Aion address.
             if (input[index] != AION_PREFIX) {
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                return new ExecutionResult(ResultCode.FAILURE, 0);
             }
 
             beneficiaries[i] = Address.wrap(Arrays.copyOfRange(input, index, index + entryAddrLen));
@@ -476,24 +476,24 @@ public final class TRSuseContract extends AbstractTRS {
         final int len = 33;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexAddress, len));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A bulk-withdraw operation can only execute if the caller is the owner of the contract.
         if (!getContractOwner(contract).equals(caller)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A bulk-withdraw operation can only execute if the current state of the TRS contract is:
         // contract is live (and obviously locked -- check this for sanity) or the funds are open.
         if (!isOpenFunds(contract) && (!isContractLocked(contract) || !isContractLive(contract))) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Iterate over all depositors and withdraw on their behalf. Once here this is a success.
@@ -542,33 +542,33 @@ public final class TRSuseContract extends AbstractTRS {
         final int len = 193;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexContract, indexAccount));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A refund operation can only execute if the caller is the contract owner.
         Address owner = getContractOwner(contract);
         if (!caller.equals(owner)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A refund operation can only execute if the current state of the TRS contract is:
         // contract is unlocked (and obviously not live -- check this for sanity) and funds are not
         // open.
         if (isContractLocked(contract) || isContractLive(contract) || isOpenFunds(contract)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Ensure the account exists (ie. has a positive deposit balance for the contract).
         Address account = Address.wrap(Arrays.copyOfRange(input, indexAccount, indexAmount));
         BigInteger accountBalance = getDepositBalance(contract, account);
         if (accountBalance.equals(BigInteger.ZERO)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Put amount in a byte array one byte larger with an empty initial byte so it is unsigned.
@@ -586,7 +586,7 @@ public final class TRSuseContract extends AbstractTRS {
         // then update the deposit meta-data (linked list, count, etc.) and refund the account.
         if (amount.compareTo(BigInteger.ZERO) > 0) {
             if (!setDepositBalance(contract, account, newBalance)) {
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                return new ExecutionResult(ResultCode.FAILURE, 0);
             }
             setTotalBalance(contract, getTotalBalance(contract).subtract(amount));
 
@@ -629,25 +629,25 @@ public final class TRSuseContract extends AbstractTRS {
         final int len = 193;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexContract, indexAccount));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A depositFor operation can only execute if caller is owner.
         if (!caller.equals(getContractOwner(contract))) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A depositFor operation can only execute if the current state of the TRS contract is:
         // contract is unlocked (and obviously not live -- check this for sanity) and funds are not
         // open.
         if (isContractLocked(contract) || isContractLive(contract) || isOpenFunds(contract)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Put amount in a byte array one byte larger with an empty initial byte so it is unsigned.
@@ -663,7 +663,7 @@ public final class TRSuseContract extends AbstractTRS {
 
         // Verify the account is an Aion address.
         if (input[indexAccount] != AION_PREFIX) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address account = Address.wrap(Arrays.copyOfRange(input, indexAccount, indexAmount));
@@ -697,23 +697,23 @@ public final class TRSuseContract extends AbstractTRS {
         final int len = 161;
 
         if (input.length != len) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         Address contract = Address.wrap(Arrays.copyOfRange(input, indexContract, indexAmount));
         byte[] specs = getContractSpecs(contract);
         if (specs == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // A depositFor operation can only execute if caller is owner.
         if (!caller.equals(getContractOwner(contract))) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // If contract has its funds open then this operation fails.
         if (isOpenFunds(contract)) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // Put amount in a byte array one byte larger with an empty initial byte so it is unsigned.
@@ -732,7 +732,7 @@ public final class TRSuseContract extends AbstractTRS {
             track.addBalance(caller, amount.negate());
             return new ExecutionResult(ResultCode.SUCCESS, COST - nrgLimit);
         }
-        return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+        return new ExecutionResult(ResultCode.FAILURE, 0);
     }
 
     // <-------------------------------------HELPER METHODS---------------------------------------->
@@ -762,7 +762,7 @@ public final class TRSuseContract extends AbstractTRS {
         if (amount.compareTo(BigInteger.ZERO) > 0) {
             BigInteger currAmount = getDepositBalance(contract, account);
             if (!setDepositBalance(contract, account, currAmount.add(amount))) {
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                return new ExecutionResult(ResultCode.FAILURE, 0);
             }
             listAddToHead(contract, account);
             setTotalBalance(contract, getTotalBalance(contract).add(amount));

--- a/modPrecompiled/src/org/aion/precompiled/contracts/TotalCurrencyContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/TotalCurrencyContract.java
@@ -128,7 +128,7 @@ public class TotalCurrencyContract extends StatefulPrecompiledContract {
         }
 
         if (input.length < 114) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // process input data
@@ -149,7 +149,7 @@ public class TotalCurrencyContract extends StatefulPrecompiledContract {
         // verify signature is correct
         Ed25519Signature sig = Ed25519Signature.fromBytes(sign);
         if (sig == null) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         byte[] payload = new byte[18];
@@ -157,12 +157,12 @@ public class TotalCurrencyContract extends StatefulPrecompiledContract {
         boolean b = ECKeyEd25519.verify(payload, sig.getSignature(), sig.getPubkey(null));
 
         if (!b) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // verify public key matches owner
         if (!this.ownerAddress.equals(Address.wrap(sig.getAddress()))) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         // payload processing
@@ -172,7 +172,7 @@ public class TotalCurrencyContract extends StatefulPrecompiledContract {
         BigInteger value = BIUtil.toBI(amount);
 
         if (signum != 0x0 && signum != 0x1) {
-            return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+            return new ExecutionResult(ResultCode.FAILURE, 0);
         }
 
         BigInteger finalValue;
@@ -182,7 +182,7 @@ public class TotalCurrencyContract extends StatefulPrecompiledContract {
         } else {
             // subtraction
             if (value.compareTo(totalCurrBI) > 0) {
-                return new ExecutionResult(ResultCode.INTERNAL_ERROR, 0);
+                return new ExecutionResult(ResultCode.FAILURE, 0);
             }
 
             finalValue = totalCurrBI.subtract(value);

--- a/modPrecompiled/test/org/aion/precompiled/TRS/TRSqueryContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/TRS/TRSqueryContractTest.java
@@ -79,7 +79,7 @@ public class TRSqueryContractTest extends TRShelpers {
     public void testCreateNullInput() {
         TRSqueryContract trs = newTRSqueryContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(null, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -87,7 +87,7 @@ public class TRSqueryContractTest extends TRShelpers {
     public void testCreateEmptyInput() {
         TRSqueryContract trs = newTRSqueryContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(ByteUtil.EMPTY_BYTE_ARRAY, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -125,7 +125,7 @@ public class TRSqueryContractTest extends TRShelpers {
         for (int i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
             if ((i < 0) || (i > MAX_OP)) {
                 input[0] = (byte) i;
-                assertEquals(ResultCode.INTERNAL_ERROR, trs.execute(input, COST).getResultCode());
+                assertEquals(ResultCode.FAILURE, trs.execute(input, COST).getResultCode());
             }
         }
     }
@@ -137,7 +137,7 @@ public class TRSqueryContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = new byte[32];
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -146,7 +146,7 @@ public class TRSqueryContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = new byte[34];
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -211,7 +211,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[32];
         input[0] = 0x1;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -221,7 +221,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[34];
         input[0] = 0x1;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -286,7 +286,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[32];
         input[0] = 0x2;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -296,7 +296,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[34];
         input[0] = 0x2;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -350,7 +350,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[32];
         input[0] = 0x3;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -360,7 +360,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[34];
         input[0] = 0x3;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -369,7 +369,7 @@ public class TRSqueryContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = getPeriodInput(acct);
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -477,7 +477,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[32];
         input[0] = 0x4;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -487,7 +487,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = new byte[34];
         input[0] = 0x4;
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -496,7 +496,7 @@ public class TRSqueryContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = getPeriodAtInput(acct, 0);
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -506,7 +506,7 @@ public class TRSqueryContractTest extends TRShelpers {
         Address contract = createLockedAndLiveTRScontract(acct, false, true, 1, BigInteger.ZERO, 0);
         byte[] input = getPeriodAtInput(contract, -1);
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -520,7 +520,7 @@ public class TRSqueryContractTest extends TRShelpers {
 
         byte[] input = getPeriodAtInput(contract, numBlocks + 1);
         ExecutionResult res = newTRSqueryContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -632,7 +632,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = getAvailableForWithdrawalAtInput(contract, 0);
         byte[] shortInput = Arrays.copyOf(input, input.length - 1);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSqueryContract(acct).execute(shortInput, COST).getResultCode());
     }
 
@@ -644,7 +644,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] longInput = new byte[input.length + 1];
         System.arraycopy(input, 0, longInput, 0, input.length);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSqueryContract(acct).execute(longInput, COST).getResultCode());
     }
 
@@ -653,7 +653,7 @@ public class TRSqueryContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = getAvailableForWithdrawalAtInput(acct, 0);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSqueryContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -663,7 +663,7 @@ public class TRSqueryContractTest extends TRShelpers {
         Address contract = createTRScontract(acct, false, true, 7, BigInteger.ZERO, 0);
         byte[] input = getAvailableForWithdrawalAtInput(contract, 0);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSqueryContract(acct).execute(input, COST).getResultCode());
     }
 

--- a/modPrecompiled/test/org/aion/precompiled/TRS/TRSstateContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/TRS/TRSstateContractTest.java
@@ -81,7 +81,7 @@ public class TRSstateContractTest extends TRShelpers {
     public void testCreateNullInput() {
         TRSstateContract trs = newTRSstateContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(null, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -89,7 +89,7 @@ public class TRSstateContractTest extends TRShelpers {
     public void testCreateEmptyInput() {
         TRSstateContract trs = newTRSstateContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(ByteUtil.EMPTY_BYTE_ARRAY, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -119,7 +119,7 @@ public class TRSstateContractTest extends TRShelpers {
         for (int i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
             if ((i < 0) || (i > MAX_OP)) {
                 input[0] = (byte) i;
-                assertEquals(ResultCode.INTERNAL_ERROR, trs.execute(input, COST).getResultCode());
+                assertEquals(ResultCode.FAILURE, trs.execute(input, COST).getResultCode());
             }
         }
     }
@@ -132,13 +132,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(true, false, 1, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test isDirectDeposit true
         input = getCreateInput(true, true, 1, BigInteger.ZERO, 0);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -147,7 +147,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 0, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -157,13 +157,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1201, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Largest too-large period: 65,535
         input = getCreateInput(false, false, 65_535, BigInteger.ZERO, 0);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -173,13 +173,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, BigInteger.ZERO, 19);
         TRSstateContract trs = newTRSstateContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Largest too-large precision: 255
         input = getCreateInput(false, false, 1, BigInteger.ZERO, 255);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -452,14 +452,14 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, raw, 0);
         TRSstateContract trs = newTRSstateContract(caller);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test 18 shifts.
         raw = new BigInteger("100000000000000000001");
         input = getCreateInput(false, false, 1, raw, 18);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test all 9 bytes of percent as 1's using zero shifts.
@@ -479,13 +479,13 @@ public class TRSstateContractTest extends TRShelpers {
         raw = new BigInteger(rawBytes);
         input = getCreateInput(false, false, 1, raw, 0);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test all 9 bytes of percent as 1's using 18 shifts -> 4722.36% still no good.
         input = getCreateInput(false, false, 1, raw, 18);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -547,7 +547,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, raw, shifts);
         TRSstateContract trs = newTRSstateContract(caller);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // With 12 shifts we have: 872.743562198734% -> no good
@@ -555,7 +555,7 @@ public class TRSstateContractTest extends TRShelpers {
         input = getCreateInput(false, false, 1, raw, shifts);
         trs = newTRSstateContract(caller);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // With 13 shifts we have: 87.2743562198734% -> good
@@ -703,7 +703,7 @@ public class TRSstateContractTest extends TRShelpers {
         input[0] = (byte) 0x1;
         TRSstateContract trs = newTRSstateContract(acct);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test on address size 31.
@@ -711,7 +711,7 @@ public class TRSstateContractTest extends TRShelpers {
         input[0] = (byte) 0x1;
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -724,7 +724,7 @@ public class TRSstateContractTest extends TRShelpers {
         System.arraycopy(contract.toBytes(), 0, input, 1, Address.ADDRESS_LEN);
         TRSstateContract trs = newTRSstateContract(acct);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -736,7 +736,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getLockInput(acct);
         TRSstateContract trs = newTRSstateContract(acct);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test attempt to lock what looks like a TRS address (proper prefix).
@@ -744,7 +744,7 @@ public class TRSstateContractTest extends TRShelpers {
         input[input.length - 1] = (byte) ~input[input.length - 1];
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -756,7 +756,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getLockInput(contract);
         TRSstateContract trs = newTRSstateContract(AION);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test in test mode: owner is AION, caller is acct.
@@ -764,7 +764,7 @@ public class TRSstateContractTest extends TRShelpers {
         input = getLockInput(contract);
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -794,7 +794,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         // attempt to lock the contract again...
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test in test mode.
@@ -819,7 +819,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         // attempt to lock the contract again...
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -886,7 +886,7 @@ public class TRSstateContractTest extends TRShelpers {
         input = getLockInput(contract);
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test in test mode.
@@ -904,7 +904,7 @@ public class TRSstateContractTest extends TRShelpers {
         input = getLockInput(contract);
         trs = newTRSstateContract(AION);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -915,7 +915,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getLockInput(contract);
         ExecutionResult res = newTRSstateContract(owner).execute(input, COST);
         AbstractTRS trs = newTRSstateContract(owner);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
         assertFalse(isContractLocked(trs, contract));
 
@@ -929,7 +929,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         input = getLockInput(contract);
         res = newTRSstateContract(owner).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
         assertFalse(isContractLocked(trs, contract));
     }
@@ -945,7 +945,7 @@ public class TRSstateContractTest extends TRShelpers {
         input[0] = (byte) 0x1;
         TRSstateContract trs = newTRSstateContract(acct);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test on address size 31.
@@ -953,7 +953,7 @@ public class TRSstateContractTest extends TRShelpers {
         input[0] = (byte) 0x1;
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -966,7 +966,7 @@ public class TRSstateContractTest extends TRShelpers {
         System.arraycopy(contract.toBytes(), 0, input, 1, Address.ADDRESS_LEN);
         TRSstateContract trs = newTRSstateContract(acct);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -980,7 +980,7 @@ public class TRSstateContractTest extends TRShelpers {
         System.arraycopy(contract.toBytes(), 0, input, 1, Address.ADDRESS_LEN);
         TRSstateContract trs = newTRSstateContract(acct);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         repo.incrementNonce(acct);
@@ -990,7 +990,7 @@ public class TRSstateContractTest extends TRShelpers {
         input[input.length - 1] = (byte) ~input[input.length - 1]; // flip a bit
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1002,7 +1002,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getLockInput(contract);
         TRSstateContract trs = newTRSstateContract(AION);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test in test mode: owner is AION, caller is acct.
@@ -1010,7 +1010,7 @@ public class TRSstateContractTest extends TRShelpers {
         input = getLockInput(contract);
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1031,7 +1031,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         // Try to start contract again.
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test in test mode.
@@ -1048,7 +1048,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         // Try to start contract again.
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1063,7 +1063,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         byte[] input = getStartInput(contract);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test in test mode.
@@ -1074,7 +1074,7 @@ public class TRSstateContractTest extends TRShelpers {
         input = getStartInput(contract);
         trs = newTRSstateContract(acct);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1276,7 +1276,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getOpenFundsInput(contract);
         byte[] shortInput = Arrays.copyOf(input, input.length - 1);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(shortInput, COST).getResultCode());
     }
 
@@ -1289,7 +1289,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] longInput = new byte[input.length + 1];
         System.arraycopy(input, 0, longInput, 0, input.length);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(longInput, COST).getResultCode());
     }
 
@@ -1301,7 +1301,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         byte[] input = getOpenFundsInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(other).execute(input, COST).getResultCode());
     }
 
@@ -1312,7 +1312,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         byte[] input = getOpenFundsInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -1321,7 +1321,7 @@ public class TRSstateContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(BigInteger.TEN);
         byte[] input = getOpenFundsInput(acct);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -1362,10 +1362,10 @@ public class TRSstateContractTest extends TRShelpers {
         assertEquals(
                 ResultCode.SUCCESS, newTRSstateContract(acct).execute(input, COST).getResultCode());
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(input, COST).getResultCode());
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -1419,13 +1419,13 @@ public class TRSstateContractTest extends TRShelpers {
 
         // A subsequent withdraw operation should not withdraw anything now.
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct1).execute(input, COST).getResultCode());
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct2).execute(input, COST).getResultCode());
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct3).execute(input, COST).getResultCode());
         assertEquals(owings1, repo.getBalance(acct1));
         assertEquals(owings2, repo.getBalance(acct2));
@@ -1496,7 +1496,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         input = getLockInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -1512,7 +1512,7 @@ public class TRSstateContractTest extends TRShelpers {
 
         input = getStartInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSstateContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -1550,7 +1550,7 @@ public class TRSstateContractTest extends TRShelpers {
         // Now try to withdraw.
         input = getWithdrawInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
         assertEquals(BigInteger.TEN, repo.getBalance(acct));
     }
@@ -1568,7 +1568,7 @@ public class TRSstateContractTest extends TRShelpers {
         // Now try to deposit.
         input = getDepositInput(contract, BigInteger.ONE);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
         assertEquals(BigInteger.TEN, repo.getBalance(acct));
         assertEquals(BigInteger.ZERO, getDepositBalance(trs, contract, acct));
@@ -1588,7 +1588,7 @@ public class TRSstateContractTest extends TRShelpers {
         // Now try to deposit.
         input = getDepositForInput(contract, other, BigInteger.ONE);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
         assertEquals(BigInteger.TEN, repo.getBalance(acct));
         assertEquals(BigInteger.ZERO, getDepositBalance(trs, contract, other));
@@ -1619,7 +1619,7 @@ public class TRSstateContractTest extends TRShelpers {
         BigInteger total = deposit.multiply(BigInteger.valueOf(numBeneficiaries));
         repo.addBalance(owner, total);
         input = getBulkDepositForInput(contract, beneficiaries, amounts);
-        assertEquals(ResultCode.INTERNAL_ERROR, trs.execute(input, COST).getResultCode());
+        assertEquals(ResultCode.FAILURE, trs.execute(input, COST).getResultCode());
         for (Address acc : beneficiaries) {
             assertEquals(BigInteger.ZERO, getDepositBalance(trs, contract, acc));
         }
@@ -1645,7 +1645,7 @@ public class TRSstateContractTest extends TRShelpers {
         // Now try to refund.
         input = getRefundInput(contract, other, BigInteger.ONE);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
         assertEquals(BigInteger.ONE, getDepositBalance(trs, contract, other));
         assertEquals(BigInteger.ZERO, repo.getBalance(other));
@@ -1666,7 +1666,7 @@ public class TRSstateContractTest extends TRShelpers {
         repo.addBalance(acct, extra);
         input = getAddExtraInput(contract, extra);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
         assertEquals(BigInteger.ZERO, getExtraFunds(trs, contract));
     }

--- a/modPrecompiled/test/org/aion/precompiled/TRS/TRSuseContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/TRS/TRSuseContractTest.java
@@ -80,7 +80,7 @@ public class TRSuseContractTest extends TRShelpers {
     public void testCreateNullInput() {
         TRSuseContract trs = newTRSuseContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(null, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -88,7 +88,7 @@ public class TRSuseContractTest extends TRShelpers {
     public void testCreateEmptyInput() {
         TRSuseContract trs = newTRSuseContract(getNewExistentAccount(BigInteger.ZERO));
         ExecutionResult res = trs.execute(ByteUtil.EMPTY_BYTE_ARRAY, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -126,7 +126,7 @@ public class TRSuseContractTest extends TRShelpers {
         for (int i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
             if ((i < 0) || (i > MAX_OP)) {
                 input[0] = (byte) i;
-                assertEquals(ResultCode.INTERNAL_ERROR, trs.execute(input, COST).getResultCode());
+                assertEquals(ResultCode.FAILURE, trs.execute(input, COST).getResultCode());
             }
         }
     }
@@ -139,13 +139,13 @@ public class TRSuseContractTest extends TRShelpers {
         TRSuseContract trs = newTRSuseContract(getNewExistentAccount(BigInteger.ZERO));
         byte[] input = new byte[1];
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test on maximum too-small amount.
         input = new byte[160];
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -154,7 +154,7 @@ public class TRSuseContractTest extends TRShelpers {
         TRSuseContract trs = newTRSuseContract(getNewExistentAccount(BigInteger.ZERO));
         byte[] input = new byte[162];
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -165,7 +165,7 @@ public class TRSuseContractTest extends TRShelpers {
         TRSuseContract trs = newTRSuseContract(acct);
         byte[] input = getDepositInput(acct, BigInteger.TWO);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test on contract address looks like a legit TRS address (proper prefix).
@@ -175,7 +175,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         input = getDepositInput(Address.wrap(addr), BigInteger.TWO);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -235,7 +235,7 @@ public class TRSuseContractTest extends TRShelpers {
         TRSuseContract trs = newTRSuseContract(acct);
         byte[] input = getDepositInput(contract, BigInteger.TWO);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -247,7 +247,7 @@ public class TRSuseContractTest extends TRShelpers {
         TRSuseContract trs = newTRSuseContract(contract);
         byte[] input = getDepositInput(contract, BigInteger.TWO);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -523,7 +523,7 @@ public class TRSuseContractTest extends TRShelpers {
         TRSuseContract trs = newTRSuseContract(acct);
         byte[] input = getDepositInput(contract, BigInteger.ONE);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -534,7 +534,7 @@ public class TRSuseContractTest extends TRShelpers {
         TRSuseContract trs = newTRSuseContract(acct);
         byte[] input = getDepositInput(contract, BigInteger.ONE);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -744,7 +744,7 @@ public class TRSuseContractTest extends TRShelpers {
         input[0] = 0x1;
         System.arraycopy(contract.toBytes(), 0, input, 1, Address.ADDRESS_LEN - 1);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -756,7 +756,7 @@ public class TRSuseContractTest extends TRShelpers {
         input[0] = 0x1;
         System.arraycopy(contract.toBytes(), 0, input, 1, Address.ADDRESS_LEN);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -770,7 +770,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         input = getWithdrawInput(contract);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
         assertEquals(DEFAULT_BALANCE, getDepositBalance(newTRSuseContract(acct), contract, acct));
     }
@@ -790,7 +790,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         input = getWithdrawInput(contract);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
         assertEquals(DEFAULT_BALANCE, getDepositBalance(newTRSuseContract(acct), contract, acct));
     }
@@ -909,7 +909,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         // Try to keep withdrawing...
         for (int i = 0; i < 5; i++) {
-            assertEquals(ResultCode.INTERNAL_ERROR, trs.execute(input, COST).getResultCode());
+            assertEquals(ResultCode.FAILURE, trs.execute(input, COST).getResultCode());
             assertEquals(expectedBal, repo.getBalance(AION));
         }
     }
@@ -1012,7 +1012,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Let's try and withdraw again, now we should not be able to.
         for (Address acc : contributors) {
             assertEquals(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     newTRSuseContract(acc).execute(input, COST).getResultCode());
             assertEquals(expectedAmt, repo.getBalance(acc));
         }
@@ -1073,7 +1073,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Try to withdraw again from the final period.
         for (Address acc : contributors) {
             assertEquals(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     newTRSuseContract(acc).execute(input, COST).getResultCode());
             assertEquals(owings, repo.getBalance(acc));
         }
@@ -1381,7 +1381,7 @@ public class TRSuseContractTest extends TRShelpers {
         mockBlockchain(timestamp + 1);
         for (Address acc : contributors) {
             assertEquals(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     newTRSuseContract(acc).execute(input, COST).getResultCode());
             assertEquals(owings, repo.getBalance(acc));
         }
@@ -1391,7 +1391,7 @@ public class TRSuseContractTest extends TRShelpers {
         assertEquals(BigInteger.valueOf(periods), getCurrentPeriod(trs, contract));
         for (Address acc : contributors) {
             assertEquals(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     newTRSuseContract(acc).execute(input, COST).getResultCode());
             assertEquals(owings, repo.getBalance(acc));
         }
@@ -1434,7 +1434,7 @@ public class TRSuseContractTest extends TRShelpers {
         mockBlockchain(timestamp + 1);
         for (Address acc : contributors) {
             assertEquals(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     newTRSuseContract(acc).execute(input, COST).getResultCode());
             assertEquals(amt, repo.getBalance(acc));
         }
@@ -1575,13 +1575,13 @@ public class TRSuseContractTest extends TRShelpers {
         input[0] = 0x3;
         System.arraycopy(contract.toBytes(), 0, input, 1, Address.ADDRESS_LEN - 1);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test minimum too-short size.
         input = new byte[1];
         res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1593,7 +1593,7 @@ public class TRSuseContractTest extends TRShelpers {
         input[0] = 0x3;
         System.arraycopy(contract.toBytes(), 0, input, 1, Address.ADDRESS_LEN);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1612,7 +1612,7 @@ public class TRSuseContractTest extends TRShelpers {
         Set<Address> contributors = getAllDepositors(trs, contract);
         for (Address acc : contributors) {
             assertEquals(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     newTRSuseContract(acc).execute(input, COST).getResultCode());
         }
 
@@ -1630,7 +1630,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Try first with no one in the contract. Caller is owner.
         byte[] input = getBulkWithdrawInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
 
         // Now deposit some and try again.
@@ -1639,7 +1639,7 @@ public class TRSuseContractTest extends TRShelpers {
                 ResultCode.SUCCESS, newTRSuseContract(acct).execute(input, COST).getResultCode());
         input = getBulkWithdrawInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -1659,7 +1659,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Try to withdraw.
         input = getBulkWithdrawInput(contract);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
         assertEquals(BigInteger.ZERO, repo.getBalance(acct));
     }
@@ -1946,13 +1946,13 @@ public class TRSuseContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = new byte[192];
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test minimum too-short size.
         input = new byte[1];
         res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1961,7 +1961,7 @@ public class TRSuseContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = new byte[194];
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -1972,7 +1972,7 @@ public class TRSuseContractTest extends TRShelpers {
         Address contract = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = getRefundInput(contract, acct, BigInteger.ZERO);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Test TRS address with TRS prefix, so it looks legit.
@@ -1982,7 +1982,7 @@ public class TRSuseContractTest extends TRShelpers {
         tempAddrs.add(contract);
         input = getRefundInput(contract, acct, BigInteger.ZERO);
         res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2001,7 +2001,7 @@ public class TRSuseContractTest extends TRShelpers {
         // acct2 calls refund but owner is acct
         input = getRefundInput(contract, acct2, BigInteger.ONE);
         res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2015,7 +2015,7 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] input = getRefundInput(contract, acct2, BigInteger.ONE);
         TRSuseContract trs = newTRSuseContract(acct2);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
 
         // Have others deposit but not acct2 and try again ... should be same result.
@@ -2030,7 +2030,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         input = getRefundInput(contract, acct2, BigInteger.ONE);
         res = newTRSuseContract(acct2).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2053,7 +2053,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Now have contract owner try to refund acct2.
         input = getRefundInput(contract, acct2, BigInteger.ONE);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2079,7 +2079,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Now have contract owner try to refund acct2.
         input = getRefundInput(contract, acct2, BigInteger.ONE);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2272,7 +2272,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Now try to refund acct2 again...
         input = getRefundInput(contract, acct2, BigInteger.ONE);
         res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2284,7 +2284,7 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] input = getRefundInput(contract, acct2, BigInteger.ZERO);
         TRSuseContract trs = newTRSuseContract(acct);
         ExecutionResult res = trs.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2304,7 +2304,7 @@ public class TRSuseContractTest extends TRShelpers {
         // Acct2 is now marked invalid.
         input = getRefundInput(contract, acct2, BigInteger.ZERO);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -2361,7 +2361,7 @@ public class TRSuseContractTest extends TRShelpers {
         System.arraycopy(input, 0, longInput, 0, input.length);
 
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(longInput, COST).getResultCode());
     }
 
@@ -2375,7 +2375,7 @@ public class TRSuseContractTest extends TRShelpers {
         System.arraycopy(input, 0, shortInput, 0, input.length - 1);
 
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(shortInput, COST).getResultCode());
     }
 
@@ -2386,7 +2386,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         byte[] input = getDepositForInput(contract, acct, BigInteger.ONE);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2398,7 +2398,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         byte[] input = getDepositForInput(contract, acct, BigInteger.ONE);
         ExecutionResult res = newTRSuseContract(acct).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2410,7 +2410,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         byte[] input = getDepositForInput(contract, whoami, DEFAULT_BALANCE);
         ExecutionResult res = newTRSuseContract(whoami).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2436,7 +2436,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         byte[] input = getDepositForInput(contract, other, BigInteger.ONE);
         ExecutionResult res = newTRSuseContract(owner).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2450,7 +2450,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         byte[] input = getDepositForInput(contract, other, BigInteger.ONE);
         ExecutionResult res = newTRSuseContract(owner).execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0, res.getNrgLeft());
     }
 
@@ -2569,7 +2569,7 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] input = getAddExtraInput(contract, DEFAULT_BALANCE);
         byte[] shortInput = Arrays.copyOf(input, input.length - 1);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(shortInput, COST).getResultCode());
     }
 
@@ -2581,7 +2581,7 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] longInput = new byte[input.length + 1];
         System.arraycopy(input, 0, longInput, 0, input.length);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(longInput, COST).getResultCode());
     }
 
@@ -2590,7 +2590,7 @@ public class TRSuseContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(DEFAULT_BALANCE);
         byte[] input = getAddExtraInput(acct, DEFAULT_BALANCE);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -2600,7 +2600,7 @@ public class TRSuseContractTest extends TRShelpers {
         Address contract = createTRScontract(AION, false, true, 1, BigInteger.ZERO, 0);
         byte[] input = getAddExtraInput(contract, DEFAULT_BALANCE);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -2625,7 +2625,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         input = getAddExtraInput(contract, DEFAULT_BALANCE);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -2645,7 +2645,7 @@ public class TRSuseContractTest extends TRShelpers {
 
         AbstractTRS trs = newTRSuseContract(acct);
         byte[] input = getAddExtraInput(contract, BigInteger.ZERO);
-        assertEquals(ResultCode.INTERNAL_ERROR, trs.execute(input, COST).getResultCode());
+        assertEquals(ResultCode.FAILURE, trs.execute(input, COST).getResultCode());
         assertEquals(BigInteger.ZERO, getExtraFunds(trs, contract));
         assertEquals(DEFAULT_BALANCE, repo.getBalance(acct));
     }
@@ -2831,7 +2831,7 @@ public class TRSuseContractTest extends TRShelpers {
             if (withdraw) {
                 // These accounts have already withdrawn this period.
                 assertEquals(
-                        ResultCode.INTERNAL_ERROR,
+                        ResultCode.FAILURE,
                         newTRSuseContract(acc).execute(input, COST).getResultCode());
             } else {
                 assertEquals(
@@ -2982,7 +2982,7 @@ public class TRSuseContractTest extends TRShelpers {
             BigInteger share = getExtraShare(trs, contract, acc, fraction, currPeriod);
             input = getWithdrawInput(contract);
             assertEquals(
-                    ResultCode.INTERNAL_ERROR,
+                    ResultCode.FAILURE,
                     newTRSuseContract(acc).execute(input, COST).getResultCode());
         }
     }
@@ -3055,7 +3055,7 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] input = makeBulkDepositForInput(contract, numBeneficiaries, BigInteger.TEN);
         byte[] shortInput = Arrays.copyOf(input, input.length - 1);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(shortInput, COST).getResultCode());
     }
 
@@ -3069,7 +3069,7 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] longInput = new byte[input.length + 1];
         System.arraycopy(input, 0, longInput, 0, input.length);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(longInput, COST).getResultCode());
     }
 
@@ -3079,7 +3079,7 @@ public class TRSuseContractTest extends TRShelpers {
         Address acct = getNewExistentAccount(BigInteger.ONE);
         byte[] input = makeBulkDepositForInput(acct, numBeneficiaries, BigInteger.TEN);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -3093,7 +3093,7 @@ public class TRSuseContractTest extends TRShelpers {
                         BigInteger.TEN.multiply(BigInteger.valueOf(numBeneficiaries)));
         byte[] input = makeBulkDepositForInput(contract, numBeneficiaries, BigInteger.TEN);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(whoami).execute(input, COST).getResultCode());
     }
 
@@ -3104,7 +3104,7 @@ public class TRSuseContractTest extends TRShelpers {
         Address contract = createAndLockTRScontract(acct, false, false, 1, BigInteger.ZERO, 0);
         byte[] input = makeBulkDepositForInput(contract, numBeneficiaries, BigInteger.TEN);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -3116,7 +3116,7 @@ public class TRSuseContractTest extends TRShelpers {
                 createLockedAndLiveTRScontract(acct, false, false, 1, BigInteger.ZERO, 0);
         byte[] input = makeBulkDepositForInput(contract, numBeneficiaries, BigInteger.TEN);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(input, COST).getResultCode());
     }
 
@@ -3131,7 +3131,7 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] noBeneficiaries = new byte[33];
         System.arraycopy(input, 0, noBeneficiaries, 0, Address.ADDRESS_LEN + 1);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(noBeneficiaries, COST).getResultCode());
     }
 
@@ -3146,14 +3146,14 @@ public class TRSuseContractTest extends TRShelpers {
         byte[] inputOff = new byte[input.length - 1];
         System.arraycopy(input, 0, inputOff, 0, input.length - 1);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(inputOff, COST).getResultCode());
 
         // Add a byte to the array.
         inputOff = new byte[input.length + 1];
         System.arraycopy(input, 0, inputOff, 0, input.length);
         assertEquals(
-                ResultCode.INTERNAL_ERROR,
+                ResultCode.FAILURE,
                 newTRSuseContract(acct).execute(inputOff, COST).getResultCode());
     }
 

--- a/modPrecompiled/test/org/aion/precompiled/contracts/AionAuctionContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/AionAuctionContractTest.java
@@ -401,7 +401,7 @@ public class AionAuctionContractTest {
 
         assertEquals(ResultCode.SUCCESS, res.getResultCode());
 
-        assertEquals(ResultCode.INTERNAL_ERROR, res2.getResultCode());
+        assertEquals(ResultCode.FAILURE, res2.getResultCode());
         Assert.assertArrayEquals("already been extended".getBytes(), res2.getOutput());
 
         // uncomment to see extension output
@@ -432,7 +432,7 @@ public class AionAuctionContractTest {
         byte[] combined2 = setupForExtension(domainName1, Address.wrap(k2.getAddress()));
         ExecutionResult res = aac.execute(combined2, inputEnergy);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
     }
 
     @Test
@@ -458,7 +458,7 @@ public class AionAuctionContractTest {
         AionAuctionContract aac2 = new AionAuctionContract(repo, AION, blockchain);
         ExecutionResult result2 = aac2.execute(combined2, inputEnergy);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, result2.getResultCode());
+        assertEquals(ResultCode.FAILURE, result2.getResultCode());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -478,7 +478,7 @@ public class AionAuctionContractTest {
                         defaultKey);
         AionAuctionContract aac = new AionAuctionContract(repo, AION, blockchain);
         ExecutionResult result = aac.execute(combined, DEFAULT_INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, result.getResultCode());
+        assertEquals(ResultCode.FAILURE, result.getResultCode());
 
         byte[] combined2 =
                 setupInputs(
@@ -488,7 +488,7 @@ public class AionAuctionContractTest {
                         defaultKey);
         AionAuctionContract aac2 = new AionAuctionContract(repo, AION, blockchain);
         ExecutionResult result2 = aac2.execute(combined2, DEFAULT_INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, result2.getResultCode());
+        assertEquals(ResultCode.FAILURE, result2.getResultCode());
 
         byte[] combined3 =
                 setupInputs(
@@ -498,7 +498,7 @@ public class AionAuctionContractTest {
                         defaultKey);
         AionAuctionContract aac3 = new AionAuctionContract(repo, AION, blockchain);
         ExecutionResult result3 = aac3.execute(combined3, DEFAULT_INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, result3.getResultCode());
+        assertEquals(ResultCode.FAILURE, result3.getResultCode());
 
         byte[] combined4 =
                 setupInputs(
@@ -508,7 +508,7 @@ public class AionAuctionContractTest {
                         defaultKey);
         AionAuctionContract aac4 = new AionAuctionContract(repo, AION, blockchain);
         ExecutionResult result4 = aac4.execute(combined4, DEFAULT_INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, result4.getResultCode());
+        assertEquals(ResultCode.FAILURE, result4.getResultCode());
 
         byte[] combined5 =
                 setupInputs(
@@ -518,7 +518,7 @@ public class AionAuctionContractTest {
                         defaultKey);
         AionAuctionContract aac5 = new AionAuctionContract(repo, AION, blockchain);
         ExecutionResult result5 = aac5.execute(combined5, DEFAULT_INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, result5.getResultCode());
+        assertEquals(ResultCode.FAILURE, result5.getResultCode());
     }
 
     @Test
@@ -532,7 +532,7 @@ public class AionAuctionContractTest {
                         notExistKey);
         AionAuctionContract aac = new AionAuctionContract(repo, AION, blockchain);
         ExecutionResult result = aac.execute(combined, DEFAULT_INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, result.getResultCode());
+        assertEquals(ResultCode.FAILURE, result.getResultCode());
         Assert.assertArrayEquals("bidder account does not exist".getBytes(), result.getOutput());
     }
 
@@ -549,7 +549,7 @@ public class AionAuctionContractTest {
                         defaultBidAmount.toByteArray(),
                         poorKey);
         ExecutionResult result = testAAC.execute(combined3, DEFAULT_INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, result.getResultCode());
+        assertEquals(ResultCode.FAILURE, result.getResultCode());
         Assert.assertArrayEquals("insufficient balance".getBytes(), result.getOutput());
     }
 
@@ -572,7 +572,7 @@ public class AionAuctionContractTest {
         System.arraycopy(input, 0, wrongInput2, 0, 131);
         ExecutionResult result2 = testAAC.execute(wrongInput2, DEFAULT_INPUT_NRG);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, result.getResultCode());
+        assertEquals(ResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getNrgLeft(), 4000);
         Assert.assertArrayEquals("incorrect input length".getBytes(), result.getOutput());
 
@@ -594,7 +594,7 @@ public class AionAuctionContractTest {
         input[110] = (byte) ~input[65];
         ExecutionResult result = testAAC.execute(input, DEFAULT_INPUT_NRG);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, result.getResultCode());
+        assertEquals(ResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getNrgLeft(), 4000);
         Assert.assertArrayEquals("incorrect signature".getBytes(), result.getOutput());
     }
@@ -611,7 +611,7 @@ public class AionAuctionContractTest {
                         anotherKey);
         ExecutionResult result = testAAC.execute(input, DEFAULT_INPUT_NRG);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, result.getResultCode());
+        assertEquals(ResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getNrgLeft(), 4000);
         Assert.assertArrayEquals("incorrect key".getBytes(), result.getOutput());
     }
@@ -642,7 +642,7 @@ public class AionAuctionContractTest {
                         defaultKey);
         ExecutionResult result = testAAC.execute(input, DEFAULT_INPUT_NRG);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, result.getResultCode());
+        assertEquals(ResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getNrgLeft(), 4000);
         Assert.assertArrayEquals("negative bid value".getBytes(), result.getOutput());
     }

--- a/modPrecompiled/test/org/aion/precompiled/contracts/AionNameServiceContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/AionNameServiceContractTest.java
@@ -234,7 +234,7 @@ public class AionNameServiceContractTest {
         assertEquals(ResultCode.SUCCESS, res.getResultCode());
         assertEquals(3000L, res.getNrgLeft());
 
-        assertEquals(ResultCode.INTERNAL_ERROR, res2.getResultCode());
+        assertEquals(ResultCode.FAILURE, res2.getResultCode());
         assertEquals(0, res2.getNrgLeft());
     }
 
@@ -417,7 +417,7 @@ public class AionNameServiceContractTest {
         ExecutionResult res = ansc.execute(combined, inputEnergy);
 
         // check for success and failure
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(expectedEnergyLeft, res.getNrgLeft());
     }
 
@@ -447,7 +447,7 @@ public class AionNameServiceContractTest {
         Address actualReturnedAddress = ansc.getResolverAddress();
 
         // check for success and failure
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(expectedEnergyLeft, res.getNrgLeft());
         assertEquals(emptyAddress, actualReturnedAddress);
     }
@@ -483,7 +483,7 @@ public class AionNameServiceContractTest {
         Address actualReturnedAddress = ansc.getResolverAddress();
 
         // check for success and failure
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(expectedEnergyLeft, res.getNrgLeft());
         // since the signature is incorrect, contract is not modified
         assertEquals(emptyAddress, actualReturnedAddress);
@@ -513,7 +513,7 @@ public class AionNameServiceContractTest {
         Address actualReturnedAddress = ansc.getResolverAddress();
 
         // check for success and failure
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(expectedEnergyLeft, res.getNrgLeft());
         assertEquals(emptyAddress, actualReturnedAddress);
     }
@@ -548,7 +548,7 @@ public class AionNameServiceContractTest {
         Address actualReturnedAddress = ansc.getResolverAddress();
 
         // check for success and failure
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(expectedEnergyLeft, res.getNrgLeft());
         // since the signature is incorrect, contract is not modified
         assertEquals(emptyAddress, actualReturnedAddress);
@@ -594,7 +594,7 @@ public class AionNameServiceContractTest {
         assertEquals(newAddress1, actualReturnedAddress);
 
         // check for success and failure for execute with invalid new address
-        assertEquals(ResultCode.INTERNAL_ERROR, res2.getResultCode());
+        assertEquals(ResultCode.FAILURE, res2.getResultCode());
         assertEquals(inputEnergy, res2.getNrgLeft());
         assertEquals(newAddress1, actualReturnedAddress2);
     }
@@ -725,7 +725,7 @@ public class AionNameServiceContractTest {
         // check for success and failure
         assertEquals(ResultCode.SUCCESS, res.getResultCode());
         assertEquals(expectedEnergyLeft, res.getNrgLeft());
-        assertEquals(ResultCode.INTERNAL_ERROR, res2.getResultCode());
+        assertEquals(ResultCode.FAILURE, res2.getResultCode());
         assertEquals(expectedEnergyLeft2, res2.getNrgLeft());
     }
 

--- a/modPrecompiled/test/org/aion/precompiled/contracts/Blake2bHashTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/Blake2bHashTest.java
@@ -162,6 +162,6 @@ public class Blake2bHashTest {
     public void testInvalidOperation() {
         byte[] input = Blake2bHashContract.setupInput(3, byteArray1);
         ExecutionResult res = blake2bHasher.execute(input, INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
     }
 }

--- a/modPrecompiled/test/org/aion/precompiled/contracts/KeccakHashTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/KeccakHashTest.java
@@ -65,7 +65,7 @@ public class KeccakHashTest {
     @Test
     public void invalidInputLength() {
         ExecutionResult res2 = keccakHasher.execute(shortByteArray, INPUT_NRG);
-        assertEquals(ResultCode.INTERNAL_ERROR, res2.getResultCode());
+        assertEquals(ResultCode.FAILURE, res2.getResultCode());
     }
 
     @Test

--- a/modPrecompiled/test/org/aion/precompiled/contracts/MultiSignatureContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/MultiSignatureContractTest.java
@@ -453,20 +453,20 @@ public class MultiSignatureContractTest {
     @Test
     public void testNullInput() {
         Address caller = getExistentAddress(BigInteger.ZERO);
-        execute(caller, null, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, null, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
     public void testEmptyInput() {
         Address caller = getExistentAddress(BigInteger.ZERO);
-        execute(caller, ByteUtil.EMPTY_BYTE_ARRAY, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, ByteUtil.EMPTY_BYTE_ARRAY, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
     public void testInputWithOperationOnly() {
         Address caller = getExistentAddress(BigInteger.ZERO);
-        execute(caller, new byte[] {(byte) 0x0}, COST, ResultCode.INTERNAL_ERROR, 0);
-        execute(caller, new byte[] {(byte) 0x1}, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, new byte[] {(byte) 0x0}, COST, ResultCode.FAILURE, 0);
+        execute(caller, new byte[] {(byte) 0x1}, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -481,7 +481,7 @@ public class MultiSignatureContractTest {
         for (int i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
             if ((i != 0) && (i != 1)) {
                 input[0] = (byte) i;
-                execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+                execute(caller, input, COST, ResultCode.FAILURE, 0);
             }
         }
     }
@@ -495,13 +495,13 @@ public class MultiSignatureContractTest {
         Address caller = owners.get(0);
         byte[] input = MultiSignatureContract.constructCreateWalletInput(Long.MIN_VALUE, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
 
         // Test with max illegal value.
         input =
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH - 1, owners);
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -511,11 +511,11 @@ public class MultiSignatureContractTest {
         Address caller = owners.get(0);
         byte[] input = MultiSignatureContract.constructCreateWalletInput(Long.MAX_VALUE, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
 
         // Test with smallest illegal value.
         input = MultiSignatureContract.constructCreateWalletInput(owners.size() + 1, owners);
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -526,7 +526,7 @@ public class MultiSignatureContractTest {
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -535,7 +535,7 @@ public class MultiSignatureContractTest {
         List<Address> owners = getExistentAddresses(1, BigInteger.ZERO);
         byte[] input = MultiSignatureContract.constructCreateWalletInput(Long.MAX_VALUE, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -545,7 +545,7 @@ public class MultiSignatureContractTest {
         Address caller = owners.get(0);
         byte[] input = MultiSignatureContract.constructCreateWalletInput(Long.MAX_VALUE, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -559,7 +559,7 @@ public class MultiSignatureContractTest {
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
 
         // Test with min amount of owners
         owners = getExistentAddresses(MultiSignatureContract.MIN_OWNERS - 1, BigInteger.ZERO);
@@ -568,7 +568,7 @@ public class MultiSignatureContractTest {
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
 
         // Test all owners same
         owners.clear();
@@ -579,7 +579,7 @@ public class MultiSignatureContractTest {
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -591,7 +591,7 @@ public class MultiSignatureContractTest {
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH, owners);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -612,7 +612,7 @@ public class MultiSignatureContractTest {
         System.arraycopy(in, 0, input, 0, in.length);
         System.arraycopy(partialAddr, 0, input, in.length, partialAddr.length);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
 
         // Test on max legal number of owners.
         owners = getExistentAddresses(MultiSignatureContract.MAX_OWNERS - 2, BigInteger.ZERO);
@@ -624,7 +624,7 @@ public class MultiSignatureContractTest {
         System.arraycopy(in, 0, input, 0, in.length);
         System.arraycopy(partialAddr, 0, input, in.length, partialAddr.length);
 
-        execute(caller, input, COST, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, COST, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -652,7 +652,7 @@ public class MultiSignatureContractTest {
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH, owners);
 
-        execute(walletCaller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(walletCaller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -682,7 +682,7 @@ public class MultiSignatureContractTest {
                 MultiSignatureContract.constructCreateWalletInput(
                         MultiSignatureContract.MIN_THRESH, owners);
 
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
     }
 
     @Test
@@ -791,7 +791,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -817,7 +817,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -843,7 +843,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -866,7 +866,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, BigInteger.ZERO);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, BigInteger.ZERO);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -889,7 +889,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -913,7 +913,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(phonyWallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(phonyWallet, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(phonyWallet, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(phonyWallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -935,7 +935,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -957,7 +957,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -979,7 +979,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1012,7 +1012,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, noNrgInput, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, noNrgInput, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1043,7 +1043,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1078,7 +1078,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1108,7 +1108,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1141,7 +1141,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1171,7 +1171,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1198,7 +1198,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1224,7 +1224,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1251,7 +1251,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1277,7 +1277,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1354,7 +1354,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1379,7 +1379,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1502,7 +1502,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1529,7 +1529,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1583,7 +1583,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(new Address(phony.getAddress()), input, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(new Address(phony.getAddress()), input, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1611,7 +1611,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1639,7 +1639,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1667,7 +1667,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1695,7 +1695,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }
@@ -1723,7 +1723,7 @@ public class MultiSignatureContractTest {
 
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
-        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.INTERNAL_ERROR, 0);
+        execute(caller, shiftedInput, NRG_LIMIT, ResultCode.FAILURE, 0);
         checkAccountState(wallet, BigInteger.ZERO, DEFAULT_BALANCE);
         checkAccountState(to, BigInteger.ZERO, BigInteger.ZERO);
     }

--- a/modPrecompiled/test/org/aion/precompiled/contracts/TotalCurrencyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/TotalCurrencyContractTest.java
@@ -104,7 +104,7 @@ public class TotalCurrencyContractTest {
         ExecutionResult res = tcc.execute(payload, COST);
 
         System.out.println("Contract result: " + res.toString());
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class TotalCurrencyContractTest {
                         constructUpdateInput((byte) 0x0, (byte) 0x0), 0, 100); // cut sig short.
         ExecutionResult res = tcc.execute(input, COST);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0L, res.getNrgLeft());
     }
 
@@ -213,7 +213,7 @@ public class TotalCurrencyContractTest {
         byte[] input = constructUpdateInput((byte) 0x0, (byte) 0x0);
         ExecutionResult res = contract.execute(input, COST);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0L, res.getNrgLeft());
     }
 
@@ -225,7 +225,7 @@ public class TotalCurrencyContractTest {
         input[30] = (byte) ~input[30]; // flip a bit
 
         ExecutionResult res = tcc.execute(input, COST);
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0L, res.getNrgLeft());
     }
 
@@ -262,7 +262,7 @@ public class TotalCurrencyContractTest {
         byte[] input = constructUpdateInput((byte) 0x0, (byte) 0x1); // 0x1 == subtract
         ExecutionResult res = tcc.execute(input, COST);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0L, res.getNrgLeft());
 
         // Verify total amount is non-negative.
@@ -277,7 +277,7 @@ public class TotalCurrencyContractTest {
         byte[] input = constructUpdateInput((byte) 0x0, (byte) 0x2); // only 0, 1 are valid.
         ExecutionResult res = tcc.execute(input, COST);
 
-        assertEquals(ResultCode.INTERNAL_ERROR, res.getResultCode());
+        assertEquals(ResultCode.FAILURE, res.getResultCode());
         assertEquals(0L, res.getNrgLeft());
     }
 

--- a/modVM/src/org/aion/vm/AbstractExecutionResult.java
+++ b/modVM/src/org/aion/vm/AbstractExecutionResult.java
@@ -23,13 +23,14 @@
 
 package org.aion.vm;
 
+import org.aion.base.type.IExecutionResult;
+import org.aion.base.util.ByteUtil;
+import org.aion.base.util.Hex;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
-import org.aion.base.type.IExecutionResult;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.Hex;
 
 /** An abstract class representing the result of either a transaction or contract execution. */
 public abstract class AbstractExecutionResult implements IExecutionResult {
@@ -46,21 +47,21 @@ public abstract class AbstractExecutionResult implements IExecutionResult {
         /*
          * Indicates a runtime failure when executing the smart contract code.
          */
-        FAILURE(1),
-        OUT_OF_NRG(2),
-        BAD_INSTRUCTION(3),
-        BAD_JUMP_DESTINATION(4),
-        STACK_OVERFLOW(5),
-        STACK_UNDERFLOW(6),
-        REVERT(7),
-        STATIC_MODE_ERROR(8),
+        FAILURE(1), // generic failure
+        OUT_OF_NRG(2), // run out of energy
+        BAD_INSTRUCTION(3), // bad FAStVM instruction
+        BAD_JUMP_DESTINATION(4), // bad JUMP destination
+        STACK_OVERFLOW(5), // stack overflow
+        STACK_UNDERFLOW(6), // stack underflow
+        REVERT(7), // the REVERT opcode triggered
+        STATIC_MODE_ERROR(8), // trying to modify the state in a STATICCALL.
 
         /*
          * Indicates a transaction rejection. This usually happens before any code execution.
          */
-        INVALID_NONCE(101),
-        INVALID_NRG_LIMIT(102),
-        INSUFFICIENT_BALANCE(103),
+        INVALID_NONCE(101), // invalid nonce
+        INVALID_NRG_LIMIT(102), // invalid energy limit
+        INSUFFICIENT_BALANCE(103), // balance is insufficient to cover the cost
 
         /*
          * Indicates an internal error, because of either bug or out-of-resource.

--- a/modVM/src/org/aion/vm/AbstractExecutionResult.java
+++ b/modVM/src/org/aion/vm/AbstractExecutionResult.java
@@ -38,7 +38,14 @@ public abstract class AbstractExecutionResult implements IExecutionResult {
     byte[] output;
 
     public enum ResultCode {
+        /*
+         * Indicates a successful transaction.
+         */
         SUCCESS(0),
+
+        /*
+         * Indicates a runtime failure when executing the smart contract code.
+         */
         FAILURE(1),
         OUT_OF_NRG(2),
         BAD_INSTRUCTION(3),
@@ -46,11 +53,21 @@ public abstract class AbstractExecutionResult implements IExecutionResult {
         STACK_OVERFLOW(5),
         STACK_UNDERFLOW(6),
         REVERT(7),
-        INVALID_NONCE(8),
-        INVALID_NRG_LIMIT(9),
-        INSUFFICIENT_BALANCE(10),
-        CONTRACT_ALREADY_EXISTS(11),
-        INTERNAL_ERROR(-1);
+        STATIC_MODE_ERROR(8),
+
+        /*
+         * Indicates a transaction rejection. This usually happens before any code execution.
+         */
+        INVALID_NONCE(101),
+        INVALID_NRG_LIMIT(102),
+        INSUFFICIENT_BALANCE(103),
+
+        /*
+         * Indicates an internal error, because of either bug or out-of-resource.
+         * The node shall shut itself down when this occurs.
+         */
+        VM_REJECTED(-1), // VM is not willing to execute the code
+        VM_INTERNAL_ERROR(-2); // VM internal implementation error
 
         private static Map<Integer, ResultCode> intMap = new HashMap<>();
 

--- a/modVM/src/org/aion/vm/TransactionExecutor.java
+++ b/modVM/src/org/aion/vm/TransactionExecutor.java
@@ -200,7 +200,7 @@ public class TransactionExecutor extends AbstractExecutor {
         Address contractAddress = tx.getContractAddress();
 
         if (repoTrack.hasAccountState(contractAddress)) {
-            exeResult.setCodeAndNrgLeft(ResultCode.CONTRACT_ALREADY_EXISTS.toInt(), 0);
+            exeResult.setCodeAndNrgLeft(ResultCode.FAILURE.toInt(), 0);
             return;
         }
 
@@ -245,7 +245,6 @@ public class TransactionExecutor extends AbstractExecutor {
             case INSUFFICIENT_BALANCE:
                 builder.markAsRejected();
                 break;
-            case CONTRACT_ALREADY_EXISTS:
             case FAILURE:
             case OUT_OF_NRG:
             case BAD_INSTRUCTION:
@@ -253,9 +252,11 @@ public class TransactionExecutor extends AbstractExecutor {
             case STACK_OVERFLOW:
             case STACK_UNDERFLOW:
             case REVERT:
-            case INTERNAL_ERROR:
+            case STATIC_MODE_ERROR:
                 builder.markAsFailed();
                 break;
+            case VM_REJECTED:
+            case VM_INTERNAL_ERROR:
             default:
                 throw new RuntimeException("invalid code path, should not ever default");
         }


### PR DESCRIPTION
## Description

This PR intends to clean up the transaction result code:
- Aligned the `ReasonCode` with the error code defined in the C interface;
- Corrected the inappropriate usage of `INTERNAL_ERROR`;
- Fixed the `STATIC_MODE_ERROR` misinterpretation.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.