### PR TITLE
Quickfix for estimating gas of contract creation txs

### DIFF
--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -57,6 +57,7 @@ import org.aion.evtmgr.impl.es.EventExecuteService;
 import org.aion.evtmgr.impl.evt.EventBlock;
 import org.aion.evtmgr.impl.evt.EventTx;
 import org.aion.mcf.blockchain.TxResponse;
+import org.aion.mcf.vm.Constants;
 import org.aion.zero.impl.AionGenesis;
 import org.aion.zero.impl.BlockContext;
 import org.aion.zero.impl.Version;
@@ -461,6 +462,12 @@ public abstract class ApiAion extends Api {
     protected long estimateNrg(ArgTxCall params) {
         Address fromAddr =
                 (params.getFrom().isEmptyAddress()) ? Address.ZERO_ADDRESS() : params.getFrom();
+
+        long nrg =
+                (params.getTo().isEmptyAddress())
+                        ? Constants.NRG_TX_CREATE_MAX
+                        : Constants.NRG_TRANSACTION_MAX;
+
         AionTransaction tx =
                 new AionTransaction(
                         params.getNonce().toByteArray(),
@@ -468,7 +475,7 @@ public abstract class ApiAion extends Api {
                         params.getTo(),
                         params.getValue().toByteArray(),
                         params.getData(),
-                        params.getNrg(),
+                        nrg,
                         params.getNrgPrice());
 
         AionTxReceipt receipt =


### PR DESCRIPTION
## Notice

**This PR is directly submitted to the master branch so we can rush-release a patch**

## Description

We have a bug in our API's `estimateGas` feature, as described in Issue #758.

This PR includes a quick fix for this, by using the maximum possible gas value when estimating gas for contract creation transactions.

The root cause of the issue also requires some fixes to other functionality, but that will be put into a later PR that goes into the next release.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

All tests pass, the example tx described in issue #758 returns a correct value now.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
