### PR TITLE
Using iterators to return database keys

### DIFF
--- a/modAionBase/src/org/aion/base/db/IKeyValueStore.java
+++ b/modAionBase/src/org/aion/base/db/IKeyValueStore.java
@@ -36,9 +36,9 @@
 package org.aion.base.db;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Functionality for a key-value cache allowing itemized updates.
@@ -63,13 +63,13 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
     boolean isEmpty();
 
     /**
-     * Returns the set of keys for the database.
+     * Returns an {@link Iterator} over the set of keys stored in the database.
      *
-     * @return Set of keys
+     * @return an iterator over the set of stored keys
      * @throws RuntimeException if the data store is closed
-     * @apiNote Returns an empty set if the database keys could not be retrieved.
+     * @apiNote Returns an empty iterator if the database keys could not be retrieved.
      */
-    Set<K> keys();
+    Iterator<K> keys();
 
     /**
      * get retrieves a value from the database, returning an optional, it is fulfilled if a value

--- a/modAionBase/src/org/aion/base/db/IKeyValueStore.java
+++ b/modAionBase/src/org/aion/base/db/IKeyValueStore.java
@@ -63,7 +63,9 @@ public interface IKeyValueStore<K, V> extends AutoCloseable {
     boolean isEmpty();
 
     /**
-     * Returns an {@link Iterator} over the set of keys stored in the database.
+     * Returns an {@link Iterator} over the set of keys stored in the database at the time when the
+     * keys were requested. A snapshot can be used to ensure that the entries do not change while
+     * iterating through the keys.
      *
      * @return an iterator over the set of stored keys
      * @throws RuntimeException if the data store is closed

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -85,10 +86,11 @@ public class AionRepositoryImpl
 
         // repository singleton instance
         private static final AionRepositoryImpl inst =
-                new AionRepositoryImpl(new RepositoryConfig(
-                    config.getDatabasePath(),
-                    ContractDetailsAion.getInstance(),
-                    config.getDb()));
+                new AionRepositoryImpl(
+                        new RepositoryConfig(
+                                config.getDatabasePath(),
+                                ContractDetailsAion.getInstance(),
+                                config.getDb()));
     }
 
     public static AionRepositoryImpl inst() {
@@ -332,8 +334,9 @@ public class AionRepositoryImpl
         List<byte[]> rtn = new ArrayList<>();
         rwLock.readLock().lock();
         try {
-            Set<byte[]> keySet = txPoolDatabase.keys();
-            for (byte[] b : keySet) {
+            Iterator<byte[]> iterator = txPoolDatabase.keys();
+            while (iterator.hasNext()) {
+                byte[] b = iterator.next();
                 if (txPoolDatabase.get(b).isPresent()) {
                     rtn.add(txPoolDatabase.get(b).get());
                 }
@@ -351,8 +354,9 @@ public class AionRepositoryImpl
         List<byte[]> rtn = new ArrayList<>();
         rwLock.readLock().lock();
         try {
-            Set<byte[]> keySet = pendingTxCacheDatabase.keys();
-            for (byte[] b : keySet) {
+            Iterator<byte[]> iterator = pendingTxCacheDatabase.keys();
+            while (iterator.hasNext()) {
+                byte[] b = iterator.next();
                 if (pendingTxCacheDatabase.get(b).isPresent()) {
                     rtn.add(pendingTxCacheDatabase.get(b).get());
                 }

--- a/modAionImpl/src/org/aion/zero/impl/db/PendingBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/PendingBlockStore.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -519,7 +520,7 @@ public class PendingBlockStore implements Flushable, Closeable {
     int getIndexSize() {
         databaseLock.readLock().lock();
         try {
-            return indexSource.keys().size();
+            return countDatabaseKeys(indexSource);
         } finally {
             databaseLock.readLock().unlock();
         }
@@ -533,7 +534,7 @@ public class PendingBlockStore implements Flushable, Closeable {
     int getLevelSize() {
         databaseLock.readLock().lock();
         try {
-            return levelDatabase.keys().size();
+            return countDatabaseKeys(levelDatabase);
         } finally {
             databaseLock.readLock().unlock();
         }
@@ -547,10 +548,20 @@ public class PendingBlockStore implements Flushable, Closeable {
     int getQueueSize() {
         databaseLock.readLock().lock();
         try {
-            return queueDatabase.keys().size();
+            return countDatabaseKeys(queueDatabase);
         } finally {
             databaseLock.readLock().unlock();
         }
+    }
+
+    private static int countDatabaseKeys(IByteArrayKeyValueDatabase db) {
+        int size = 0;
+        Iterator<byte[]> iterator = db.keys();
+        while (iterator.hasNext()) {
+            iterator.next();
+            size++;
+        }
+        return size;
     }
 
     /**

--- a/modAionImpl/test/org/aion/zero/impl/BlockchainDataRecoveryTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/BlockchainDataRecoveryTest.java
@@ -26,6 +26,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
@@ -263,7 +264,10 @@ public class BlockchainDataRecoveryTest {
 
         repo.flush();
         List<byte[]> statesToDelete = new ArrayList<>();
-        statesToDelete.addAll(database.keys());
+        Iterator<byte[]> iterator = database.keys();
+        while (iterator.hasNext()) {
+            statesToDelete.add(iterator.next());
+        }
 
         for (byte[] key : statesToDelete) {
             database.delete(key);

--- a/modDbImpl/src/org/aion/db/generic/CacheIteratorWrapper.java
+++ b/modDbImpl/src/org/aion/db/generic/CacheIteratorWrapper.java
@@ -1,0 +1,71 @@
+package org.aion.db.generic;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.aion.base.util.ByteArrayWrapper;
+
+/**
+ * A wrapper for the iterator needed by {@link DatabaseWithCache} conforming to the {@link
+ * Iterator<byte[]>} interface.
+ *
+ * @implNote Assumes that the given database iterator does not return duplicate values.
+ * @author Alexandra Roatis
+ */
+public class CacheIteratorWrapper implements Iterator<byte[]> {
+    Iterator<byte[]> itr;
+    byte[] next;
+    List<ByteArrayWrapper> additions;
+    List<ByteArrayWrapper> removals;
+
+    public CacheIteratorWrapper(Iterator<byte[]> itr, Map<ByteArrayWrapper, byte[]> dirtyEntries) {
+        this.itr = itr;
+        additions = new ArrayList<>();
+        removals = new ArrayList<>();
+
+        for (Map.Entry<ByteArrayWrapper, byte[]> entry : dirtyEntries.entrySet()) {
+            if (entry.getValue() == null) {
+                removals.add(entry.getKey());
+            } else {
+                additions.add(entry.getKey());
+            }
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        boolean seek = true;
+        ByteArrayWrapper wrapper;
+        // check in the database iterator
+        while (seek && itr.hasNext()) {
+            next = itr.next();
+            wrapper = ByteArrayWrapper.wrap(next);
+            if (removals.contains(wrapper)) {
+                // key deleted, move to next in iterator
+                removals.remove(wrapper);
+            } else if (additions.contains(wrapper)) {
+                // found an entry that was updated
+                seek = false;
+                additions.remove(wrapper);
+            } else {
+                // found an entry that was not changed
+                seek = false;
+            }
+        }
+
+        // exhausted the initial iterator, trying the dirty entries
+        // check in the cached entries
+        if (seek && !additions.isEmpty()) {
+            next = additions.remove(0).getData();
+            seek = false;
+        }
+
+        return !seek;
+    }
+
+    @Override
+    public byte[] next() {
+        return next;
+    }
+}

--- a/modDbImpl/src/org/aion/db/generic/CacheIteratorWrapper.java
+++ b/modDbImpl/src/org/aion/db/generic/CacheIteratorWrapper.java
@@ -7,20 +7,25 @@ import java.util.Map;
 import org.aion.base.util.ByteArrayWrapper;
 
 /**
- * A wrapper for the iterator needed by {@link DatabaseWithCache} conforming to the {@link
- * Iterator<byte[]>} interface.
+ * A wrapper for the iterator needed by {@link DatabaseWithCache} conforming to the {@link Iterator}
+ * interface.
  *
  * @implNote Assumes that the given database iterator does not return duplicate values.
  * @author Alexandra Roatis
  */
 public class CacheIteratorWrapper implements Iterator<byte[]> {
-    Iterator<byte[]> itr;
-    byte[] next;
-    List<ByteArrayWrapper> additions;
-    List<ByteArrayWrapper> removals;
+    private final Iterator<byte[]> iterator;
+    private byte[] next;
+    private final List<ByteArrayWrapper> additions;
+    private final List<ByteArrayWrapper> removals;
 
-    public CacheIteratorWrapper(Iterator<byte[]> itr, Map<ByteArrayWrapper, byte[]> dirtyEntries) {
-        this.itr = itr;
+    /**
+     * @implNote Building two wrappers for the same {@link Iterator} will lead to inconsistent
+     *     behavior.
+     */
+    public CacheIteratorWrapper(
+            final Iterator<byte[]> iterator, Map<ByteArrayWrapper, byte[]> dirtyEntries) {
+        this.iterator = iterator;
         additions = new ArrayList<>();
         removals = new ArrayList<>();
 
@@ -38,8 +43,8 @@ public class CacheIteratorWrapper implements Iterator<byte[]> {
         boolean seek = true;
         ByteArrayWrapper wrapper;
         // check in the database iterator
-        while (seek && itr.hasNext()) {
-            next = itr.next();
+        while (seek && iterator.hasNext()) {
+            next = iterator.next();
             wrapper = ByteArrayWrapper.wrap(next);
             if (removals.contains(wrapper)) {
                 // key deleted, move to next in iterator

--- a/modDbImpl/src/org/aion/db/generic/DatabaseWithCache.java
+++ b/modDbImpl/src/org/aion/db/generic/DatabaseWithCache.java
@@ -41,10 +41,9 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.primitives.Longs;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.PersistenceMethod;
 import org.aion.base.util.ByteArrayWrapper;
@@ -379,26 +378,9 @@ public class DatabaseWithCache implements IByteArrayKeyValueDatabase {
     }
 
     @Override
-    public Set<byte[]> keys() {
-
-        Set<byte[]> keys = new HashSet<>();
-
+    public Iterator<byte[]> keys() {
         check();
-
-        // add all database keys
-        keys.addAll(database.keys());
-
-        // add updated cached keys
-        dirtyEntries.forEach(
-                (k, v) -> {
-                    if (v == null) {
-                        keys.remove(k.getData());
-                    } else {
-                        keys.add(k.getData());
-                    }
-                });
-
-        return keys;
+        return new CacheIteratorWrapper(database.keys(), dirtyEntries);
     }
 
     /**

--- a/modDbImpl/src/org/aion/db/generic/LockedDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/LockedDatabase.java
@@ -24,9 +24,9 @@
 package org.aion.db.generic;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
@@ -221,7 +221,7 @@ public class LockedDatabase implements IByteArrayKeyValueDatabase {
     }
 
     @Override
-    public Set<byte[]> keys() {
+    public Iterator<byte[]> keys() {
         // acquire read lock
         lock.readLock().lock();
 

--- a/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
+++ b/modDbImpl/src/org/aion/db/generic/TimedDatabase.java
@@ -24,9 +24,9 @@
 package org.aion.db.generic;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.PersistenceMethod;
 import org.aion.base.util.Hex;
@@ -175,9 +175,9 @@ public class TimedDatabase implements IByteArrayKeyValueDatabase {
     }
 
     @Override
-    public Set<byte[]> keys() {
+    public Iterator<byte[]> keys() {
         long t1 = System.nanoTime();
-        Set<byte[]> result = database.keys();
+        Iterator<byte[]> result = database.keys();
         long t2 = System.nanoTime();
 
         LOG.debug(database.toString() + " keys() in " + (t2 - t1) + " ns.");

--- a/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
+++ b/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
@@ -36,10 +36,9 @@ package org.aion.db.impl.h2;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.db.impl.AbstractDB;
 import org.h2.mvstore.FileStore;
@@ -238,15 +237,10 @@ public class H2MVMap extends AbstractDB {
     }
 
     @Override
-    public Set<byte[]> keys() {
-
-        Set<byte[]> keys = new HashSet<>();
-
+    public Iterator<byte[]> keys() {
         check();
 
-        keys.addAll(map.keySet());
-
-        return keys;
+        return map.keySet().iterator();
     }
 
     @Override

--- a/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
+++ b/modDbImpl/src/org/aion/db/impl/h2/H2MVMap.java
@@ -240,7 +240,15 @@ public class H2MVMap extends AbstractDB {
     public Iterator<byte[]> keys() {
         check();
 
-        return map.keySet().iterator();
+        // get current version
+        long version = store.getCurrentVersion();
+        // making the version read-only
+        store.commit();
+
+        // get snapshot of version
+        MVMap<byte[], byte[]> snapshot = map.openVersion(version);
+
+        return snapshot.keySet().iterator();
     }
 
     @Override

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -38,8 +38,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.db.impl.AbstractDB;
 import org.fusesource.leveldbjni.JniDBFactory;
@@ -178,7 +178,11 @@ public class LevelDB extends AbstractDB {
             try {
                 db = JniDBFactory.factory.open(f, options);
             } catch (Exception e2) {
-                LOG.error("Failed second attempt to open the database " + this.toString() + " due to: ", e2);
+                LOG.error(
+                        "Failed second attempt to open the database "
+                                + this.toString()
+                                + " due to: ",
+                        e2);
                 // close the connection and cleanup if needed
                 close();
             }
@@ -285,22 +289,61 @@ public class LevelDB extends AbstractDB {
     }
 
     @Override
-    public Set<byte[]> keys() {
-        Set<byte[]> set = new HashSet<>();
-
+    public Iterator<byte[]> keys() {
         check();
 
-        try (DBIterator itr = db.iterator()) {
-            // extract keys
-            for (itr.seekToFirst(); itr.hasNext(); itr.next()) {
-                set.add(itr.peekNext().getKey());
-            }
+        try {
+            return new LevelDBIteratorWrapper(db.iterator());
         } catch (Exception e) {
             LOG.error("Unable to extract keys from database " + this.toString() + ".", e);
         }
 
         // empty when retrieval failed
-        return set;
+        return new HashSet<byte[]>().iterator();
+    }
+
+    /**
+     * A wrapper for the {@link DBIterator} conforming to the {@link Iterator<byte[]>} interface.
+     *
+     * @author Alexandra Roatis
+     */
+    public static class LevelDBIteratorWrapper implements Iterator<byte[]> {
+        private final DBIterator iterator;
+        private boolean closed;
+
+        public LevelDBIteratorWrapper(DBIterator iterator) {
+            this.iterator = iterator;
+            iterator.seekToFirst();
+            closed = false;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (!closed) {
+                boolean hasNext = iterator.hasNext();
+
+                // close iterator after last entry
+                if (!hasNext) {
+                    try {
+                        iterator.close();
+                    } catch (IOException e) {
+                        LOG.error("Unable to close iterator object.", e);
+                    }
+                    closed = true;
+                }
+
+                return hasNext;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public byte[] next() {
+            byte[] key = iterator.peekNext().getKey();
+            iterator.next();
+            return key;
+        }
     }
 
     @Override

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -37,7 +37,7 @@ package org.aion.db.impl.leveldb;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import org.aion.base.util.ByteArrayWrapper;
@@ -302,20 +302,24 @@ public class LevelDB extends AbstractDB {
         }
 
         // empty when retrieval failed
-        return new HashSet<byte[]>().iterator();
+        return Collections.emptyIterator();
     }
 
     /**
-     * A wrapper for the {@link DBIterator} conforming to the {@link Iterator<byte[]>} interface.
+     * A wrapper for the {@link DBIterator} conforming to the {@link Iterator} interface.
      *
      * @author Alexandra Roatis
      */
-    public static class LevelDBIteratorWrapper implements Iterator<byte[]> {
+    private static class LevelDBIteratorWrapper implements Iterator<byte[]> {
         private final DBIterator iterator;
         private final ReadOptions readOptions;
         private boolean closed;
 
-        public LevelDBIteratorWrapper(ReadOptions readOptions, DBIterator iterator) {
+        /**
+         * @implNote Building two wrappers for the same {@link DBIterator} will lead to inconsistent
+         *     behavior.
+         */
+        LevelDBIteratorWrapper(final ReadOptions readOptions, final DBIterator iterator) {
             this.readOptions = readOptions;
             this.iterator = iterator;
             iterator.seekToFirst();
@@ -414,7 +418,7 @@ public class LevelDB extends AbstractDB {
         }
     }
 
-    WriteBatch batch = null;
+    private WriteBatch batch = null;
 
     @Override
     public void putToBatch(byte[] key, byte[] value) {

--- a/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
+++ b/modDbImpl/src/org/aion/db/impl/leveldb/LevelDB.java
@@ -48,6 +48,7 @@ import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.DBIterator;
 import org.iq80.leveldb.Options;
+import org.iq80.leveldb.ReadOptions;
 import org.iq80.leveldb.WriteBatch;
 
 /**
@@ -293,7 +294,9 @@ public class LevelDB extends AbstractDB {
         check();
 
         try {
-            return new LevelDBIteratorWrapper(db.iterator());
+            ReadOptions readOptions = new ReadOptions();
+            readOptions.snapshot(db.getSnapshot());
+            return new LevelDBIteratorWrapper(readOptions, db.iterator(readOptions));
         } catch (Exception e) {
             LOG.error("Unable to extract keys from database " + this.toString() + ".", e);
         }
@@ -309,9 +312,11 @@ public class LevelDB extends AbstractDB {
      */
     public static class LevelDBIteratorWrapper implements Iterator<byte[]> {
         private final DBIterator iterator;
+        private final ReadOptions readOptions;
         private boolean closed;
 
-        public LevelDBIteratorWrapper(DBIterator iterator) {
+        public LevelDBIteratorWrapper(ReadOptions readOptions, DBIterator iterator) {
+            this.readOptions = readOptions;
             this.iterator = iterator;
             iterator.seekToFirst();
             closed = false;
@@ -326,6 +331,7 @@ public class LevelDB extends AbstractDB {
                 if (!hasNext) {
                     try {
                         iterator.close();
+                        readOptions.snapshot().close();
                     } catch (IOException e) {
                         LOG.error("Unable to close iterator object.", e);
                     }

--- a/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
+++ b/modDbImpl/src/org/aion/db/impl/mockdb/MockDB.java
@@ -26,6 +26,7 @@ package org.aion.db.impl.mockdb;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import org.aion.base.db.PersistenceMethod;
@@ -107,7 +108,7 @@ public class MockDB extends AbstractDB {
     }
 
     @Override
-    public Set<byte[]> keys() {
+    public Iterator<byte[]> keys() {
         Set<byte[]> set = new HashSet<>();
 
         check();
@@ -115,7 +116,7 @@ public class MockDB extends AbstractDB {
         kv.keySet().forEach(k -> set.add(k.getData()));
 
         // empty when retrieval failed
-        return set;
+        return set.iterator();
     }
 
     @Override

--- a/modDbImpl/src/org/aion/db/impl/rocksdb/RocksDBWrapper.java
+++ b/modDbImpl/src/org/aion/db/impl/rocksdb/RocksDBWrapper.java
@@ -25,7 +25,7 @@ package org.aion.db.impl.rocksdb;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import org.aion.base.util.ByteArrayWrapper;
@@ -233,20 +233,24 @@ public class RocksDBWrapper extends AbstractDB {
         }
 
         // empty when retrieval failed
-        return new HashSet<byte[]>().iterator();
+        return Collections.emptyIterator();
     }
 
     /**
-     * A wrapper for the {@link RocksIterator} conforming to the {@link Iterator<byte[]>} interface.
+     * A wrapper for the {@link RocksIterator} conforming to the {@link Iterator} interface.
      *
      * @author Alexandra Roatis
      */
-    public static class RocksDBIteratorWrapper implements Iterator<byte[]> {
+    private static class RocksDBIteratorWrapper implements Iterator<byte[]> {
         private final RocksIterator iterator;
         private final ReadOptions readOptions;
         private boolean closed;
 
-        public RocksDBIteratorWrapper(ReadOptions readOptions, RocksIterator iterator) {
+        /**
+         * @implNote Building two wrappers for the same {@link RocksIterator} will lead to
+         *     inconsistent behavior.
+         */
+        RocksDBIteratorWrapper(final ReadOptions readOptions, final RocksIterator iterator) {
             this.readOptions = readOptions;
             this.iterator = iterator;
             iterator.seekToFirst();
@@ -321,7 +325,7 @@ public class RocksDBWrapper extends AbstractDB {
         }
     }
 
-    WriteBatch batch = null;
+    private WriteBatch batch = null;
 
     @Override
     public void putToBatch(byte[] key, byte[] value) {

--- a/modDbImpl/test/org/aion/db/impl/ConcurrencyTest.java
+++ b/modDbImpl/test/org/aion/db/impl/ConcurrencyTest.java
@@ -31,10 +31,10 @@ import static org.aion.db.impl.DatabaseTestUtils.assertConcurrent;
 import com.google.common.truth.Truth;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
@@ -90,6 +90,15 @@ public class ConcurrencyTest {
         return DatabaseTestUtils.unlockedDatabaseInstanceDefinitions();
     }
 
+    private static int count(Iterator<byte[]> keys) {
+        int size = 0;
+        while (keys.hasNext()) {
+            size++;
+            keys.next();
+        }
+        return size;
+    }
+
     private void addThread4IsEmpty(List<Runnable> threads, IByteArrayKeyValueDatabase db) {
         threads.add(
                 () -> {
@@ -106,10 +115,10 @@ public class ConcurrencyTest {
     private void addThread4Keys(List<Runnable> threads, IByteArrayKeyValueDatabase db) {
         threads.add(
                 () -> {
-                    Set<byte[]> keys = db.keys();
+                    Iterator<byte[]> keys = db.keys();
                     if (DISPLAY_MESSAGES) {
                         System.out.println(
-                                Thread.currentThread().getName() + ": #keys = " + keys.size());
+                                Thread.currentThread().getName() + ": #keys = " + count(keys));
                     }
                 });
     }
@@ -304,7 +313,7 @@ public class ConcurrencyTest {
         assertConcurrent("Testing put(...) ", threads, TIME_OUT);
 
         // check that all values were added
-        assertThat(db.keys().size()).isEqualTo(CONCURRENT_THREADS);
+        assertThat(count(db.keys())).isEqualTo(CONCURRENT_THREADS);
 
         // ensuring close
         db.close();
@@ -330,7 +339,7 @@ public class ConcurrencyTest {
         assertConcurrent("Testing putBatch(...) ", threads, TIME_OUT);
 
         // check that all values were added
-        assertThat(db.keys().size()).isEqualTo(3 * CONCURRENT_THREADS);
+        assertThat(count(db.keys())).isEqualTo(3 * CONCURRENT_THREADS);
 
         // ensuring close
         db.close();

--- a/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
+++ b/modDbImpl/test/org/aion/db/impl/DriverBaseTest.java
@@ -43,8 +43,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.PersistenceMethod;
 import org.aion.db.generic.DatabaseWithCache;
@@ -468,6 +468,15 @@ public class DriverBaseTest {
         assertThat(db.getName().get()).isEqualTo(dbName);
     }
 
+    private static int count(Iterator<byte[]> keys) {
+        int size = 0;
+        while (keys.hasNext()) {
+            size++;
+            keys.next();
+        }
+        return size;
+    }
+
     @Test
     public void testConcurrentAccess() {
         // TODO: import test from legacy test case
@@ -512,7 +521,7 @@ public class DriverBaseTest {
             // ensure persistence
             assertThat(db.get(k1).get()).isEqualTo(v1);
             assertThat(db.isEmpty()).isFalse();
-            assertThat(db.keys().size()).isEqualTo(1);
+            assertThat(count(db.keys())).isEqualTo(1);
             assertThat(db.isLocked()).isFalse();
 
             // deleting data
@@ -534,7 +543,7 @@ public class DriverBaseTest {
             // ensure absence
             assertThat(db.get(k1).isPresent()).isFalse();
             assertThat(db.isEmpty()).isTrue();
-            assertThat(db.keys().size()).isEqualTo(0);
+            assertThat(db.keys().hasNext()).isFalse();
             assertThat(db.isLocked()).isFalse();
         }
     }
@@ -572,7 +581,7 @@ public class DriverBaseTest {
             assertThat(db.get(k2).get()).isEqualTo(v2);
             assertThat(db.get(k3).get()).isEqualTo(v3);
             assertThat(db.isEmpty()).isFalse();
-            assertThat(db.keys().size()).isEqualTo(3);
+            assertThat(count(db.keys())).isEqualTo(3);
             assertThat(db.isLocked()).isFalse();
 
             // updating data
@@ -601,7 +610,7 @@ public class DriverBaseTest {
             assertThat(db.get(k2).get()).isEqualTo(v3);
             assertThat(db.get(k3).isPresent()).isFalse();
             assertThat(db.isEmpty()).isFalse();
-            assertThat(db.keys().size()).isEqualTo(2);
+            assertThat(count(db.keys())).isEqualTo(2);
             assertThat(db.isLocked()).isFalse();
 
             // deleting data
@@ -626,7 +635,7 @@ public class DriverBaseTest {
             assertThat(db.get(k2).isPresent()).isFalse();
             assertThat(db.get(k3).isPresent()).isFalse();
             assertThat(db.isEmpty()).isTrue();
-            assertThat(db.keys().size()).isEqualTo(0);
+            assertThat(db.keys().hasNext()).isFalse();
             assertThat(db.isLocked()).isFalse();
         }
     }
@@ -801,11 +810,11 @@ public class DriverBaseTest {
     @Test
     public void testKeys() {
         // keys shouldn't be null even when empty
-        Set<byte[]> keys = db.keys();
+        Iterator<byte[]> keys = db.keys();
         assertThat(db.isLocked()).isFalse();
         assertThat(db.isEmpty()).isTrue();
         assertThat(keys).isNotNull();
-        assertThat(keys.size()).isEqualTo(0);
+        assertThat(keys.hasNext()).isFalse();
 
         // checking after put
         db.put(k1, v1);
@@ -815,16 +824,19 @@ public class DriverBaseTest {
 
         keys = db.keys();
         assertThat(db.isLocked()).isFalse();
-        assertThat(keys.size()).isEqualTo(2);
 
         // because of byte[], set.contains() does not work as expected
-        int count = 0;
-        for (byte[] k : keys) {
+        int countIn = 0, countOut = 0;
+        while (keys.hasNext()) {
+            byte[] k = keys.next();
             if (Arrays.equals(k1, k) || Arrays.equals(k2, k)) {
-                count++;
+                countIn++;
+            } else {
+                countOut++;
             }
         }
-        assertThat(count).isEqualTo(2);
+        assertThat(countIn).isEqualTo(2);
+        assertThat(countOut).isEqualTo(0);
 
         // checking after delete
         db.delete(k2);
@@ -832,15 +844,19 @@ public class DriverBaseTest {
 
         keys = db.keys();
         assertThat(db.isLocked()).isFalse();
-        assertThat(keys.size()).isEqualTo(1);
 
-        count = 0;
-        for (byte[] k : keys) {
+        countIn = 0;
+        countOut = 0;
+        while (keys.hasNext()) {
+            byte[] k = keys.next();
             if (Arrays.equals(k1, k)) {
-                count++;
+                countIn++;
+            } else {
+                countOut++;
             }
         }
-        assertThat(count).isEqualTo(1);
+        assertThat(countIn).isEqualTo(1);
+        assertThat(countOut).isEqualTo(0);
 
         // checking after putBatch
         Map<byte[], byte[]> ops = new HashMap<>();
@@ -851,22 +867,26 @@ public class DriverBaseTest {
 
         keys = db.keys();
         assertThat(db.isLocked()).isFalse();
-        assertThat(keys.size()).isEqualTo(2);
 
-        count = 0;
-        for (byte[] k : keys) {
+        countIn = 0;
+        countOut = 0;
+        while (keys.hasNext()) {
+            byte[] k = keys.next();
             if (Arrays.equals(k2, k) || Arrays.equals(k3, k)) {
-                count++;
+                countIn++;
+            } else {
+                countOut++;
             }
         }
-        assertThat(count).isEqualTo(2);
+        assertThat(countIn).isEqualTo(2);
+        assertThat(countOut).isEqualTo(0);
 
         // checking after deleteBatch
         db.deleteBatch(ops.keySet());
 
         keys = db.keys();
         assertThat(db.isLocked()).isFalse();
-        assertThat(keys.size()).isEqualTo(0);
+        assertThat(keys.hasNext()).isFalse();
     }
 
     @Test
@@ -931,7 +951,7 @@ public class DriverBaseTest {
             // ensure lack of persistence
             assertThat(db.get(k1).isPresent()).isFalse();
             assertThat(db.isEmpty()).isTrue();
-            assertThat(db.keys().size()).isEqualTo(0);
+            assertThat(db.keys().hasNext()).isFalse();
             assertThat(db.isLocked()).isFalse();
 
             // deleting data
@@ -952,7 +972,7 @@ public class DriverBaseTest {
             // ensure lack of persistence of delete
             assertThat(db.get(k1).get()).isEqualTo(v1);
             assertThat(db.isEmpty()).isFalse();
-            assertThat(db.keys().size()).isEqualTo(1);
+            assertThat(count(db.keys())).isEqualTo(1);
             assertThat(db.isLocked()).isFalse();
 
             // batch update
@@ -983,7 +1003,7 @@ public class DriverBaseTest {
             assertThat(db.get(k2).get()).isEqualTo(v2);
             assertThat(db.get(k3).get()).isEqualTo(v3);
             assertThat(db.isEmpty()).isFalse();
-            assertThat(db.keys().size()).isEqualTo(2);
+            assertThat(count(db.keys())).isEqualTo(2);
             assertThat(db.isLocked()).isFalse();
 
             // batch delete
@@ -1002,7 +1022,7 @@ public class DriverBaseTest {
             assertThat(db.get(k2).get()).isEqualTo(v2);
             assertThat(db.get(k3).get()).isEqualTo(v3);
             assertThat(db.isEmpty()).isFalse();
-            assertThat(db.keys().size()).isEqualTo(2);
+            assertThat(count(db.keys())).isEqualTo(2);
             assertThat(db.isLocked()).isFalse();
         }
     }

--- a/modMcf/src/org/aion/mcf/db/DetailsDataStore.java
+++ b/modMcf/src/org/aion/mcf/db/DetailsDataStore.java
@@ -196,14 +196,18 @@ public class DetailsDataStore<
 
     /**
      * A wrapper for the iterator needed by {@link DetailsDataStore} conforming to the {@link
-     * Iterator<byte[]>} interface.
+     * Iterator} interface.
      *
      * @author Alexandra Roatis
      */
-    public class DetailsIteratorWrapper implements Iterator<ByteArrayWrapper> {
-        Iterator<byte[]> sourceIterator;
+    private class DetailsIteratorWrapper implements Iterator<ByteArrayWrapper> {
+        private Iterator<byte[]> sourceIterator;
 
-        public DetailsIteratorWrapper(Iterator<byte[]> sourceIterator) {
+        /**
+         * @implNote Building two wrappers for the same {@link Iterator} will lead to inconsistent
+         *     behavior.
+         */
+        DetailsIteratorWrapper(final Iterator<byte[]> sourceIterator) {
             this.sourceIterator = sourceIterator;
         }
 

--- a/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/ArchivedDataSource.java
@@ -24,9 +24,9 @@
 package org.aion.mcf.ds;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueDatabase;
 import org.aion.base.db.IByteArrayKeyValueStore;
 
@@ -50,7 +50,7 @@ public class ArchivedDataSource implements IByteArrayKeyValueStore {
     }
 
     @Override
-    public Set<byte[]> keys() {
+    public Iterator<byte[]> keys() {
         return data.keys();
     }
 

--- a/modMcf/src/org/aion/mcf/ds/XorDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/XorDataSource.java
@@ -36,10 +36,9 @@ package org.aion.mcf.ds;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.base.util.ByteUtil;
@@ -73,13 +72,32 @@ public class XorDataSource implements IByteArrayKeyValueStore {
     }
 
     @Override
-    public Set<byte[]> keys() {
-        Set<byte[]> keys = source.keys();
-        Set<byte[]> ret = new HashSet<>(keys.size());
-        for (byte[] key : keys) {
-            ret.add(convertKey(key));
+    public Iterator<byte[]> keys() {
+        return new XorDSIteratorWrapper(source.keys());
+    }
+
+    /**
+     * A wrapper for the iterator needed by {@link XorDataSource} conforming to the {@link
+     * Iterator<byte[]>} interface.
+     *
+     * @author Alexandra Roatis
+     */
+    public class XorDSIteratorWrapper implements Iterator<byte[]> {
+        Iterator<byte[]> sourceIterator;
+
+        public XorDSIteratorWrapper(Iterator<byte[]> sourceIterator) {
+            this.sourceIterator = sourceIterator;
         }
-        return ret;
+
+        @Override
+        public boolean hasNext() {
+            return sourceIterator.hasNext();
+        }
+
+        @Override
+        public byte[] next() {
+            return convertKey(sourceIterator.next());
+        }
     }
 
     @Override

--- a/modMcf/src/org/aion/mcf/ds/XorDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/XorDataSource.java
@@ -44,8 +44,8 @@ import org.aion.base.util.ByteArrayWrapper;
 import org.aion.base.util.ByteUtil;
 
 public class XorDataSource implements IByteArrayKeyValueStore {
-    IByteArrayKeyValueStore source;
-    byte[] subKey;
+    private final IByteArrayKeyValueStore source;
+    private final byte[] subKey;
 
     public XorDataSource(IByteArrayKeyValueStore source, byte[] subKey) {
         this.source = source;
@@ -77,15 +77,19 @@ public class XorDataSource implements IByteArrayKeyValueStore {
     }
 
     /**
-     * A wrapper for the iterator needed by {@link XorDataSource} conforming to the {@link
-     * Iterator<byte[]>} interface.
+     * A wrapper for the iterator needed by {@link XorDataSource} conforming to the {@link Iterator}
+     * interface.
      *
      * @author Alexandra Roatis
      */
-    public class XorDSIteratorWrapper implements Iterator<byte[]> {
-        Iterator<byte[]> sourceIterator;
+    private class XorDSIteratorWrapper implements Iterator<byte[]> {
+        final Iterator<byte[]> sourceIterator;
 
-        public XorDSIteratorWrapper(Iterator<byte[]> sourceIterator) {
+        /**
+         * @implNote Building two wrappers for the same {@link Iterator} will lead to inconsistent
+         *     behavior.
+         */
+        XorDSIteratorWrapper(final Iterator<byte[]> sourceIterator) {
             this.sourceIterator = sourceIterator;
         }
 

--- a/modMcf/src/org/aion/mcf/trie/Cache.java
+++ b/modMcf/src/org/aion/mcf/trie/Cache.java
@@ -229,7 +229,9 @@ public class Cache {
                 }
             }
         } else {
-            for (byte[] key : this.dataSource.keys()) {
+            Iterator<byte[]> iterator = dataSource.keys();
+            while (iterator.hasNext()) {
+                byte[] key = iterator.next();
                 rows.put(key, this.dataSource.get(key).get());
             }
 

--- a/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
+++ b/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -348,7 +349,7 @@ public class JournalPruneDataSource implements IByteArrayKeyValueStore {
         }
     }
 
-    public Set<byte[]> keys() {
+    public Iterator<byte[]> keys() {
         lock.readLock().lock();
         try {
             return src.keys();

--- a/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
+++ b/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
@@ -29,10 +29,10 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -49,7 +49,7 @@ import org.junit.Test;
 public class JournalPruneDataSourceTest {
 
     private static final String dbName = "TestDB";
-    private static IByteArrayKeyValueDatabase source_db = DatabaseFactory.connect(dbName);
+    private static final IByteArrayKeyValueDatabase source_db = DatabaseFactory.connect(dbName);
     private static JournalPruneDataSource db;
 
     private static final byte[] k1 = "key1".getBytes();
@@ -240,10 +240,10 @@ public class JournalPruneDataSourceTest {
         db.setPruneEnabled(false);
 
         // keys shouldn't be null even when empty
-        Set<byte[]> keys = db.keys();
+        Iterator<byte[]> keys = db.keys();
         assertThat(db.isEmpty()).isTrue();
         assertThat(keys).isNotNull();
-        assertThat(keys.size()).isEqualTo(0);
+        assertThat(count(keys)).isEqualTo(0);
 
         // checking after put
         db.put(k1, v1);
@@ -251,15 +251,13 @@ public class JournalPruneDataSourceTest {
         assertThat(db.get(k1).get()).isEqualTo(v1);
         assertThat(db.get(k2).get()).isEqualTo(v2);
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(2);
+        assertThat(count(db.keys())).isEqualTo(2);
 
         // checking after delete
         db.delete(k2);
         assertThat(db.get(k2).isPresent()).isTrue();
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(2);
+        assertThat(count(db.keys())).isEqualTo(2);
 
         // checking after putBatch
         Map<byte[], byte[]> ops = new HashMap<>();
@@ -268,18 +266,29 @@ public class JournalPruneDataSourceTest {
         ops.put(k3, v3);
         db.putBatch(ops);
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(3);
+        List<byte[]> del = new ArrayList<>();
+        del.add(k1);
+        db.deleteBatch(del);
+
+        assertThat(count(db.keys())).isEqualTo(3);
 
         // checking after deleteBatch
         db.deleteBatch(ops.keySet());
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(3);
+        assertThat(count(db.keys())).isEqualTo(3);
 
         // ensure no cached values
         assertThat(db.getInsertedKeysCount()).isEqualTo(0);
         assertThat(db.getDeletedKeysCount()).isEqualTo(0);
+    }
+
+    private static int count(Iterator<byte[]> keys) {
+        int size = 0;
+        while (keys.hasNext()) {
+            size++;
+            keys.next();
+        }
+        return size;
     }
 
     @Test
@@ -512,10 +521,10 @@ public class JournalPruneDataSourceTest {
         db.setPruneEnabled(true);
 
         // keys shouldn't be null even when empty
-        Set<byte[]> keys = db.keys();
+        Iterator<byte[]> keys = db.keys();
         assertThat(db.isEmpty()).isTrue();
         assertThat(keys).isNotNull();
-        assertThat(keys.size()).isEqualTo(0);
+        assertThat(count(keys)).isEqualTo(0);
 
         // checking after put
         db.put(k1, v1);
@@ -523,15 +532,13 @@ public class JournalPruneDataSourceTest {
         assertThat(db.get(k1).get()).isEqualTo(v1);
         assertThat(db.get(k2).get()).isEqualTo(v2);
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(2);
+        assertThat(count(db.keys())).isEqualTo(2);
 
         // checking after delete
         db.delete(k2);
         assertThat(db.get(k2).isPresent()).isTrue();
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(2);
+        assertThat(count(db.keys())).isEqualTo(2);
 
         // checking after putBatch
         Map<byte[], byte[]> ops = new HashMap<>();
@@ -540,14 +547,16 @@ public class JournalPruneDataSourceTest {
         ops.put(k3, v3);
         db.putBatch(ops);
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(3);
+        List<byte[]> del = new ArrayList<>();
+        del.add(k1);
+        db.deleteBatch(del);
+
+        assertThat(count(db.keys())).isEqualTo(3);
 
         // checking after deleteBatch
         db.deleteBatch(ops.keySet());
 
-        keys = db.keys();
-        assertThat(keys.size()).isEqualTo(3);
+        assertThat(count(db.keys())).isEqualTo(3);
 
         // ensure no cached values
         assertThat(db.getInsertedKeysCount()).isEqualTo(3);
@@ -776,7 +785,7 @@ public class JournalPruneDataSourceTest {
         db.deleteBatch(list);
     }
 
-    public static byte[] randomBytes(int length) {
+    private static byte[] randomBytes(int length) {
         byte[] result = new byte[length];
         new Random().nextBytes(result);
         return result;
@@ -804,10 +813,10 @@ public class JournalPruneDataSourceTest {
     private void addThread_Keys(List<Runnable> threads, JournalPruneDataSource db) {
         threads.add(
                 () -> {
-                    Set<byte[]> keys = db.keys();
+                    Iterator<byte[]> keys = db.keys();
                     if (DISPLAY_MESSAGES) {
                         System.out.println(
-                                Thread.currentThread().getName() + ": #keys = " + keys.size());
+                                Thread.currentThread().getName() + ": #keys = " + count(keys));
                     }
                 });
     }
@@ -1000,7 +1009,7 @@ public class JournalPruneDataSourceTest {
         assertConcurrent("Testing put(...) ", threads, TIME_OUT);
 
         // check that all values were added
-        assertThat(db.keys().size()).isEqualTo(CONCURRENT_THREADS);
+        assertThat(count(db.keys())).isEqualTo(CONCURRENT_THREADS);
 
         // ensuring close
         db.close();
@@ -1023,7 +1032,7 @@ public class JournalPruneDataSourceTest {
         assertConcurrent("Testing putBatch(...) ", threads, TIME_OUT);
 
         // check that all values were added
-        assertThat(db.keys().size()).isEqualTo(3 * CONCURRENT_THREADS);
+        assertThat(count(db.keys())).isEqualTo(3 * CONCURRENT_THREADS);
 
         // ensuring close
         db.close();
@@ -1082,7 +1091,7 @@ public class JournalPruneDataSourceTest {
      * href="https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency">JUnit
      * Wiki on multithreaded code and concurrency</a>
      */
-    public static void assertConcurrent(
+    private static void assertConcurrent(
             final String message,
             final List<? extends Runnable> runnables,
             final int maxTimeoutSeconds)
@@ -1397,7 +1406,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b0, 0);
         assertThat(db.getBlockUpdates().size()).isEqualTo(1);
 
-        assertThat(source_db.keys().size()).isEqualTo(3);
+        assertThat(count(source_db.keys())).isEqualTo(3);
         assertThat(source_db.get(k1).get()).isEqualTo(v1);
         assertThat(source_db.get(k2).get()).isEqualTo(v2);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1409,7 +1418,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b1, 1);
         assertThat(db.getBlockUpdates().size()).isEqualTo(2);
 
-        assertThat(source_db.keys().size()).isEqualTo(4);
+        assertThat(count(source_db.keys())).isEqualTo(4);
         assertThat(source_db.get(k1).get()).isEqualTo(v2);
         assertThat(source_db.get(k2).get()).isEqualTo(v2);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1424,7 +1433,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b2, 2);
         assertThat(db.getBlockUpdates().size()).isEqualTo(3);
 
-        assertThat(source_db.keys().size()).isEqualTo(5);
+        assertThat(count(source_db.keys())).isEqualTo(5);
         assertThat(source_db.get(k1).get()).isEqualTo(v4);
         assertThat(source_db.get(k2).get()).isEqualTo(v3);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1439,7 +1448,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b3, 2);
         assertThat(db.getBlockUpdates().size()).isEqualTo(4);
 
-        assertThat(source_db.keys().size()).isEqualTo(6);
+        assertThat(count(source_db.keys())).isEqualTo(6);
         assertThat(source_db.get(k1).get()).isEqualTo(v3);
         assertThat(source_db.get(k2).get()).isEqualTo(v4);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1450,19 +1459,19 @@ public class JournalPruneDataSourceTest {
         // prune block b0
         db.prune(b0, 0);
         assertThat(db.getBlockUpdates().size()).isEqualTo(3);
-        assertThat(source_db.keys().size()).isEqualTo(6);
+        assertThat(count(source_db.keys())).isEqualTo(6);
 
         // prune block b1
         db.prune(b1, 1);
         assertThat(db.getBlockUpdates().size()).isEqualTo(2);
-        assertThat(source_db.keys().size()).isEqualTo(6);
+        assertThat(count(source_db.keys())).isEqualTo(6);
 
         // prune block b3 at level 2 (should be called for main chain block)
         db.prune(b3, 2);
         // also removed the updates for block b2
         assertThat(db.getBlockUpdates().size()).isEqualTo(0);
 
-        assertThat(source_db.keys().size()).isEqualTo(4);
+        assertThat(count(source_db.keys())).isEqualTo(4);
         assertThat(source_db.get(k1).get()).isEqualTo(v3);
         assertThat(source_db.get(k2).get()).isEqualTo(v4);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1482,7 +1491,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b0, 0);
         assertThat(db.getBlockUpdates().size()).isEqualTo(1);
 
-        assertThat(source_db.keys().size()).isEqualTo(3);
+        assertThat(count(source_db.keys())).isEqualTo(3);
         assertThat(source_db.get(k1).get()).isEqualTo(v1);
         assertThat(source_db.get(k2).get()).isEqualTo(v2);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1494,7 +1503,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b1, 1);
         assertThat(db.getBlockUpdates().size()).isEqualTo(2);
 
-        assertThat(source_db.keys().size()).isEqualTo(4);
+        assertThat(count(source_db.keys())).isEqualTo(4);
         assertThat(source_db.get(k1).get()).isEqualTo(v2);
         assertThat(source_db.get(k2).get()).isEqualTo(v2);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1508,7 +1517,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b2, 1);
         assertThat(db.getBlockUpdates().size()).isEqualTo(3);
 
-        assertThat(source_db.keys().size()).isEqualTo(5);
+        assertThat(count(source_db.keys())).isEqualTo(5);
         assertThat(source_db.get(k1).get()).isEqualTo(v4);
         assertThat(source_db.get(k2).get()).isEqualTo(v3);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1522,7 +1531,7 @@ public class JournalPruneDataSourceTest {
         db.storeBlockChanges(b3, 2);
         assertThat(db.getBlockUpdates().size()).isEqualTo(4);
 
-        assertThat(source_db.keys().size()).isEqualTo(6);
+        assertThat(count(source_db.keys())).isEqualTo(6);
         assertThat(source_db.get(k1).get()).isEqualTo(v3);
         assertThat(source_db.get(k2).get()).isEqualTo(v4);
         assertThat(source_db.get(k3).get()).isEqualTo(v3);
@@ -1533,12 +1542,12 @@ public class JournalPruneDataSourceTest {
         // prune block b0
         db.prune(b0, 0);
         assertThat(db.getBlockUpdates().size()).isEqualTo(3);
-        assertThat(source_db.keys().size()).isEqualTo(6);
+        assertThat(count(source_db.keys())).isEqualTo(6);
 
         // prune block b2 at level 1 : (should be called for main chain block)
         db.prune(b2, 1);
         assertThat(db.getBlockUpdates().size()).isEqualTo(1);
-        assertThat(source_db.keys().size()).isEqualTo(4);
+        assertThat(count(source_db.keys())).isEqualTo(4);
         assertThat(source_db.get(k1).get()).isEqualTo(v3);
         assertThat(source_db.get(k2).get()).isEqualTo(v4);
         assertThat(source_db.get(k3).isPresent()).isFalse();
@@ -1551,7 +1560,7 @@ public class JournalPruneDataSourceTest {
         // also removed the updates for block b2
         assertThat(db.getBlockUpdates().size()).isEqualTo(0);
 
-        assertThat(source_db.keys().size()).isEqualTo(4);
+        assertThat(count(source_db.keys())).isEqualTo(4);
         assertThat(source_db.get(k1).get()).isEqualTo(v3);
         assertThat(source_db.get(k2).get()).isEqualTo(v4);
         assertThat(source_db.get(k3).isPresent()).isFalse();


### PR DESCRIPTION
## Description

The `keys()` method is used to return all the database keys to the caller. Loading all these keys in a set as done by the current implementation leads to performance issues. This PR changes the return type from `Set` to `Iterator` to improve memory usage when calling this method.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- the existing test suite with the required changes

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
