### PR TITLE
Correction to version test

### DIFF
--- a/modP2p/test/org/aion/p2p/VerTest.java
+++ b/modP2p/test/org/aion/p2p/VerTest.java
@@ -43,7 +43,7 @@ public class VerTest {
         /*
          * inactive versions
          */
-        byte b1 = (byte) ThreadLocalRandom.current().nextInt(2, Short.MAX_VALUE);
+        byte b1 = (byte) ThreadLocalRandom.current().nextInt(2, Byte.MAX_VALUE);
         assertEquals(Ver.UNKNOWN, Ver.filter(b1));
     }
 }


### PR DESCRIPTION
## Description

- The unknown version test can fail on certain of the random inputs because it is casting what is effectively a short to a byte, and the short will get truncated on large inputs. Two of these truncated results will be 0 and 1, which are the two numbers this test is expressly trying to avoid, because they are supposed to fail.
- The random range is now bound above by `Byte.MAX_VALUE` so that this truncating does not occur anymore and every possible input will pass.

Fixes Issue # N/A.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- The test suite.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
