### PR TITLE
Remove dependency on aion.base from rlp, crypto and p2p

### DIFF
--- a/modAionBase/src/org/aion/base/util/ByteUtil.java
+++ b/modAionBase/src/org/aion/base/util/ByteUtil.java
@@ -44,6 +44,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+/** @apiNote This functionality is migrated to modUtil. Use that class instead. */
+@Deprecated
 public class ByteUtil {
 
     public static final byte[] EMPTY_WORD = new byte[32];

--- a/modAionBase/src/org/aion/base/util/Hex.java
+++ b/modAionBase/src/org/aion/base/util/Hex.java
@@ -39,7 +39,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-/** Utility class for converting hex data to bytes and back again. */
+/**
+ * Utility class for converting hex data to bytes and back again.
+ *
+ * @apiNote This functionality is migrated to modUtil. Use that class instead.
+ */
+@Deprecated
 public class Hex {
 
     private static final HexEncoder encoder = new HexEncoder();

--- a/modAionBase/src/org/aion/base/util/HexEncoder.java
+++ b/modAionBase/src/org/aion/base/util/HexEncoder.java
@@ -38,7 +38,12 @@ package org.aion.base.util;
 import java.io.IOException;
 import java.io.OutputStream;
 
-/** A streaming Hex encoder. */
+/**
+ * A streaming Hex encoder.
+ *
+ * @apiNote This functionality is migrated to modUtil. Use that class instead.
+ */
+@Deprecated
 public class HexEncoder {
 
     protected final byte[] encodingTable = {

--- a/modAionBase/src/org/aion/base/util/NativeLoader.java
+++ b/modAionBase/src/org/aion/base/util/NativeLoader.java
@@ -48,7 +48,9 @@ import java.util.Scanner;
  * Native library loader.
  *
  * @author jin
+ * @apiNote This functionality is migrated to modUtil. Use that class instead.
  */
+@Deprecated
 public class NativeLoader {
 
     /**

--- a/modCrypto/build.gradle
+++ b/modCrypto/build.gradle
@@ -1,7 +1,7 @@
 ext.moduleName = 'aion.crypto'
 
 dependencies {
-    compile project(':modAionBase')
+    compile project(':modUtil')
     compile project(':modRlp')
     compile files('../lib/libnsc.jar')
     compile 'org.slf4j:slf4j-api:1.7.25'

--- a/modCrypto/src/module-info.java
+++ b/modCrypto/src/module-info.java
@@ -1,6 +1,6 @@
 module aion.crypto {
     requires slf4j.api;
-    requires aion.base;
+    requires aion.util;
     requires aion.rlp;
     requires libnsc;
 

--- a/modCrypto/src/org/aion/crypto/AddressSpecs.java
+++ b/modCrypto/src/org/aion/crypto/AddressSpecs.java
@@ -26,7 +26,7 @@ package org.aion.crypto;
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Optional;
-import org.aion.base.util.ByteUtil;
+import org.aion.util.bytes.ByteUtil;
 
 /** A set of static functions to define the creation of addresses */
 public class AddressSpecs {

--- a/modCrypto/src/org/aion/crypto/HashUtil.java
+++ b/modCrypto/src/org/aion/crypto/HashUtil.java
@@ -36,18 +36,18 @@
 package org.aion.crypto;
 
 import static java.util.Arrays.copyOfRange;
-import static org.aion.base.util.ByteUtil.EMPTY_BYTE_ARRAY;
 import static org.aion.crypto.HashUtil.H256Type.BLAKE2B_256;
+import static org.aion.util.bytes.ByteUtil.EMPTY_BYTE_ARRAY;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import org.aion.base.util.NativeLoader;
 import org.aion.crypto.hash.Blake2b;
 import org.aion.crypto.hash.Blake2bNative;
 import org.aion.rlp.RLP;
+import org.aion.util.NativeLoader;
 import org.spongycastle.crypto.Digest;
 import org.spongycastle.crypto.digests.KeccakDigest;
 import org.spongycastle.crypto.digests.RIPEMD160Digest;

--- a/modCrypto/src/org/aion/crypto/ecdsa/ECDSASignature.java
+++ b/modCrypto/src/org/aion/crypto/ecdsa/ECDSASignature.java
@@ -35,19 +35,18 @@
 
 package org.aion.crypto.ecdsa;
 
-import static org.aion.base.util.BIUtil.isLessThan;
-import static org.aion.base.util.ByteUtil.bigIntegerToBytes;
 import static org.aion.crypto.ecdsa.ECKeySecp256k1.CURVE;
 import static org.aion.crypto.ecdsa.ECKeySecp256k1.ETH_SECP256K1N;
 import static org.aion.crypto.ecdsa.ECKeySecp256k1.HALF_CURVE_ORDER;
+import static org.aion.util.bytes.ByteUtil.bigIntegerToBytes;
 
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.Hex;
 import org.aion.crypto.ISignature;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.util.hex.Hex;
 import org.spongycastle.asn1.ASN1InputStream;
 import org.spongycastle.asn1.ASN1Integer;
 import org.spongycastle.asn1.DLSequence;
@@ -160,6 +159,15 @@ public class ECDSASignature implements ISignature {
             return false;
         }
         return isLessThan(s, ETH_SECP256K1N);
+    }
+
+    /**
+     * @param valueA - not null
+     * @param valueB - not null
+     * @return true - if the valueA is less than valueB is zero
+     */
+    public static boolean isLessThan(BigInteger valueA, BigInteger valueB) {
+        return valueA.compareTo(valueB) < 0;
     }
 
     public static ECDSASignature decodeFromDER(byte[] bytes) {

--- a/modCrypto/src/org/aion/crypto/ecdsa/ECDSASignature.java
+++ b/modCrypto/src/org/aion/crypto/ecdsa/ECDSASignature.java
@@ -46,7 +46,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import org.aion.crypto.ISignature;
 import org.aion.util.bytes.ByteUtil;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.spongycastle.asn1.ASN1InputStream;
 import org.spongycastle.asn1.ASN1Integer;
 import org.spongycastle.asn1.DLSequence;

--- a/modCrypto/src/org/aion/crypto/ecdsa/ECKeySecp256k1.java
+++ b/modCrypto/src/org/aion/crypto/ecdsa/ECKeySecp256k1.java
@@ -36,7 +36,7 @@
 package org.aion.crypto.ecdsa;
 
 import static java.util.Arrays.copyOfRange;
-import static org.aion.base.util.ByteUtil.bigIntegerToBytes;
+import static org.aion.util.bytes.ByteUtil.bigIntegerToBytes;
 
 import java.io.Serializable;
 import java.math.BigInteger;

--- a/modCrypto/src/org/aion/crypto/ed25519/ECKeyEd25519.java
+++ b/modCrypto/src/org/aion/crypto/ed25519/ECKeyEd25519.java
@@ -24,11 +24,11 @@
 package org.aion.crypto.ed25519;
 
 import java.math.BigInteger;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.NativeLoader;
 import org.aion.crypto.AddressSpecs;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ISignature;
+import org.aion.util.NativeLoader;
+import org.aion.util.bytes.ByteUtil;
 import org.libsodium.jni.NaCl;
 import org.libsodium.jni.Sodium;
 import org.spongycastle.util.encoders.Hex;
@@ -148,6 +148,7 @@ public class ECKeyEd25519 implements ECKey {
 
     @Override
     public String toString() {
+        // TODO: why is this using Hex from spongycastle lib?
         return "pub:" + Hex.toHexString(pk);
     }
 }

--- a/modCrypto/src/org/aion/crypto/ed25519/Ed25519Signature.java
+++ b/modCrypto/src/org/aion/crypto/ed25519/Ed25519Signature.java
@@ -23,9 +23,9 @@
 package org.aion.crypto.ed25519;
 
 import java.util.Arrays;
-import org.aion.base.util.ByteUtil;
 import org.aion.crypto.AddressSpecs;
 import org.aion.crypto.ISignature;
+import org.aion.util.bytes.ByteUtil;
 
 /**
  * ED25519 signature implementation. Each {@link Ed25519Signature} contains two components, public

--- a/modCrypto/test/org/aion/crypto/ChecksumTest.java
+++ b/modCrypto/test/org/aion/crypto/ChecksumTest.java
@@ -26,7 +26,7 @@ package org.aion.crypto;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Optional;
-import org.aion.base.util.ByteUtil;
+import org.aion.util.bytes.ByteUtil;
 import org.junit.Test;
 
 public class ChecksumTest {
@@ -48,10 +48,8 @@ public class ChecksumTest {
 
     @Test
     public void testChecksum0x() {
-        String input =
-                "a0x896b9366f09e5efb1fa2ed9f3820b865ae97adbc6f364d691eb17784c9b1b"; // 0x is not
-                                                                                    // removed, h ==
-                                                                                    // null
+        String input = "a0x896b9366f09e5efb1fa2ed9f3820b865ae97adbc6f364d691eb17784c9b1b";
+        // 0x is not removed, h == null
         assertEquals(Optional.empty(), (AddressSpecs.checksummedAddress(input)));
     }
 

--- a/modCrypto/test/org/aion/crypto/ECKeyTest.java
+++ b/modCrypto/test/org/aion/crypto/ECKeyTest.java
@@ -37,7 +37,7 @@ package org.aion.crypto;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 
-import org.aion.base.util.ByteUtil;
+import org.aion.util.bytes.ByteUtil;
 import org.junit.AfterClass;
 import org.junit.Test;
 

--- a/modCrypto/test/org/aion/crypto/HashTest.java
+++ b/modCrypto/test/org/aion/crypto/HashTest.java
@@ -36,7 +36,7 @@ package org.aion.crypto;
 
 import static org.junit.Assert.assertEquals;
 
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Test;
 
 public class HashTest {

--- a/modCrypto/test/org/aion/crypto/HashTest.java
+++ b/modCrypto/test/org/aion/crypto/HashTest.java
@@ -36,7 +36,7 @@ package org.aion.crypto;
 
 import static org.junit.Assert.assertEquals;
 
-import org.aion.base.util.Hex;
+import org.aion.util.hex.Hex;
 import org.junit.Test;
 
 public class HashTest {

--- a/modCrypto/test/org/aion/crypto/ecdsa/ECDSATest.java
+++ b/modCrypto/test/org/aion/crypto/ecdsa/ECDSATest.java
@@ -35,7 +35,7 @@
 package org.aion.crypto.ecdsa;
 
 import java.math.BigInteger;
-import org.aion.base.util.Hex;
+import org.aion.util.hex.Hex;
 import org.junit.Test;
 
 public class ECDSATest {

--- a/modCrypto/test/org/aion/crypto/ecdsa/ECDSATest.java
+++ b/modCrypto/test/org/aion/crypto/ecdsa/ECDSATest.java
@@ -35,7 +35,7 @@
 package org.aion.crypto.ecdsa;
 
 import java.math.BigInteger;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Test;
 
 public class ECDSATest {

--- a/modP2p/build.gradle
+++ b/modP2p/build.gradle
@@ -1,8 +1,6 @@
 ext.moduleName = 'aion.p2p'
 
 dependencies {
-    compile project(':modAionBase')
-
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-core:1.3'
 }

--- a/modP2p/src/module-info.java
+++ b/modP2p/src/module-info.java
@@ -1,5 +1,3 @@
 module aion.p2p {
-    requires aion.base;
-
     exports org.aion.p2p;
 }

--- a/modP2pImpl/build.gradle
+++ b/modP2pImpl/build.gradle
@@ -9,7 +9,7 @@ sourceSets {
 }
 
 dependencies {
-    compile project(':modAionBase')
+    compile project(':modUtil')
     compile project(':modP2p')
     compile project(':modLogger')
     compile files('../lib/miniupnpc_linux.jar')

--- a/modP2pImpl/src/module-info.java
+++ b/modP2pImpl/src/module-info.java
@@ -1,6 +1,6 @@
 module aion.p2p.impl {
     requires aion.p2p;
-    requires aion.base;
+    requires aion.util;
     requires aion.log;
     requires miniupnpc.linux;
     requires slf4j.api;

--- a/modP2pImpl/src/org/aion/p2p/impl/comm/Node.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/comm/Node.java
@@ -28,9 +28,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.Arrays;
 import java.util.regex.Pattern;
-import org.aion.base.util.ByteUtil;
 import org.aion.p2p.INode;
 import org.aion.p2p.IPeerMetric;
+import org.aion.util.bytes.ByteUtil;
 
 /**
  * @author Chris p2p://{node-id}@{ip}:{port} node-id could be any non-empty string update to 36

--- a/modRlp/build.gradle
+++ b/modRlp/build.gradle
@@ -1,7 +1,7 @@
 ext.moduleName = 'aion.rlp'
 
 dependencies {
-    compile project(':modAionBase')
+    compile project(':modUtil')
     compile files('../lib/libnsc.jar')
     compile 'com.google.guava:guava:25.1-jre'
 

--- a/modRlp/src/module-info.java
+++ b/modRlp/src/module-info.java
@@ -1,5 +1,5 @@
 module aion.rlp {
-    requires aion.base;
+    requires aion.util;
 
     exports org.aion.rlp;
 }

--- a/modRlp/src/org/aion/rlp/CompactEncoder.java
+++ b/modRlp/src/org/aion/rlp/CompactEncoder.java
@@ -36,8 +36,8 @@ package org.aion.rlp;
 
 import static java.util.Arrays.copyOf;
 import static java.util.Arrays.copyOfRange;
-import static org.aion.base.util.ByteUtil.appendByte;
 import static org.aion.rlp.Utils.hexEncode;
+import static org.aion.util.bytes.ByteUtil.appendByte;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/modRlp/src/org/aion/rlp/DecodeResult.java
+++ b/modRlp/src/org/aion/rlp/DecodeResult.java
@@ -35,7 +35,7 @@
 package org.aion.rlp;
 
 import java.io.Serializable;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 
 @SuppressWarnings("serial")
 public class DecodeResult implements Serializable {

--- a/modRlp/src/org/aion/rlp/DecodeResult.java
+++ b/modRlp/src/org/aion/rlp/DecodeResult.java
@@ -35,7 +35,7 @@
 package org.aion.rlp;
 
 import java.io.Serializable;
-import org.aion.base.util.Hex;
+import org.aion.util.hex.Hex;
 
 @SuppressWarnings("serial")
 public class DecodeResult implements Serializable {

--- a/modRlp/src/org/aion/rlp/RLP.java
+++ b/modRlp/src/org/aion/rlp/RLP.java
@@ -35,18 +35,18 @@
 package org.aion.rlp;
 
 import static java.util.Arrays.copyOfRange;
-import static org.aion.base.util.ByteUtil.byteArrayToInt;
-import static org.aion.base.util.ByteUtil.intToBytesNoLeadZeroes;
-import static org.aion.base.util.ByteUtil.isNullOrZeroArray;
-import static org.aion.base.util.ByteUtil.isSingleZero;
 import static org.aion.rlp.Utils.asUnsignedByteArray;
 import static org.aion.rlp.Utils.concatenate;
+import static org.aion.util.bytes.ByteUtil.byteArrayToInt;
+import static org.aion.util.bytes.ByteUtil.intToBytesNoLeadZeroes;
+import static org.aion.util.bytes.ByteUtil.isNullOrZeroArray;
+import static org.aion.util.bytes.ByteUtil.isSingleZero;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.Hex;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.util.hex.Hex;
 
 /**
  * @author Roman Mandeleil 2014

--- a/modRlp/src/org/aion/rlp/RLP.java
+++ b/modRlp/src/org/aion/rlp/RLP.java
@@ -46,7 +46,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import org.aion.util.bytes.ByteUtil;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 
 /**
  * @author Roman Mandeleil 2014

--- a/modRlp/src/org/aion/rlp/RLPItem.java
+++ b/modRlp/src/org/aion/rlp/RLPItem.java
@@ -34,7 +34,7 @@
  */
 package org.aion.rlp;
 
-import org.aion.base.util.ByteUtil;
+import org.aion.util.bytes.ByteUtil;
 
 /**
  * @author Roman Mandeleil 2014

--- a/modRlp/src/org/aion/rlp/RLPList.java
+++ b/modRlp/src/org/aion/rlp/RLPList.java
@@ -35,7 +35,7 @@
 package org.aion.rlp;
 
 import java.util.ArrayList;
-import org.aion.base.util.ByteUtil;
+import org.aion.util.bytes.ByteUtil;
 
 /**
  * @author Roman Mandeleil

--- a/modRlp/src/org/aion/rlp/Value.java
+++ b/modRlp/src/org/aion/rlp/Value.java
@@ -37,8 +37,8 @@ package org.aion.rlp;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.Hex;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.util.hex.Hex;
 
 /**
  * Class to encapsulate an object and provide utilities for conversion

--- a/modRlp/src/org/aion/rlp/Value.java
+++ b/modRlp/src/org/aion/rlp/Value.java
@@ -38,7 +38,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import org.aion.util.bytes.ByteUtil;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 
 /**
  * Class to encapsulate an object and provide utilities for conversion

--- a/modRlp/test/org/aion/rlp/ByteUtilTest.java
+++ b/modRlp/test/org/aion/rlp/ByteUtilTest.java
@@ -42,14 +42,15 @@ import static org.junit.Assert.assertTrue;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.FastByteComparisons;
-import org.aion.base.util.Hex;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.util.hex.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 import org.spongycastle.util.BigIntegers;
 
+/** TODO: functionality should be moved to modUtil */
 public class ByteUtilTest {
 
     @Test
@@ -268,7 +269,7 @@ public class ByteUtilTest {
             byte[] max = ByteBuffer.allocate(4).putInt(Integer.MAX_VALUE).array();
             long start1 = System.currentTimeMillis();
             while (ByteUtil.increment(counter1)) {
-                if (FastByteComparisons.compareTo(counter1, 0, 4, max, 0, 4) == 0) {
+                if (compareTo(counter1, 0, 4, max, 0, 4) == 0) {
                     break;
                 }
             }
@@ -292,6 +293,15 @@ public class ByteUtilTest {
                             + "ms to reach: "
                             + Hex.toHexString(BigIntegers.asUnsignedByteArray(4, counter2)));
         }
+    }
+
+    /** Compares two regions of byte array. */
+    public static int compareTo(
+            byte[] array1, int offset1, int size1, byte[] array2, int offset2, int size2) {
+        byte[] b1 = Arrays.copyOfRange(array1, offset1, offset1 + size1);
+        byte[] b2 = Arrays.copyOfRange(array2, offset2, offset2 + size2);
+
+        return Arrays.compare(b1, b2);
     }
 
     @Test

--- a/modRlp/test/org/aion/rlp/ByteUtilTest.java
+++ b/modRlp/test/org/aion/rlp/ByteUtilTest.java
@@ -45,7 +45,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.aion.util.bytes.ByteUtil;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 import org.spongycastle.util.BigIntegers;

--- a/modRlp/test/org/aion/rlp/RLPDump.java
+++ b/modRlp/test/org/aion/rlp/RLPDump.java
@@ -35,7 +35,7 @@
 package org.aion.rlp;
 
 import java.util.Arrays;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Test;
 
 public class RLPDump {

--- a/modRlp/test/org/aion/rlp/RLPDump.java
+++ b/modRlp/test/org/aion/rlp/RLPDump.java
@@ -35,7 +35,7 @@
 package org.aion.rlp;
 
 import java.util.Arrays;
-import org.aion.base.util.Hex;
+import org.aion.util.hex.Hex;
 import org.junit.Test;
 
 public class RLPDump {

--- a/modRlp/test/org/aion/rlp/RLPElementTest.java
+++ b/modRlp/test/org/aion/rlp/RLPElementTest.java
@@ -25,7 +25,7 @@ package org.aion.rlp;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.aion.base.util.ByteUtil;
+import org.aion.util.bytes.ByteUtil;
 import org.junit.Test;
 
 public class RLPElementTest {

--- a/modRlp/test/org/aion/rlp/RLPSpecExtraTest.java
+++ b/modRlp/test/org/aion/rlp/RLPSpecExtraTest.java
@@ -23,8 +23,6 @@
 package org.aion.rlp;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.aion.base.util.ByteUtil.EMPTY_BYTE_ARRAY;
-import static org.aion.base.util.ByteUtil.byteArrayToInt;
 import static org.aion.rlp.RLPSpecTest.assertDecodeBigInteger;
 import static org.aion.rlp.RLPSpecTest.assertDecodeInt;
 import static org.aion.rlp.RLPSpecTest.assertDecodeLong;
@@ -33,11 +31,13 @@ import static org.aion.rlp.RLPSpecTest.assertEncodeInt;
 import static org.aion.rlp.RLPSpecTest.assertEncodeLong;
 import static org.aion.rlp.RLPSpecTest.assertEncodeShort;
 import static org.aion.rlp.Utils.asUnsignedByteArray;
+import static org.aion.util.bytes.ByteUtil.EMPTY_BYTE_ARRAY;
+import static org.aion.util.bytes.ByteUtil.byteArrayToInt;
 
 import java.math.BigInteger;
 import java.util.List;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.Hex;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.util.hex.Hex;
 import org.junit.Test;
 
 /**

--- a/modRlp/test/org/aion/rlp/RLPSpecExtraTest.java
+++ b/modRlp/test/org/aion/rlp/RLPSpecExtraTest.java
@@ -37,7 +37,7 @@ import static org.aion.util.bytes.ByteUtil.byteArrayToInt;
 import java.math.BigInteger;
 import java.util.List;
 import org.aion.util.bytes.ByteUtil;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Test;
 
 /**

--- a/modRlp/test/org/aion/rlp/RLPSpecTest.java
+++ b/modRlp/test/org/aion/rlp/RLPSpecTest.java
@@ -32,7 +32,7 @@ import static org.aion.util.bytes.ByteUtil.byteArrayToLong;
 import java.math.BigInteger;
 import java.util.List;
 import org.aion.util.bytes.ByteUtil;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Test;
 
 /**

--- a/modRlp/test/org/aion/rlp/RLPSpecTest.java
+++ b/modRlp/test/org/aion/rlp/RLPSpecTest.java
@@ -23,16 +23,16 @@
 package org.aion.rlp;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.aion.base.util.ByteUtil.EMPTY_BYTE_ARRAY;
-import static org.aion.base.util.ByteUtil.byteArrayToInt;
-import static org.aion.base.util.ByteUtil.byteArrayToLong;
 import static org.aion.rlp.RLPTest.bytesToAscii;
 import static org.aion.rlp.Utils.asUnsignedByteArray;
+import static org.aion.util.bytes.ByteUtil.EMPTY_BYTE_ARRAY;
+import static org.aion.util.bytes.ByteUtil.byteArrayToInt;
+import static org.aion.util.bytes.ByteUtil.byteArrayToLong;
 
 import java.math.BigInteger;
 import java.util.List;
-import org.aion.base.util.ByteUtil;
-import org.aion.base.util.Hex;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.util.hex.Hex;
 import org.junit.Test;
 
 /**

--- a/modRlp/test/org/aion/rlp/RLPTest.java
+++ b/modRlp/test/org/aion/rlp/RLPTest.java
@@ -34,7 +34,6 @@
  */
 package org.aion.rlp;
 
-import static org.aion.base.util.ByteUtil.byteArrayToInt;
 import static org.aion.rlp.RLP.decode;
 import static org.aion.rlp.RLP.decode2;
 import static org.aion.rlp.RLP.decodeInt;
@@ -74,6 +73,7 @@ import static org.aion.rlp.RlpTestData.test09;
 import static org.aion.rlp.RlpTestData.test12;
 import static org.aion.rlp.RlpTestData.test13;
 import static org.aion.rlp.RlpTestData.test16;
+import static org.aion.util.bytes.ByteUtil.byteArrayToInt;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -88,7 +88,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.aion.base.util.Hex;
+import org.aion.util.hex.Hex;
 import org.junit.Test;
 
 public class RLPTest {

--- a/modRlp/test/org/aion/rlp/RLPTest.java
+++ b/modRlp/test/org/aion/rlp/RLPTest.java
@@ -88,7 +88,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Test;
 
 public class RLPTest {

--- a/modRlp/test/org/aion/rlp/UtilsTest.java
+++ b/modRlp/test/org/aion/rlp/UtilsTest.java
@@ -25,7 +25,7 @@ package org.aion.rlp;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Arrays;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 import org.junit.Test;
 
 public class UtilsTest {

--- a/modRlp/test/org/aion/rlp/UtilsTest.java
+++ b/modRlp/test/org/aion/rlp/UtilsTest.java
@@ -25,7 +25,7 @@ package org.aion.rlp;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Arrays;
-import org.aion.base.util.Hex;
+import org.aion.util.hex.Hex;
 import org.junit.Test;
 
 public class UtilsTest {

--- a/modUtil/build.gradle
+++ b/modUtil/build.gradle
@@ -1,0 +1,6 @@
+ext.moduleName = 'aion.util'
+
+dependencies {
+    testCompile 'junit:junit:4.12'
+    testCompile 'pl.pragmatists:JUnitParams:1.1.1'
+}

--- a/modUtil/src/module-info.java
+++ b/modUtil/src/module-info.java
@@ -1,5 +1,5 @@
 module aion.util {
     exports org.aion.util;
     exports org.aion.util.bytes;
-    exports org.aion.util.hex;
+    exports org.aion.util.conversions;
 }

--- a/modUtil/src/module-info.java
+++ b/modUtil/src/module-info.java
@@ -1,0 +1,5 @@
+module aion.util {
+    exports org.aion.util;
+    exports org.aion.util.bytes;
+    exports org.aion.util.hex;
+}

--- a/modUtil/src/org/aion/util/NativeLoader.java
+++ b/modUtil/src/org/aion/util/NativeLoader.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ *     <ether.camp> team through the ethereumJ library.
+ *     Ether.Camp Inc. (US) team through Ethereum Harmony.
+ *     John Tromp through the Equihash solver.
+ *     Samuel Neves through the BLAKE2 implementation.
+ *     Zcash project team.
+ *     Bitcoinj team.
+ */
+
+package org.aion.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Scanner;
+
+// import java.io.FileNotFoundException;
+// import java.io.FileOutputStream;
+// import java.io.InputStream;
+// import java.io.OutputStream;
+
+/**
+ * Native library loader.
+ *
+ * @author jin
+ */
+public class NativeLoader {
+
+    /**
+     * Returns the current OS name.
+     *
+     * @return
+     */
+    public static String getOS() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.contains("win")) {
+            return "win";
+        } else if (osName.contains("linux")) {
+            return "linux";
+        } else if (osName.contains("mac")) {
+            return "mac";
+        } else {
+            throw new RuntimeException("Unrecognized OS: " + osName);
+        }
+    }
+
+    /**
+     * Builds a file path given a list of folder names.
+     *
+     * @param args
+     * @return
+     */
+    public static File buildPath(String... args) {
+        StringBuilder sb = new StringBuilder();
+        for (String arg : args) {
+            sb.append(File.separator);
+            sb.append(arg);
+        }
+
+        return sb.length() > 0 ? new File(sb.substring(1)) : new File(".");
+    }
+
+    /**
+     * Loads library based on the file list in the given module folder.
+     *
+     * @param module
+     */
+    public static void loadLibrary(String module) {
+        File dir = buildPath("native", getOS(), module);
+
+        try (Scanner s = new Scanner(new File(dir, "file.list"))) {
+            while (s.hasNextLine()) {
+                String line = s.nextLine();
+
+                if (line.startsWith("/") || line.startsWith(".")) { // for debug
+                    // purpose
+                    // mainly
+                    System.load(line);
+                } else {
+                    System.load(new File(dir, line).getCanonicalPath());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load libraries for " + module, e);
+        }
+    }
+
+    //    public static void loadLibraryFromJar(@SuppressWarnings("rawtypes") Class clz, String
+    // path)
+    //            throws IOException {
+    //
+    //        if (!path.startsWith("/")) {
+    //            throw new IllegalArgumentException("The path has to be absolute (start with
+    // '/').");
+    //        }
+    //
+    //        // Obtain filename from path
+    //        String[] parts = path.split("/");
+    //        String filename = (parts.length > 1) ? parts[parts.length - 1] : null;
+    //
+    //        // Split filename to prexif and suffix (extension)
+    //        String prefix = "";
+    //        String suffix = null;
+    //        if (filename != null) {
+    //            parts = filename.split("\\.", 2);
+    //            prefix = parts[0];
+    //            suffix = (parts.length > 1) ? "." + parts[parts.length - 1] : null;
+    //        }
+    //
+    //        // Check if the filename is okay
+    //        if (filename == null || prefix.length() < 3) {
+    //            throw new IllegalArgumentException(
+    //                    "The filename has to be at least 3 characters long.");
+    //        }
+    //
+    //        // Prepare temporary file
+    //        File temp = File.createTempFile(prefix, suffix);
+    //        temp.deleteOnExit();
+    //
+    //        if (!temp.exists()) {
+    //            throw new FileNotFoundException("File " + temp.getAbsolutePath() + " does not
+    // exist.");
+    //        }
+    //
+    //        // Prepare buffer for data copying
+    //        byte[] buffer = new byte[1024];
+    //        int readBytes;
+    //
+    //        // Open and check input stream
+    //        InputStream is = clz.getResourceAsStream(path);
+    //        if (is == null) {
+    //            throw new FileNotFoundException("File " + path + " was not found inside JAR.");
+    //        }
+    //
+    //        // Open output stream and copy data between source file in JAR and the
+    //        // temporary file
+    //        OutputStream os = new FileOutputStream(temp);
+    //        try {
+    //            while ((readBytes = is.read(buffer)) != -1) {
+    //                os.write(buffer, 0, readBytes);
+    //            }
+    //        } finally {
+    //            // If read/write fails, close streams safely before throwing an
+    //            // exception
+    //            os.close();
+    //            is.close();
+    //        }
+    //
+    //        // Finally, load the library
+    //        System.load(temp.getAbsolutePath());
+    //    }
+}

--- a/modUtil/src/org/aion/util/bytes/ByteUtil.java
+++ b/modUtil/src/org/aion/util/bytes/ByteUtil.java
@@ -1,0 +1,738 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ *     <ether.camp> team through the ethereumJ library.
+ *     Ether.Camp Inc. (US) team through Ethereum Harmony.
+ *     John Tromp through the Equihash solver.
+ *     Samuel Neves through the BLAKE2 implementation.
+ *     Zcash project team.
+ *     Bitcoinj team.
+ */
+
+package org.aion.util.bytes;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.aion.util.hex.Hex;
+
+public class ByteUtil {
+
+    public static final byte[] EMPTY_WORD = new byte[32];
+    public static final byte[] EMPTY_HALFWORD = new byte[16];
+    public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    public static final byte[] ZERO_BYTE_ARRAY = new byte[] {0};
+    public static final String EMPTY_STRING = "";
+
+    /** Creates a copy of bytes and appends b to the end of it */
+    public static byte[] appendByte(byte[] bytes, byte b) {
+        byte[] result = Arrays.copyOf(bytes, bytes.length + 1);
+        result[result.length - 1] = b;
+        return result;
+    }
+
+    /**
+     * The regular {@link BigInteger#toByteArray()} method isn't quite what we often need: it
+     * appends a leading zero to indicate that the number is positive and may need padding.
+     *
+     * @param b the integer to format into a byte array
+     * @param numBytes the desired size of the resulting byte array
+     * @return numBytes byte long array.
+     */
+    public static byte[] bigIntegerToBytes(BigInteger b, int numBytes) {
+        if (b == null) {
+            return null;
+        }
+        byte[] bytes = new byte[numBytes];
+        byte[] biBytes = b.toByteArray();
+        int start = (biBytes.length == numBytes + 1) ? 1 : 0;
+        int length = Math.min(biBytes.length, numBytes);
+        System.arraycopy(biBytes, start, bytes, numBytes - length, length);
+        return bytes;
+    }
+
+    public static byte[] bigIntegerToBytesSigned(BigInteger b, int numBytes) {
+        if (b == null) {
+            return null;
+        }
+        byte[] bytes = new byte[numBytes];
+        Arrays.fill(bytes, b.signum() < 0 ? (byte) 0xFF : 0x00);
+        byte[] biBytes = b.toByteArray();
+        int start = (biBytes.length == numBytes + 1) ? 1 : 0;
+        int length = Math.min(biBytes.length, numBytes);
+        System.arraycopy(biBytes, start, bytes, numBytes - length, length);
+        return bytes;
+    }
+
+    /**
+     * Omitting sign indication byte. <br>
+     * <br>
+     * Instead of {@code org.spongycastle.util.BigIntegers#asUnsignedByteArray(BigInteger)} <br>
+     * we use this custom method to avoid an empty array in case of BigInteger.ZERO
+     *
+     * @param value - any big integer number. A <code>null</code>-value will return <code>null
+     *     </code>
+     * @return A byte array without a leading zero byte if present in the signed encoding.
+     *     BigInteger.ZERO will return an array with length 1 and byte-value 0.
+     */
+    public static byte[] bigIntegerToBytes(BigInteger value) {
+        if (value == null) {
+            return null;
+        }
+
+        byte[] data = value.toByteArray();
+
+        if (data.length != 1 && data[0] == 0) {
+            byte[] tmp = new byte[data.length - 1];
+            System.arraycopy(data, 1, tmp, 0, tmp.length);
+            data = tmp;
+        }
+        return data;
+    }
+
+    public static BigInteger bytesToBigInteger(byte[] bb) {
+        return bb.length == 0 ? BigInteger.ZERO : new BigInteger(1, bb);
+    }
+
+    /**
+     * Returns the amount of nibbles that match each other from 0 ... amount will never be larger
+     * than smallest input
+     *
+     * @param a - first input
+     * @param b - second input
+     * @return Number of bytes that match
+     */
+    public static int matchingNibbleLength(byte[] a, byte[] b) {
+        int i = 0;
+        int length = a.length < b.length ? a.length : b.length;
+        while (i < length) {
+            if (a[i] != b[i]) {
+                return i;
+            }
+            i++;
+        }
+        return i;
+    }
+
+    /** Perform an in-place conversion of a byte array from big endian to little endian. */
+    public static void toLEByteArray(byte[] toConvert) {
+
+        if (toConvert == null) {
+            return;
+        }
+
+        for (int i = 0; i < toConvert.length / 2; i++) {
+            byte temp = toConvert[i];
+            toConvert[i] = toConvert[toConvert.length - 1 - i];
+            toConvert[toConvert.length - 1 - i] = temp;
+        }
+    }
+
+    /**
+     * Converts a long value into a byte array.
+     *
+     * @param val - long value to convert
+     * @return <code>byte[]</code> of length 8, representing the long value
+     */
+    public static byte[] longToBytes(long val) {
+        return ByteBuffer.allocate(8).putLong(val).array();
+    }
+
+    public static byte[] longToBytesLE(long val) {
+        ByteBuffer bb = ByteBuffer.allocate(8);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        return bb.putLong(val).array();
+    }
+
+    /**
+     * Converts a long value into a byte array.
+     *
+     * @param val - long value to convert
+     * @return decimal value with leading byte that are zeroes striped
+     */
+    public static byte[] longToBytesNoLeadZeroes(long val) {
+
+        // todo: improve performance by while strip numbers until (long >> 8 ==
+        // 0)
+        if (val == 0) {
+            return EMPTY_BYTE_ARRAY;
+        }
+
+        byte[] data = ByteBuffer.allocate(8).putLong(val).array();
+
+        return stripLeadingZeroes(data);
+    }
+
+    /**
+     * Converts int value into a byte array.
+     *
+     * @param val - int value to convert
+     * @return <code>byte[]</code> of length 4, representing the int value
+     */
+    public static byte[] intToBytes(int val) {
+        return ByteBuffer.allocate(4).putInt(val).array();
+    }
+
+    /**
+     * Converts and int value to a byte array (Little Endian) @ param val
+     *
+     * @return <code>byte[]</code> of length 4; representing the int value in LE order
+     */
+    public static byte[] intToBytesLE(int val) {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        return bb.putInt(val).array();
+    }
+
+    /**
+     * Converts and int value to a byte array (Big Endian) @ param val
+     *
+     * @return <code>byte[]</code> of length 4; representing the int value in LE order
+     */
+    public static byte[] intToBytesBE(int val) {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.order(ByteOrder.BIG_ENDIAN);
+        return bb.putInt(val).array();
+    }
+
+    /**
+     * Converts a int value into a byte array.
+     *
+     * @param val - int value to convert
+     * @return value with leading byte that are zeroes striped
+     */
+    public static byte[] intToBytesNoLeadZeroes(int val) {
+
+        if (val == 0) {
+            return EMPTY_BYTE_ARRAY;
+        }
+
+        int lenght = 0;
+
+        int tmpVal = val;
+        while (tmpVal != 0) {
+            tmpVal = tmpVal >>> 8;
+            ++lenght;
+        }
+
+        byte[] result = new byte[lenght];
+
+        int index = result.length - 1;
+        while (val != 0) {
+
+            result[index] = (byte) (val & 0xFF);
+            val = val >>> 8;
+            index -= 1;
+        }
+
+        return result;
+    }
+
+    /**
+     * Convert a byte-array into a hex String.<br>
+     * Works similar to {@link Hex#toHexString} but allows for <code>null</code>
+     *
+     * @param data - byte-array to convert to a hex-string
+     * @return hex representation of the data.<br>
+     *     Returns an empty String if the input is <code>null</code> TODO: swap out with more
+     *     efficient implementation, for now seems like we are stuck with this
+     * @see Hex#toHexString
+     */
+    public static String toHexString(byte[] data) {
+        return data == null ? "" : Hex.toHexString(data);
+    }
+
+    public static String toHexStringWithPrefix(byte[] data) {
+        return "0x" + toHexString(data);
+    }
+
+    /**
+     * Calculate packet length
+     *
+     * @param msg byte[]
+     * @return byte-array with 4 elements
+     */
+    public static byte[] calcPacketLength(byte[] msg) {
+        int msgLen = msg.length;
+        return new byte[] {
+            (byte) ((msgLen >> 24) & 0xFF),
+            (byte) ((msgLen >> 16) & 0xFF),
+            (byte) ((msgLen >> 8) & 0xFF),
+            (byte) ((msgLen) & 0xFF)
+        };
+    }
+
+    /**
+     * Cast hex encoded value from byte[] to int
+     *
+     * <p>Limited to Integer.MAX_VALUE: 2^31-1 (4 bytes)
+     *
+     * @param b array contains the values
+     * @return unsigned positive int value.
+     */
+    public static int byteArrayToInt(byte[] b) {
+        if (b == null || b.length == 0) {
+            return 0;
+        }
+        return new BigInteger(1, b).intValue();
+    }
+
+    /**
+     * Cast hex encoded value from byte[] to long
+     *
+     * <p>Limited to Long.MAX_VALUE: 2^63-1 (8 bytes)
+     *
+     * @param b array contains the values
+     * @return unsigned positive long value.
+     */
+    public static long byteArrayToLong(byte[] b) {
+        if (b == null || b.length == 0) {
+            return 0;
+        }
+        return new BigInteger(1, b).longValue();
+    }
+
+    /** Used in conjunction w/ RLP, casts to byte */
+    public static byte toByte(byte[] b) {
+        if (b == null || b.length == 0) {
+            return 0;
+        }
+        return b[0];
+    }
+
+    /**
+     * Turn nibbles to a pretty looking output string
+     *
+     * <p>Example. [ 1, 2, 3, 4, 5 ] becomes '\x11\x23\x45'
+     *
+     * @param nibbles - getting byte of data [ 04 ] and turning it to a '\x04' representation
+     * @return pretty string of nibbles
+     */
+    public static String nibblesToPrettyString(byte[] nibbles) {
+        StringBuilder builder = new StringBuilder();
+        for (byte nibble : nibbles) {
+            final String nibbleString = oneByteToHexString(nibble);
+            builder.append("\\x").append(nibbleString);
+        }
+        return builder.toString();
+    }
+
+    public static String oneByteToHexString(byte value) {
+        String retVal = Integer.toString(value & 0xFF, 16);
+        if (retVal.length() == 1) {
+            retVal = "0" + retVal;
+        }
+        return retVal;
+    }
+
+    /**
+     * Calculate the number of bytes need to encode the number
+     *
+     * @param val - number
+     * @return number of min bytes used to encode the number
+     */
+    public static int numBytes(String val) {
+
+        BigInteger bInt = new BigInteger(val);
+        int bytes = 0;
+
+        while (!bInt.equals(BigInteger.ZERO)) {
+            bInt = bInt.shiftRight(8);
+            ++bytes;
+        }
+        if (bytes == 0) {
+            ++bytes;
+        }
+        return bytes;
+    }
+
+    /**
+     * @param arg - not more that 32 bits
+     * @return - bytes of the value pad with complete to 32 zeroes
+     */
+    public static byte[] encodeValFor32Bits(Object arg) {
+
+        byte[] data;
+
+        // check if the string is numeric
+        if (arg.toString().trim().matches("-?\\d+(\\.\\d+)?")) {
+            data = new BigInteger(arg.toString().trim()).toByteArray();
+        } // check if it's hex number
+        else if (arg.toString().trim().matches("0[xX][0-9a-fA-F]+")) {
+            data = new BigInteger(arg.toString().trim().substring(2), 16).toByteArray();
+        } else {
+            data = arg.toString().trim().getBytes();
+        }
+
+        if (data.length > 32) {
+            throw new RuntimeException("values can't be more than 32 byte");
+        }
+
+        byte[] val = new byte[32];
+
+        int j = 0;
+        for (int i = data.length; i > 0; --i) {
+            val[31 - j] = data[i - 1];
+            ++j;
+        }
+        return val;
+    }
+
+    /**
+     * encode the values and concatenate together
+     *
+     * @param args Object
+     * @return byte[]
+     */
+    public static byte[] encodeDataList(Object... args) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        for (Object arg : args) {
+            byte[] val = encodeValFor32Bits(arg);
+            try {
+                baos.write(val);
+            } catch (IOException e) {
+                throw new Error("Happen something that should never happen ", e);
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    public static int firstNonZeroByte(byte[] data) {
+        for (int i = 0; i < data.length; ++i) {
+            if (data[i] != 0) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static byte[] stripLeadingZeroes(byte[] data) {
+
+        if (data == null) {
+            return null;
+        }
+
+        final int firstNonZero = firstNonZeroByte(data);
+        switch (firstNonZero) {
+            case -1:
+                return ZERO_BYTE_ARRAY;
+
+            case 0:
+                return data;
+
+            default:
+                byte[] result = new byte[data.length - firstNonZero];
+                System.arraycopy(data, firstNonZero, result, 0, data.length - firstNonZero);
+
+                return result;
+        }
+    }
+
+    /**
+     * increment byte array as a number until max is reached
+     *
+     * @param bytes byte[]
+     * @return boolean
+     */
+    public static boolean increment(byte[] bytes) {
+        final int startIndex = 0;
+        int i;
+        for (i = bytes.length - 1; i >= startIndex; i--) {
+            bytes[i]++;
+            if (bytes[i] != 0) {
+                break;
+            }
+        }
+        // we return false when all bytes are 0 again
+        return (i >= startIndex || bytes[startIndex] != 0);
+    }
+
+    /**
+     * Utility function to copy a byte array into a new byte array with given size. If the src
+     * length is smaller than the given size, the result will be left-padded with zeros.
+     *
+     * @param value - a BigInteger with a maximum value of 2^256-1
+     * @return Byte array of given size with a copy of the <code>src</code>
+     */
+    public static byte[] copyToArray(BigInteger value) {
+        byte[] src = ByteUtil.bigIntegerToBytes(value);
+        byte[] dest = ByteBuffer.allocate(32).array();
+        System.arraycopy(src, 0, dest, dest.length - src.length, src.length);
+        return dest;
+    }
+
+    public static byte[] setBit(byte[] data, int pos, int val) {
+
+        if ((data.length * 8) - 1 < pos) {
+            throw new Error("outside byte array limit, pos: " + pos);
+        }
+
+        int posByte = data.length - 1 - (pos) / 8;
+        int posBit = (pos) % 8;
+        byte setter = (byte) (1 << (posBit));
+        byte toBeSet = data[posByte];
+        byte result;
+        if (val == 1) {
+            result = (byte) (toBeSet | setter);
+        } else {
+            result = (byte) (toBeSet & ~setter);
+        }
+
+        data[posByte] = result;
+        return data;
+    }
+
+    public static int getBit(byte[] data, int pos) {
+
+        if ((data.length * 8) - 1 < pos) {
+            throw new Error("outside byte array limit, pos: " + pos);
+        }
+
+        int posByte = data.length - 1 - pos / 8;
+        int posBit = pos % 8;
+        byte dataByte = data[posByte];
+        return Math.min(1, (dataByte & (1 << (posBit))));
+    }
+
+    public static byte[] and(byte[] b1, byte[] b2) {
+        if (b1.length != b2.length) {
+            throw new RuntimeException("Array sizes differ");
+        }
+        byte[] ret = new byte[b1.length];
+        for (int i = 0; i < ret.length; i++) {
+            ret[i] = (byte) (b1[i] & b2[i]);
+        }
+        return ret;
+    }
+
+    public static byte[] or(byte[] b1, byte[] b2) {
+        if (b1.length != b2.length) {
+            throw new RuntimeException("Array sizes differ");
+        }
+        byte[] ret = new byte[b1.length];
+        for (int i = 0; i < ret.length; i++) {
+            ret[i] = (byte) (b1[i] | b2[i]);
+        }
+        return ret;
+    }
+
+    public static byte[] xor(byte[] b1, byte[] b2) {
+        if (b1.length != b2.length) {
+            throw new RuntimeException("Array sizes differ");
+        }
+        byte[] ret = new byte[b1.length];
+        for (int i = 0; i < ret.length; i++) {
+            ret[i] = (byte) (b1[i] ^ b2[i]);
+        }
+        return ret;
+    }
+
+    /**
+     * XORs byte arrays of different lengths by aligning length of the shortest via adding zeros at
+     * beginning
+     */
+    public static byte[] xorAlignRight(byte[] b1, byte[] b2) {
+        if (b1.length > b2.length) {
+            byte[] b2_ = new byte[b1.length];
+            System.arraycopy(b2, 0, b2_, b1.length - b2.length, b2.length);
+            b2 = b2_;
+        } else if (b2.length > b1.length) {
+            byte[] b1_ = new byte[b2.length];
+            System.arraycopy(b1, 0, b1_, b2.length - b1.length, b1.length);
+            b1 = b1_;
+        }
+
+        return xor(b1, b2);
+    }
+
+    /**
+     * @param arrays - arrays to merge
+     * @return - merged array
+     */
+    public static byte[] merge(byte[]... arrays) {
+        int count = 0;
+        for (byte[] array : arrays) {
+            count += array.length;
+        }
+
+        // Create new array and copy all array contents
+        byte[] mergedArray = new byte[count];
+        int start = 0;
+        for (byte[] array : arrays) {
+            System.arraycopy(array, 0, mergedArray, start, array.length);
+            start += array.length;
+        }
+        return mergedArray;
+    }
+
+    public static boolean isNullOrZeroArray(byte[] array) {
+        return (array == null) || (array.length == 0);
+    }
+
+    public static boolean isSingleZero(byte[] array) {
+        return (array.length == 1 && array[0] == 0);
+    }
+
+    public static Set<byte[]> difference(Set<byte[]> setA, Set<byte[]> setB) {
+
+        Set<byte[]> result = new HashSet<>();
+
+        for (byte[] elementA : setA) {
+            boolean found = false;
+            for (byte[] elementB : setB) {
+
+                if (Arrays.equals(elementA, elementB)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                result.add(elementA);
+            }
+        }
+
+        return result;
+    }
+
+    public static int length(byte[]... bytes) {
+        int result = 0;
+        for (byte[] array : bytes) {
+            result += (array == null) ? 0 : array.length;
+        }
+        return result;
+    }
+
+    public static byte[] intsToBytes(int[] arr, boolean bigEndian) {
+        byte[] ret = new byte[arr.length * 4];
+        intsToBytes(arr, ret, bigEndian);
+        return ret;
+    }
+
+    public static int[] bytesToInts(byte[] arr, boolean bigEndian) {
+        int[] ret = new int[arr.length / 4];
+        bytesToInts(arr, ret, bigEndian);
+        return ret;
+    }
+
+    public static void bytesToInts(byte[] b, int[] arr, boolean bigEndian) {
+        if (!bigEndian) {
+            int off = 0;
+            for (int i = 0; i < arr.length; i++) {
+                int ii = b[off++] & 0x000000FF;
+                ii |= (b[off++] << 8) & 0x0000FF00;
+                ii |= (b[off++] << 16) & 0x00FF0000;
+                ii |= (b[off++] << 24);
+                arr[i] = ii;
+            }
+        } else {
+            int off = 0;
+            for (int i = 0; i < arr.length; i++) {
+                int ii = b[off++] << 24;
+                ii |= (b[off++] << 16) & 0x00FF0000;
+                ii |= (b[off++] << 8) & 0x0000FF00;
+                ii |= b[off++] & 0x000000FF;
+                arr[i] = ii;
+            }
+        }
+    }
+
+    public static void intsToBytes(int[] arr, byte[] b, boolean bigEndian) {
+        if (!bigEndian) {
+            int off = 0;
+            for (int i = 0; i < arr.length; i++) {
+                int ii = arr[i];
+                b[off++] = (byte) (ii & 0xFF);
+                b[off++] = (byte) ((ii >> 8) & 0xFF);
+                b[off++] = (byte) ((ii >> 16) & 0xFF);
+                b[off++] = (byte) ((ii >> 24) & 0xFF);
+            }
+        } else {
+            int off = 0;
+            for (int i = 0; i < arr.length; i++) {
+                int ii = arr[i];
+                b[off++] = (byte) ((ii >> 24) & 0xFF);
+                b[off++] = (byte) ((ii >> 16) & 0xFF);
+                b[off++] = (byte) ((ii >> 8) & 0xFF);
+                b[off++] = (byte) (ii & 0xFF);
+            }
+        }
+    }
+
+    public static short bigEndianToShort(byte[] bs) {
+        return bigEndianToShort(bs, 0);
+    }
+
+    public static short bigEndianToShort(byte[] bs, int off) {
+        int n = bs[off] << 8;
+        ++off;
+        n |= bs[off] & 0xFF;
+        return (short) n;
+    }
+
+    public static byte[] shortToBytes(short n) {
+        return ByteBuffer.allocate(2).putShort(n).array();
+    }
+
+    /**
+     * Converts string hex representation to data bytes Accepts following hex: - with or without 0x
+     * prefix - with no leading 0, like 0xabc -> 0x0abc
+     *
+     * @param data String like '0xa5e..' or just 'a5e..'
+     * @return decoded bytes array
+     */
+    public static byte[] hexStringToBytes(String data) {
+        if (data == null) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        if (data.startsWith("0x")) {
+            data = data.substring(2);
+        }
+        if (data.length() % 2 == 1) {
+            data = "0" + data;
+        }
+        return Hex.decode(data);
+    }
+
+    /**
+     * Chops a 32-byte value into a 16-byte value. Keep in mind the subtlety that a "chopped"
+     * bytearray is a different reference from a "unchopped" bytearray, so make no assummptions as
+     * to whether this function news the element.
+     *
+     * @return 16-byte value representing the LOWER portion of the original
+     */
+    public static byte[] chop(byte[] in) {
+        if (in.length <= 16) {
+            return in;
+        }
+        return Arrays.copyOfRange(in, in.length - 16, in.length);
+    }
+}

--- a/modUtil/src/org/aion/util/bytes/ByteUtil.java
+++ b/modUtil/src/org/aion/util/bytes/ByteUtil.java
@@ -43,7 +43,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import org.aion.util.hex.Hex;
+import org.aion.util.conversions.Hex;
 
 public class ByteUtil {
 

--- a/modUtil/src/org/aion/util/conversions/Hex.java
+++ b/modUtil/src/org/aion/util/conversions/Hex.java
@@ -33,7 +33,7 @@
  *     Bitcoinj team.
  */
 
-package org.aion.util.hex;
+package org.aion.util.conversions;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/modUtil/src/org/aion/util/conversions/HexEncoder.java
+++ b/modUtil/src/org/aion/util/conversions/HexEncoder.java
@@ -33,7 +33,7 @@
  *     Bitcoinj team.
  */
 
-package org.aion.util.hex;
+package org.aion.util.conversions;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/modUtil/src/org/aion/util/hex/Hex.java
+++ b/modUtil/src/org/aion/util/hex/Hex.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ *     <ether.camp> team through the ethereumJ library.
+ *     Ether.Camp Inc. (US) team through Ethereum Harmony.
+ *     John Tromp through the Equihash solver.
+ *     Samuel Neves through the BLAKE2 implementation.
+ *     Zcash project team.
+ *     Bitcoinj team.
+ */
+
+package org.aion.util.hex;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** Utility class for converting hex data to bytes and back again. */
+public class Hex {
+
+    private static final HexEncoder encoder = new HexEncoder();
+
+    public static String toHexString(byte[] data) {
+        return toHexString(data, 0, data.length);
+    }
+
+    public static String toHexString(byte[] data, int off, int length) {
+        byte[] encoded = encode(data, off, length);
+        return new String(encoded);
+    }
+
+    /**
+     * encode the input data producing a Hex encoded byte array.
+     *
+     * @return a byte array containing the Hex encoded data.
+     */
+    public static byte[] encode(byte[] data) {
+        return encode(data, 0, data.length);
+    }
+
+    /**
+     * encode the input data producing a Hex encoded byte array.
+     *
+     * @return a byte array containing the Hex encoded data.
+     */
+    public static byte[] encode(byte[] data, int off, int length) {
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+
+        encoder.encode(data, off, length, bOut);
+
+        return bOut.toByteArray();
+    }
+
+    /**
+     * Hex encode the byte data writing it to the given output stream.
+     *
+     * @return the number of bytes produced.
+     */
+    public static int encode(byte[] data, OutputStream out) throws IOException {
+        return encoder.encode(data, 0, data.length, out);
+    }
+
+    /**
+     * Hex encode the byte data writing it to the given output stream.
+     *
+     * @return the number of bytes produced.
+     */
+    public static int encode(byte[] data, int off, int length, OutputStream out)
+            throws IOException {
+        return encoder.encode(data, off, length, out);
+    }
+
+    /**
+     * decode the Hex encoded input data. It is assumed the input data is valid.
+     *
+     * @return a byte array representing the decoded data.
+     */
+    public static byte[] decode(byte[] data) {
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        try {
+            encoder.decode(data, 0, data.length, bOut);
+        } catch (IOException e) {
+            System.err.println("Hex decode failed! " + data);
+            return null;
+        }
+
+        return bOut.toByteArray();
+    }
+
+    /**
+     * decode the Hex encoded String data - whitespace will be ignored.
+     *
+     * @return a byte array representing the decoded data.
+     */
+    public static byte[] decode(String data) {
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        try {
+            encoder.decode(data, bOut);
+        } catch (IOException e) {
+            System.err.println("Hex decode failed! " + data);
+            return null;
+        }
+        return bOut.toByteArray();
+    }
+
+    /**
+     * decode the Hex encoded String data writing it to the given output stream, whitespace
+     * characters will be ignored.
+     *
+     * @return the number of bytes produced.
+     */
+    public static int decode(String data, OutputStream out) throws IOException {
+        return encoder.decode(data, out);
+    }
+}

--- a/modUtil/src/org/aion/util/hex/HexEncoder.java
+++ b/modUtil/src/org/aion/util/hex/HexEncoder.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ *     The aion network project leverages useful source code from other
+ *     open source projects. We greatly appreciate the effort that was
+ *     invested in these projects and we thank the individual contributors
+ *     for their work. For provenance information and contributors
+ *     please see <https://github.com/aionnetwork/aion/wiki/Contributors>.
+ *
+ * Contributors to the aion source files in decreasing order of code volume:
+ *     Aion foundation.
+ *     <ether.camp> team through the ethereumJ library.
+ *     Ether.Camp Inc. (US) team through Ethereum Harmony.
+ *     John Tromp through the Equihash solver.
+ *     Samuel Neves through the BLAKE2 implementation.
+ *     Zcash project team.
+ *     Bitcoinj team.
+ */
+
+package org.aion.util.hex;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** A streaming Hex encoder. */
+public class HexEncoder {
+
+    protected final byte[] encodingTable = {
+        (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6',
+                (byte) '7',
+        (byte) '8', (byte) '9', (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e',
+                (byte) 'f'
+    };
+
+    /*
+     * set up the decoding table.
+     */
+    protected final byte[] decodingTable = new byte[128];
+
+    protected void initialiseDecodingTable() {
+        for (int i = 0; i < decodingTable.length; i++) {
+            decodingTable[i] = (byte) 0xff;
+        }
+
+        for (int i = 0; i < encodingTable.length; i++) {
+            decodingTable[encodingTable[i]] = (byte) i;
+        }
+
+        decodingTable['A'] = decodingTable['a'];
+        decodingTable['B'] = decodingTable['b'];
+        decodingTable['C'] = decodingTable['c'];
+        decodingTable['D'] = decodingTable['d'];
+        decodingTable['E'] = decodingTable['e'];
+        decodingTable['F'] = decodingTable['f'];
+    }
+
+    public HexEncoder() {
+        initialiseDecodingTable();
+    }
+
+    /**
+     * encode the input data producing a Hex output stream.
+     *
+     * @return the number of bytes produced.
+     */
+    public int encode(byte[] data, int off, int length, OutputStream out) {
+        for (int i = off; i < (off + length); i++) {
+            int v = data[i] & 0xff;
+            try {
+                out.write(encodingTable[(v >>> 4)]);
+                out.write(encodingTable[v & 0xf]);
+            } catch (Exception e) {
+            }
+        }
+
+        return length * 2;
+    }
+
+    private static boolean ignore(char c) {
+        return c == '\n' || c == '\r' || c == '\t' || c == ' ';
+    }
+
+    /**
+     * decode the Hex encoded byte data writing it to the given output stream, whitespace characters
+     * will be ignored.
+     *
+     * @return the number of bytes produced.
+     */
+    public int decode(byte[] data, int off, int length, OutputStream out) throws IOException {
+        byte b1, b2;
+        int outLen = 0;
+
+        int end = off + length;
+
+        while (end > off) {
+            if (!ignore((char) data[end - 1])) {
+                break;
+            }
+
+            end--;
+        }
+
+        int i = off;
+        while (i < end) {
+            while (i < end && ignore((char) data[i])) {
+                i++;
+            }
+
+            b1 = decodingTable[data[i++]];
+
+            while (i < end && ignore((char) data[i])) {
+                i++;
+            }
+
+            b2 = decodingTable[data[i++]];
+
+            if ((b1 | b2) < 0) {
+                throw new IOException("invalid characters encountered in Hex data");
+            }
+
+            try {
+                out.write((b1 << 4) | b2);
+            } catch (Exception e) {
+
+            }
+
+            outLen++;
+        }
+
+        return outLen;
+    }
+
+    /**
+     * decode the Hex encoded String data writing it to the given output stream, whitespace
+     * characters will be ignored.
+     *
+     * @return the number of bytes produced.
+     */
+    public int decode(String data, OutputStream out) throws IOException {
+        byte b1, b2;
+        int length = 0;
+
+        int end = data.length();
+
+        while (end > 0) {
+            if (!ignore(data.charAt(end - 1))) {
+                break;
+            }
+
+            end--;
+        }
+
+        int i = 0;
+        while (i < end) {
+            while (i < end && ignore(data.charAt(i))) {
+                i++;
+            }
+
+            b1 = decodingTable[data.charAt(i++)];
+
+            while (i < end && ignore(data.charAt(i))) {
+                i++;
+            }
+
+            b2 = decodingTable[data.charAt(i++)];
+
+            if ((b1 | b2) < 0) {
+                throw new IOException("invalid characters encountered in Hex string");
+            }
+
+            out.write((b1 << 4) | b2);
+
+            length++;
+        }
+
+        return length;
+    }
+}

--- a/modUtil/test/org/aion/util/bytes/ByteUtilTest.java
+++ b/modUtil/test/org/aion/util/bytes/ByteUtilTest.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2017-2018 Aion foundation.
+ *
+ *     This file is part of the aion network project.
+ *
+ *     The aion network project is free software: you can redistribute it
+ *     and/or modify it under the terms of the GNU General Public License
+ *     as published by the Free Software Foundation, either version 3 of
+ *     the License, or any later version.
+ *
+ *     The aion network project is distributed in the hope that it will
+ *     be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *     See the GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with the aion network project source files.
+ *     If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contributors:
+ *     Aion foundation.
+ */
+
+package org.aion.util.bytes;
+
+import static org.aion.util.bytes.ByteUtil.and;
+import static org.aion.util.bytes.ByteUtil.appendByte;
+import static org.aion.util.bytes.ByteUtil.bigEndianToShort;
+import static org.aion.util.bytes.ByteUtil.bigIntegerToBytes;
+import static org.aion.util.bytes.ByteUtil.bigIntegerToBytesSigned;
+import static org.aion.util.bytes.ByteUtil.byteArrayToInt;
+import static org.aion.util.bytes.ByteUtil.byteArrayToLong;
+import static org.aion.util.bytes.ByteUtil.bytesToBigInteger;
+import static org.aion.util.bytes.ByteUtil.copyToArray;
+import static org.aion.util.bytes.ByteUtil.encodeValFor32Bits;
+import static org.aion.util.bytes.ByteUtil.firstNonZeroByte;
+import static org.aion.util.bytes.ByteUtil.getBit;
+import static org.aion.util.bytes.ByteUtil.hexStringToBytes;
+import static org.aion.util.bytes.ByteUtil.increment;
+import static org.aion.util.bytes.ByteUtil.intToBytes;
+import static org.aion.util.bytes.ByteUtil.intToBytesBE;
+import static org.aion.util.bytes.ByteUtil.intToBytesLE;
+import static org.aion.util.bytes.ByteUtil.intToBytesNoLeadZeroes;
+import static org.aion.util.bytes.ByteUtil.isNullOrZeroArray;
+import static org.aion.util.bytes.ByteUtil.isSingleZero;
+import static org.aion.util.bytes.ByteUtil.length;
+import static org.aion.util.bytes.ByteUtil.longToBytes;
+import static org.aion.util.bytes.ByteUtil.longToBytesLE;
+import static org.aion.util.bytes.ByteUtil.longToBytesNoLeadZeroes;
+import static org.aion.util.bytes.ByteUtil.numBytes;
+import static org.aion.util.bytes.ByteUtil.oneByteToHexString;
+import static org.aion.util.bytes.ByteUtil.or;
+import static org.aion.util.bytes.ByteUtil.setBit;
+import static org.aion.util.bytes.ByteUtil.shortToBytes;
+import static org.aion.util.bytes.ByteUtil.stripLeadingZeroes;
+import static org.aion.util.bytes.ByteUtil.toByte;
+import static org.aion.util.bytes.ByteUtil.toHexString;
+import static org.aion.util.bytes.ByteUtil.toHexStringWithPrefix;
+import static org.aion.util.bytes.ByteUtil.toLEByteArray;
+import static org.aion.util.bytes.ByteUtil.xor;
+import static org.aion.util.bytes.ByteUtil.xorAlignRight;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class ByteUtilTest {
+
+    private static final Random random = new Random();
+
+    private final String[] testHex = {
+        null, // 0 - Null
+        "", // 1 - Empty
+        "eF", // 2 - One Byte
+        "aA11bB22cC33dd44aA11bB22cC33dd44aA11bB22cC33dd44aA11bB22cC33dd44", // 3 - Upper/Lower
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // 4 - Negative (-1)
+        "0000000000000000000000000000000000000000000000000000000000000000", // 5 - Zeroes
+        "0000000000000000000000000000000000000000000000000000000000000001", // 6 - Positive (+1)
+    }; // 1byte
+
+    private final byte[][] testByte = {
+        null,
+        hexStringToBytes(testHex[1]),
+        hexStringToBytes(testHex[2]),
+        hexStringToBytes(testHex[3]),
+        hexStringToBytes(testHex[4]),
+        hexStringToBytes(testHex[5]),
+        hexStringToBytes(testHex[6]),
+    };
+
+    private final String[][] testNum = {
+        {null, null},
+        {"-00000000000000000000", "00000000000000000000"},
+        {"-00000000000000000001", "00000000000000000001"},
+        {"-10000000000000000000", "10000000000000000000"},
+        {"-20000000000000000000", "20000000000000000000"},
+        {"-30000000000000000000", "30000000000000000000"},
+        {"-99999999999999999999", "99999999999999999999"},
+    };
+
+    private final BigInteger[][] testBigInt = {
+        {null, null},
+        {new BigInteger(testNum[1][0]), new BigInteger(testNum[1][1])},
+        {new BigInteger(testNum[2][0]), new BigInteger(testNum[2][1])},
+        {new BigInteger(testNum[3][0]), new BigInteger(testNum[3][1])},
+        {new BigInteger(testNum[4][0]), new BigInteger(testNum[4][1])},
+        {new BigInteger(testNum[5][0]), new BigInteger(testNum[5][1])},
+        {new BigInteger(testNum[6][0]), new BigInteger(testNum[6][1])},
+    };
+
+    /** @return input values for {@link #longTest(long)} */
+    @SuppressWarnings("unused")
+    private Object longValues() {
+
+        List<Object> parameters = new ArrayList<>();
+
+        // longs similar to integer values
+        parameters.add(0L);
+        parameters.add(1L);
+        parameters.add(10L);
+        parameters.add((long) random.nextInt(Integer.MAX_VALUE));
+        parameters.add((long) Integer.MAX_VALUE);
+
+        // additional long values
+        parameters.add((long) Integer.MAX_VALUE + random.nextInt(Integer.MAX_VALUE));
+        parameters.add(10L * (long) Integer.MAX_VALUE);
+        parameters.add(Long.MAX_VALUE - 1L);
+
+        return parameters.toArray();
+    }
+
+    /** @return input values for {@link #intTest(int)} */
+    @SuppressWarnings("unused")
+    private Object intValues() {
+
+        List<Object> parameters = new ArrayList<>();
+
+        // integer values
+        parameters.add(0);
+        parameters.add(1);
+        parameters.add(10);
+        parameters.add(15);
+        parameters.add(20);
+        parameters.add(random.nextInt(Integer.MAX_VALUE));
+        parameters.add(Integer.MAX_VALUE);
+
+        return parameters.toArray();
+    }
+
+    /** @return input values for {@link #shortTest(short)} */
+    @SuppressWarnings("unused")
+    private Object shortValues() {
+
+        Short[] temp = {
+            0, 1, 10, 15, 20, (short) random.nextInt(Integer.MAX_VALUE), (short) Integer.MAX_VALUE
+        };
+
+        return temp;
+    }
+
+    /**
+     * TEST: BI <--> Bytes (+ve) bigIntegerToBytes(BI) bigIntegerToBytes(BI, num)
+     * bigIntegerToBytesSigned(BI, num) bytesToBigInteger(byte) {@link #intValues()}.
+     */
+    @Test
+    public void bigIntegerTest() {
+        for (int b = 1; b < 2; b++) {
+            for (int a = 0; a < testBigInt.length; a++) {
+                try {
+                    byte[] temp1 = bigIntegerToBytes(testBigInt[a][b]);
+                    byte[] temp2 = bigIntegerToBytes(testBigInt[a][b], temp1.length);
+                    byte[] temp3 = bigIntegerToBytesSigned(testBigInt[a][b], temp1.length);
+                    byte[] temp4 = encodeValFor32Bits(testNum[a][b]);
+
+                    assertEquals(testBigInt[a][b], bytesToBigInteger(temp1));
+                    assertEquals(testBigInt[a][b], bytesToBigInteger(temp2));
+                    assertEquals(testBigInt[a][b], bytesToBigInteger(temp3));
+                    assertEquals(bytesToBigInteger(temp1), bytesToBigInteger(temp4));
+                } catch (NullPointerException e) {
+                    System.out.println(b + " " + a);
+                    System.out.println("\nNull Big Integer Test!");
+                }
+            }
+        }
+    }
+
+    // TODO: Object --> Bytes
+    // encodeValFor32Bits(Object)
+    // encodeDataList(Object)
+    @Test
+    public void objectTest() {
+        for (int a = 0; a < testNum.length; a++) {
+            try {
+                byte[] temp1 = encodeValFor32Bits(testNum[a][1]);
+            } catch (NullPointerException e) {
+                System.out.println("\nNull Object Test!");
+            }
+        }
+    }
+
+    /** TEST: hex <--> Bytes hexStringToBytes(hex) toHexString(byte) toHexStringWithPrefix(byte) */
+    @Test
+    public void hexTest() {
+        byte[] temp0 = hexStringToBytes(testHex[0]);
+        assertEquals("", toHexString(temp0));
+        assertEquals("0x", toHexStringWithPrefix(temp0));
+
+        for (int a = 1; a < testHex.length; a++) {
+            byte[] temp1 = hexStringToBytes(testHex[a]);
+            assertEquals(testHex[a].toLowerCase(), toHexString(temp1));
+            assertEquals("0x" + testHex[a].toLowerCase(), toHexStringWithPrefix(temp1));
+        }
+    }
+
+    /**
+     * TEST: long <--> Bytes longToBytes(long) longToBytesNoLeadZeroes(long) byteArrayToLong(byte)
+     * longToBytesLE(long)
+     */
+    @Test
+    @Parameters(method = "longValues")
+    public void longTest(long testLong) {
+
+        byte[] temp1 = longToBytes(testLong);
+        byte[] temp2 = longToBytesNoLeadZeroes(testLong);
+        byte[] temp3 = longToBytesLE(testLong);
+
+        toLEByteArray(temp3);
+
+        assertEquals(testLong, byteArrayToLong(temp1));
+        assertEquals(testLong, byteArrayToLong(temp2));
+        assertEquals(testLong, byteArrayToLong(temp3));
+    }
+
+    /**
+     * TEST: short <--> Bytes shortToBytes(short) bigEndianToShort(byte) ~ bigEndianToShort(byte,
+     * offset)
+     */
+    @Test
+    @Parameters(method = "shortValues")
+    public void shortTest(short testShort) {
+        byte[] temp1 = shortToBytes(testShort);
+        assertEquals(testShort, bigEndianToShort(temp1));
+    }
+
+    /**
+     * TEST: int <--> Bytes intToBytes(int) intToBytesLE(int) intToBytesBE(int)
+     * intToBytesNoLeadZeroes(int) byteArrayToInt(byte) ~ intsToBytes(array, BE) ~
+     * intsToBytes(array, byte, BE) ~ bytesToInts(byte, BE) ~ bytesToInts(byte, array, BE)
+     */
+    @Test
+    @Parameters(method = "intValues")
+    public void intTest(int testInt) {
+
+        byte[] temp1 = intToBytes(testInt);
+        byte[] temp2 = intToBytesLE(testInt);
+        byte[] temp3 = intToBytesBE(testInt);
+        byte[] temp4 = intToBytesNoLeadZeroes(testInt);
+
+        toLEByteArray(temp2);
+
+        assertEquals(testInt, byteArrayToInt(temp1));
+        assertEquals(testInt, byteArrayToInt(temp2));
+        assertEquals(testInt, byteArrayToInt(temp3));
+        assertEquals(testInt, byteArrayToInt(temp4));
+    }
+
+    /**
+     * TEST: Byte validation toByte(byte) toLEByteArray(byte) firstNonZeroByte(byte) numBytes(hex)
+     * isNullOrZeroArray(byte) isSingleZero(byte) length(byte) stripLeadingZeroes(byte)
+     * appendByte(byte1, byte2) oneByteToHexString(byte) ~ matchingNibbleLength(byte1, byte2) ~
+     * nibblesToPrettyString(byte) ~ difference(byteSet1, byteSet2)
+     */
+    @Test
+    public void byteTest() {
+
+        // Single 'zero' byte
+        String singleZero = "0";
+        byte[] temp = bigIntegerToBytes(new BigInteger(singleZero));
+        assertEquals(-1, firstNonZeroByte(temp));
+        assertEquals(1, numBytes(singleZero));
+        assertEquals(1, length(temp));
+        assertFalse(isNullOrZeroArray(temp));
+        assertTrue(isSingleZero(temp));
+
+        // Null Variable
+        byte[] temp0 = bigIntegerToBytes(new BigInteger(singleZero));
+        assertEquals(-1, firstNonZeroByte(temp0));
+        assertTrue(isNullOrZeroArray(testByte[0]));
+        assertNull(stripLeadingZeroes(testByte[0]));
+
+        // Empty Array
+        byte[] temp1 = stripLeadingZeroes(testByte[1]);
+        assertEquals(-1, firstNonZeroByte(temp1));
+        assertEquals(-1, firstNonZeroByte(testByte[1]));
+        assertTrue(isNullOrZeroArray(testByte[1]));
+
+        // Leading Non-zero
+        byte[] temp2 = stripLeadingZeroes(testByte[2]);
+        assertEquals(0, firstNonZeroByte(temp2));
+        assertEquals(0, firstNonZeroByte(testByte[2]));
+        assertEquals(0, firstNonZeroByte(testByte[3]));
+        assertEquals(0, firstNonZeroByte(testByte[4]));
+
+        // Only Zeroes
+        assertEquals(-1, firstNonZeroByte(testByte[5]));
+        assertFalse(isNullOrZeroArray(testByte[5]));
+        assertFalse(isSingleZero(testByte[5]));
+
+        // Leading Zeroes
+        byte[] temp3 = stripLeadingZeroes(testByte[6]);
+        assertEquals(0, firstNonZeroByte(temp3));
+        assertEquals(31, firstNonZeroByte(testByte[6]));
+
+        // n Byte = { 2n Hex || (256^n) - 1 }
+        assertEquals(1, numBytes("255"));
+        assertEquals(2, numBytes("65535"));
+        assertEquals(3, numBytes("16777215"));
+        assertEquals(4, numBytes("4294967295"));
+        assertEquals(5, numBytes("1099511627775"));
+
+        // TFAE (+ve);
+        // 1) numBytes(number)
+        // 2) bigInt.length
+        // 3) hex.length()/2
+        for (int a = 1; a < testBigInt.length; a++) {
+            byte[] temp4 = bigIntegerToBytes(testBigInt[a][1]);
+            String temp5 = toHexString(temp4);
+            assertEquals(temp5.length() / 2, temp4.length);
+            assertEquals(temp5.length() / 2, numBytes(testNum[a][1]));
+        }
+
+        // Append
+        for (int a = 0; a < testHex.length; a++) {
+            byte[] temp6 = hexStringToBytes(testHex[a]);
+            byte temp7 = toByte(testByte[2]);
+            byte[] temp8 = appendByte(temp6, temp7);
+            String temp9 = oneByteToHexString(temp7);
+            assertEquals(testHex[2].toLowerCase(), temp9);
+            assertEquals(toHexString(temp6) + temp9, toHexString(temp8));
+        }
+    }
+
+    /**
+     * TEST: Bit manipulation increment(byte) copyToArray(byte) setBit(byte, pos, val) getBit(byte,
+     * pos) and(byte1, byte2) or(byte1, byte2) xor(byte1, byte2) xorAlignRight(byte1, byte2)
+     */
+    @Test
+    public void bitTest() {
+
+        // Increment for all byte size (+ve)
+        int increment = 123;
+        boolean max = false;
+        for (int a = 1; a < testBigInt.length; a++) {
+
+            BigInteger temp1 = testBigInt[a][1];
+            byte[] temp2 = bigIntegerToBytes(temp1);
+            BigInteger capacity = BigInteger.valueOf((long) Math.pow(255, temp2.length));
+
+            for (int i = 0; i < increment; i++) {
+                while (!max) {
+                    max = increment(temp2);
+                }
+                temp1 = bytesToBigInteger(temp2);
+                max = false;
+            }
+
+            BigInteger temp3 = BigInteger.valueOf(increment).mod(capacity);
+            BigInteger temp4 = testBigInt[a][1].add(temp3);
+            assertEquals(temp4, temp1);
+        }
+
+        // Copy array, convert and assert (+ve)
+        for (int a = 1; a < testBigInt.length; a++) {
+            byte[] temp5 = copyToArray(testBigInt[a][1]);
+            BigInteger temp6 = bytesToBigInteger(temp5);
+            assertEquals(testBigInt[a][1], temp6);
+        }
+
+        // Set bit, get bit for every bit
+        int shifts = 8;
+        for (int c = 0; c < shifts; c++) {
+            byte[] temp6 = bigIntegerToBytesSigned(testBigInt[1][1], 1);
+            setBit(temp6, c, 1);
+            assertEquals(1, getBit(temp6, c));
+            assertEquals(BigInteger.valueOf((long) Math.pow(2, c)), bytesToBigInteger(temp6));
+        }
+
+        // AND + OR with zero (+ve)
+        for (int a = 2; a < testBigInt.length; a++) {
+            byte[] temp8 = bigIntegerToBytes(testBigInt[a][1]);
+            byte[] temp9 = bigIntegerToBytes(testBigInt[1][1], temp8.length);
+            byte[] temp10 = or(temp8, temp9);
+            byte[] temp11 = and(temp8, temp9);
+            assertEquals(testBigInt[a][1], bytesToBigInteger(temp10));
+            assertEquals(testBigInt[1][1], bytesToBigInteger(temp11));
+            System.out.println(
+                    testBigInt[a][1]
+                            + " || "
+                            + testBigInt[1][1]
+                            + " --> "
+                            + bytesToBigInteger(temp10));
+            System.out.println(
+                    testBigInt[a][1]
+                            + " && "
+                            + testBigInt[1][1]
+                            + " --> "
+                            + bytesToBigInteger(temp11));
+        }
+
+        // 2's compliment -ve BI --> +ve BI
+        for (int a = 1; a < testBigInt.length; a++) {
+            boolean found = false;
+            int rightMost = 0;
+            byte[] temp7 = bigIntegerToBytes(testBigInt[a][0]);
+            while (!found && rightMost < temp7.length * 8) {
+                if (getBit(temp7, rightMost) == 1) {
+                    found = true;
+                } else {
+                    rightMost++;
+                }
+            }
+            if (found) {
+                for (int b = rightMost + 1; b < temp7.length * 8; b++) {
+                    if (getBit(temp7, b) == 0) {
+                        setBit(temp7, b, 1);
+                    } else if (getBit(temp7, b) == 1) {
+                        setBit(temp7, b, 0);
+                    }
+                }
+            }
+            assertEquals(testBigInt[a][1], bytesToBigInteger(temp7));
+            System.out.println(testBigInt[a][0] + " --> " + bytesToBigInteger(temp7));
+        }
+
+        // 1's compliment | XOR with "FF" * numBytes
+        for (int b = 0; b < 2; b++) {
+            for (int a = 1; a < testBigInt.length; a++) {
+                byte[] temp12 = bigIntegerToBytes(testBigInt[a][b]);
+                StringBuilder allForOne = new StringBuilder();
+                for (int i = 0; i < temp12.length; i++) {
+                    allForOne.append("FF");
+                }
+                byte[] temp13 = hexStringToBytes(allForOne.toString());
+                byte[] temp14 = xor(temp13, temp12);
+                byte[] temp15 = xorAlignRight(temp13, temp12);
+                for (int c = 0; c < temp12.length * 8; c++) {
+                    if (getBit(temp12, c) == 0) {
+                        setBit(temp12, c, 1);
+                    } else if (getBit(temp12, c) == 1) {
+                        setBit(temp12, c, 0);
+                    }
+                }
+                assertEquals(bytesToBigInteger(temp14), bytesToBigInteger(temp12));
+                assertEquals(bytesToBigInteger(temp15), bytesToBigInteger(temp12));
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'aion'
 include 'modAionBase', 'modAion', 'modAionImpl',
+    'modUtil',
     'modCrypto',
     'modLogger',
     'modRlp',


### PR DESCRIPTION
## Description

This change is part of the VM API extraction #734  but can be reviewed separately. The objective is to have the kernel know about the VM, but not vice versa (as the dependencies are set now).

This intermediary step extracts the dependency on `modAionBase` for modules that were only using some utility functionality: crypto, rlp, and p2p.

**The initial classes are still left in the base module because a full refactoring is too complicated to track and review. They have been deprecated to indicate that this refactoring should be completed before the next release.**

The refactoring for the VM related modules will continue separately and will be completed as part of the API extraction.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
