### PR TITLE
Removed lib from aion.sh

### DIFF
--- a/aion.sh
+++ b/aion.sh
@@ -130,7 +130,7 @@ if $guard; then
 
 		# Execute Java kernel
 		env EVMJIT="-cache=1" ./rt/bin/java ${JAVA_OPTS} \
-			-cp "./lib/*:./lib/libminiupnp/*:./jars/*" org.aion.Aion "$@" &
+			-cp "./jars/*" org.aion.Aion "$@" &
 		kPID=$!
 		running=true
 		watching=true
@@ -216,7 +216,7 @@ else
 	# if there's CLI args, we just run it and quit
 	if [ "$#" -gt 0 ]; then
 		env EVMJIT="-cache=1" $JAVA_CMD ${JAVA_OPTS} \
-			-cp "./lib/*:./lib/libminiupnp/*:./jars/*" org.aion.Aion "$@"
+			-cp "./jars/*" org.aion.Aion "$@"
 		exit
 	fi
 
@@ -233,7 +233,7 @@ else
 	}
 
   	env EVMJIT="-cache=1" $JAVA_CMD ${JAVA_OPTS} \
-  		-cp "./lib/*:./lib/libminiupnp/*:./jars/*" org.aion.Aion "$@" &
+  		-cp "./jars/*" org.aion.Aion "$@" &
     kernel_pid=$!
     wait
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -293,7 +293,7 @@ task pack(type: Tar) {
         from "${dirPack}/rt"
         include '**'
     }
-    into('/aion/console') {
+    into('/aion/web-console') {
         from "${dirPack}/web3"
         include '**'
     }


### PR DESCRIPTION
## Description

- The use of the `lib` directory in `aion.sh` can lead to importing libraries twice in the classpath if someone unpacks a new kernel on top of an old one. Since all the libraries are packed in `jars` for the new implementation, only this directory should be added to the classpath.
- Renamed `console` to `web-console` to avoid frustrations when trying to auto-complete with tab in the terminal due to the common prefix with `config`.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite + manual checks unpacking binary on top of old kernel folder

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
