### PR TITLE
Step 6: kernel integration (process fvm transactions in bulk)

### DIFF
--- a/modAion/src/org/aion/zero/db/AionRepositoryCache.java
+++ b/modAion/src/org/aion/zero/db/AionRepositoryCache.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.db.IRepository;
 import org.aion.base.db.IRepositoryCache;
+import org.aion.base.type.AionAddress;
 import org.aion.mcf.core.AccountState;
 import org.aion.mcf.db.AbstractRepositoryCache;
 import org.aion.mcf.db.ContractDetailsCacheImpl;
@@ -24,6 +25,74 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
     @Override
     public IRepositoryCache startTracking() {
         return new AionRepositoryCache(this);
+    }
+
+    /**
+     * Flushes its state to other in such a manner that other receives sufficiently deep copies of
+     * its {@link AccountState} and {@link IContractDetails} objects.
+     *
+     * If {@code clearStateAfterFlush == true} then this repository's state will be completely
+     * cleared after this method returns, otherwise it will retain all of its state.
+     *
+     * A "sufficiently deep copy" is an imperfect deep copy (some original object references get
+     * leaked) but such that for all conceivable use cases these imperfections should go unnoticed.
+     * This is because doing something like copying the underlying data store makes no sense, both
+     * repositories should be accessing it, and there are some other cases where objects are defined
+     * as type {@link Object} and are cast to their expected types and copied, but will not be copied
+     * if they are not in fact their expected types. This is something to be aware of. Most of the
+     * imperfection results from the inability to copy
+     * {@link org.aion.base.db.IByteArrayKeyValueStore} and {@link org.aion.mcf.trie.SecureTrie}
+     * perfectly or at all (in the case of the former), for the above reasons.
+     *
+     * @param other The repository that will consume the state of this repository.
+     * @param clearStateAfterFlush True if this repository should clear its state after flushing.
+     */
+    public void flushCopiesTo(IRepository other, boolean clearStateAfterFlush) {
+        fullyWriteLock();
+        try {
+            // determine which accounts should get stored
+            HashMap<Address, AccountState> cleanedCacheAccounts = new HashMap<>();
+            for (Map.Entry<Address, AccountState> entry : cachedAccounts.entrySet()) {
+                AccountState account = entry.getValue().copy();
+                if (account != null && account.isDirty() && account.isEmpty()) {
+                    // ignore contract state for empty accounts at storage
+                    cachedDetails.remove(entry.getKey());
+                } else {
+                    cleanedCacheAccounts.put(new AionAddress(entry.getKey().toBytes()), account);
+                }
+            }
+            // determine which contracts should get stored
+            for (Map.Entry<Address, IContractDetails> entry : cachedDetails.entrySet()) {
+                IContractDetails ctd = entry.getValue().copy();
+                // TODO: this functionality will be improved with the switch to a
+                // different ContractDetails implementation
+                if (ctd != null && ctd instanceof ContractDetailsCacheImpl) {
+                    ContractDetailsCacheImpl contractDetailsCache = (ContractDetailsCacheImpl) ctd;
+                    contractDetailsCache.commit();
+
+                    if (contractDetailsCache.origContract == null
+                        && other.hasContractDetails(entry.getKey())) {
+                        // in forked block the contract account might not exist thus
+                        // it is created without
+                        // origin, but on the main chain details can contain data
+                        // which should be merged
+                        // into a single storage trie so both branches with
+                        // different stateRoots are valid
+                        contractDetailsCache.origContract =
+                            other.getContractDetails(entry.getKey()).copy();
+                        contractDetailsCache.commit();
+                    }
+                }
+            }
+
+            other.updateBatch(cleanedCacheAccounts, cachedDetails);
+            if (clearStateAfterFlush) {
+                cachedAccounts.clear();
+                cachedDetails.clear();
+            }
+        } finally {
+            fullyWriteUnlock();
+        }
     }
 
     @Override
@@ -97,7 +166,7 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
 
             for (Map.Entry<Address, IContractDetails> ctdEntry : details.entrySet()) {
                 ContractDetailsCacheImpl contractDetailsCache =
-                        (ContractDetailsCacheImpl) ctdEntry.getValue();
+                        (ContractDetailsCacheImpl) ctdEntry.getValue().copy();
                 if (contractDetailsCache.origContract != null
                         && !(contractDetailsCache.origContract
                                 instanceof AionContractDetailsImpl)) {

--- a/modAion/src/org/aion/zero/db/AionRepositoryCache.java
+++ b/modAion/src/org/aion/zero/db/AionRepositoryCache.java
@@ -26,13 +26,8 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
         return new AionRepositoryCache(this);
     }
 
-    /**
-     * @implNote To maintain intended functionality this method does not call the parent's {@code
-     *     flush()} method. The changes are propagated to the parent through calling the parent's
-     *     {@code updateBatch()} method.
-     */
     @Override
-    public void flush() {
+    public void flushTo(IRepository other, boolean clearStateAfterFlush) {
         fullyWriteLock();
         try {
             // determine which accounts should get stored
@@ -56,7 +51,7 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
                     contractDetailsCache.commit();
 
                     if (contractDetailsCache.origContract == null
-                            && repository.hasContractDetails(entry.getKey())) {
+                        && other.hasContractDetails(entry.getKey())) {
                         // in forked block the contract account might not exist thus
                         // it is created without
                         // origin, but on the main chain details can contain data
@@ -64,18 +59,30 @@ public class AionRepositoryCache extends AbstractRepositoryCache<IBlockStoreBase
                         // into a single storage trie so both branches with
                         // different stateRoots are valid
                         contractDetailsCache.origContract =
-                                repository.getContractDetails(entry.getKey());
+                            other.getContractDetails(entry.getKey());
                         contractDetailsCache.commit();
                     }
                 }
             }
 
-            repository.updateBatch(cleanedCacheAccounts, cachedDetails);
-            cachedAccounts.clear();
-            cachedDetails.clear();
+            other.updateBatch(cleanedCacheAccounts, cachedDetails);
+            if (clearStateAfterFlush) {
+                cachedAccounts.clear();
+                cachedDetails.clear();
+            }
         } finally {
             fullyWriteUnlock();
         }
+    }
+
+    /**
+     * @implNote To maintain intended functionality this method does not call the parent's {@code
+     *     flush()} method. The changes are propagated to the parent through calling the parent's
+     *     {@code updateBatch()} method.
+     */
+    @Override
+    public void flush() {
+        flushTo(repository, true);
     }
 
     @Override

--- a/modAionBase/src/org/aion/base/db/IContractDetails.java
+++ b/modAionBase/src/org/aion/base/db/IContractDetails.java
@@ -168,4 +168,13 @@ public interface IContractDetails {
      * @param dataSource The new dataSource.
      */
     void setDataSource(IByteArrayKeyValueStore dataSource);
+
+    /**
+     * Returns a sufficiently deep copy of this object. It is up to all implementations of this
+     * method to declare which original object references are in fact leaked by this copy, if any,
+     * and to provide justification of why, despite this, the copy is nonetheless sufficiently deep.
+     *
+     * @return A copy of this object.
+     */
+    IContractDetails copy();
 }

--- a/modAionBase/src/org/aion/base/db/IRepositoryCache.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryCache.java
@@ -80,4 +80,6 @@ public interface IRepositoryCache<AS, BSB> extends IRepository<AS, BSB> {
      * @param value the data to be stored
      */
     void addStorageRow(Address address, ByteArrayWrapper key, ByteArrayWrapper value);
+
+    void flushTo(IRepository repo, boolean clearStateAfterFlush);
 }

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -1073,37 +1073,24 @@ public class AionBlockchainImpl implements IAionBlockchain {
         List<AionTxExecSummary> summaries = new ArrayList<>();
         List<AionTransaction> transactions = new ArrayList<>();
 
-        long energyRemaining = block.getNrgLimit();
-        for (AionTransaction tx : block.getTransactionsList()) {
-            ExecutionBatch details = new ExecutionBatch(block, Collections.singletonList(tx));
-            BulkExecutor executor =
-                    new BulkExecutor(
-                            details,
-                            track,
-                            false,
-                            true,
-                            energyRemaining,
-                            LOGGER_VM,
-                            (r, c, s, t, b) -> {
-                                return 0;
-                            });
+        ExecutionBatch batch = new ExecutionBatch(block, block.getTransactionsList());
+        BulkExecutor executor =
+            new BulkExecutor(
+                batch,
+                repository,
+                track,
+                false,
+                true,
+                block.getNrgLimit(),
+                LOGGER_VM,
+                getPostExecutionWorkForGeneratePreBlock());
+        List<AionTxExecSummary> executionSummaries = executor.execute();
 
-            AionTxExecSummary summary = executor.execute().get(0);
-
+        for (AionTxExecSummary summary : executionSummaries) {
             if (!summary.isRejected()) {
-                track.flush();
-
-                AionTxReceipt receipt = summary.getReceipt();
-                receipt.setPostTxState(repository.getRoot());
-                receipt.setTransaction(tx);
-
-                // otherwise, assuming we don't have timeouts, add the
-                // transaction
-                transactions.add(tx);
-
-                receipts.add(receipt);
+                transactions.add(summary.getTransaction());
+                receipts.add(summary.getReceipt());
                 summaries.add(summary);
-                energyRemaining -= receipt.getEnergyUsed();
             }
         }
 
@@ -1116,6 +1103,13 @@ public class AionBlockchainImpl implements IAionBlockchain {
         return new RetValidPreBlock(transactions, rewards, receipts, summaries);
     }
 
+    /**
+     * Returns a {@link PostExecutionWork} object whose {@code doPostExecutionWork()} method will run
+     * the provided logic defined in this method. This work is to be applied after each transaction
+     * has been run.
+     *
+     * This "work" is specific to the {@link AionBlockchainImpl#generatePreBlock(IAionBlock)} method.
+     */
     private static PostExecutionWork getPostExecutionWorkForGeneratePreBlock() {
         return (topRepository,
                 childRepository,
@@ -1142,27 +1136,21 @@ public class AionBlockchainImpl implements IAionBlockchain {
         List<AionTxReceipt> receipts = new ArrayList<>();
         List<AionTxExecSummary> summaries = new ArrayList<>();
 
-        for (AionTransaction tx : block.getTransactionsList()) {
-            ExecutionBatch details = new ExecutionBatch(block, Collections.singletonList(tx));
-            BulkExecutor executor =
-                    new BulkExecutor(
-                            details,
-                            track,
-                            false,
-                            true,
-                            block.getNrgLimit(),
-                            LOGGER_VM,
-                            (r, c, s, t, b) -> {
-                                return 0L;
-                            });
+        ExecutionBatch batch = new ExecutionBatch(block, block.getTransactionsList());
+        BulkExecutor executor =
+            new BulkExecutor(
+                batch,
+                repository,
+                track,
+                false,
+                true,
+                block.getNrgLimit(),
+                LOGGER_VM,
+                getPostExecutionWorkForApplyBlock());
+        List<AionTxExecSummary> executionSummaries = executor.execute();
 
-            AionTxExecSummary summary = executor.execute().get(0);
-
-            track.flush();
-            AionTxReceipt receipt = summary.getReceipt();
-            receipt.setPostTxState(repository.getRoot());
-            receipts.add(receipt);
-
+        for (AionTxExecSummary summary : executionSummaries) {
+            receipts.add(summary.getReceipt());
             summaries.add(summary);
         }
         Map<Address, BigInteger> rewards = addReward(block, summaries);
@@ -1171,6 +1159,27 @@ public class AionBlockchainImpl implements IAionBlockchain {
         chainStats.addBlockExecTime(totalTime);
 
         return new AionBlockSummary(block, rewards, receipts, summaries);
+    }
+
+    /**
+     * Returns a {@link PostExecutionWork} object whose {@code doPostExecutionWork()} method will run
+     * the provided logic defined in this method. This work is to be applied after each transaction
+     * has been run.
+     *
+     * This "work" is specific to the {@link AionBlockchainImpl#applyBlock(IAionBlock)} method.
+     */
+    private static PostExecutionWork getPostExecutionWorkForApplyBlock() {
+        return (topRepository,
+            childRepository,
+            transactionSummary,
+            transaction,
+            blockEnergyLeft) -> {
+
+            childRepository.flush();
+            AionTxReceipt receipt = transactionSummary.getReceipt();
+            receipt.setPostTxState(topRepository.getRoot());
+            return 0;
+        };
     }
 
     /**

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
@@ -178,10 +178,13 @@ public class AionImpl implements IAionChain {
         }
     }
 
-    /** There is no post-execution work to do for any calls in this class. */
-    private PostExecutionWork getPostExecutionWork() {
+    /**
+     * There is no post-execution work to do for any calls in this class to do. In accordance with
+     * the specs, we return zero since we have no meaningful value to return here.
+     */
+    private static PostExecutionWork getPostExecutionWork() {
         return (r, c, s, t, b) -> {
-            return 0L;
+            return 0;
         };
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -1070,12 +1070,15 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
     }
 
     /**
-     * Currently there is no post-execution work to do.
+     * Currently there is no post-execution work to do because this class actually uses the
+     * {@link BulkExecutor} to execute transactions sequentially instead of in bulk.
      *
-     * <p>In the future we may choose to be more ambitious and to use the {@link BulkExecutor}
-     * properly, in which case we will have to give this method real functionality.
+     * In the future we may choose to be more ambitious and to use the {@link BulkExecutor} properly,
+     * in which case we will have to give this method real functionality. Likely, we will need
+     * several methods that will capture the different post-execution work logic that the different
+     * methods in this class expect to have done when they call into the executor.
      */
-    private PostExecutionWork getPostExecutionWork() {
+    private static PostExecutionWork getPostExecutionWork() {
         return (r, c, s, t, b) -> {
             return 0L;
         };

--- a/modAionImpl/test/org/aion/zero/impl/db/FlushCopiesTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/db/FlushCopiesTest.java
@@ -1,0 +1,176 @@
+package org.aion.zero.impl.db;
+
+import static org.aion.crypto.ECKeyFac.ECKeyType.ED25519;
+import static org.aion.crypto.HashUtil.H256Type.BLAKE2B_256;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.io.File;
+import java.math.BigInteger;
+import org.aion.base.db.IContractDetails;
+import org.aion.base.db.IRepository;
+import org.aion.base.type.AionAddress;
+import org.aion.base.util.ByteArrayWrapper;
+import org.aion.crypto.ECKeyFac;
+import org.aion.crypto.HashUtil;
+import org.aion.db.utils.FileUtils;
+import org.aion.log.AionLoggerFactory;
+import org.aion.mcf.core.AccountState;
+import org.aion.mcf.vm.types.DataWord;
+import org.aion.mcf.vm.types.DoubleDataWord;
+import org.aion.utils.NativeLibrary;
+import org.aion.vm.api.interfaces.Address;
+import org.aion.zero.db.AionRepositoryCache;
+import org.aion.zero.impl.AionHub;
+import org.aion.zero.impl.config.CfgAion;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests the {@link org.aion.zero.db.AionRepositoryCache#flushCopiesTo(IRepository, boolean)}
+ * method.
+ */
+public class FlushCopiesTest {
+    private IRepository repository;
+
+    @Before
+    public void setup() {
+        NativeLibrary.checkNativeLibrariesLoaded();
+        ECKeyFac.setType(ED25519);
+        HashUtil.setType(BLAKE2B_256);
+        CfgAion cfg = CfgAion.inst();
+        AionLoggerFactory.init(
+                cfg.getLog().getModules(), cfg.getLog().getLogFile(), cfg.getLogPath());
+        this.repository = AionHub.inst().getRepository();
+    }
+
+    @After
+    public void tearDown() {
+        this.repository = null;
+        FileUtils.deleteRecursively(new File(System.getProperty("user.dir") + "/mainnet"));
+    }
+
+    @Test
+    public void testAccountStateObjectReference() {
+        AionRepositoryCache repositoryChild = (AionRepositoryCache) this.repository.startTracking();
+
+        Address account = randomAionAddress();
+        BigInteger nonce = BigInteger.TEN;
+        BigInteger balance = BigInteger.valueOf(11223344);
+        byte[] code = new byte[100];
+
+        System.out.println("testAccountStateObjectReference using address: " + account);
+
+        // Create a new account state in the child, flush to the parent without clearing child
+        // state.
+        repositoryChild.createAccount(account);
+        repositoryChild.setNonce(account, nonce);
+        repositoryChild.addBalance(account, balance);
+        repositoryChild.saveCode(account, code);
+        repositoryChild.flushCopiesTo(this.repository, false);
+
+        // Compare object references.
+        AccountState accountStateInChild = repositoryChild.getAccountState(account);
+        AccountState accountStateInParent = (AccountState) this.repository.getAccountState(account);
+
+        // These references must be different.
+        assertNotSame(accountStateInChild, accountStateInParent);
+        assertNotSame(accountStateInChild.getStateRoot(), accountStateInParent.getStateRoot());
+
+        // Ensure that the essential state of the objects are equivalent.
+        assertEquals(accountStateInChild.getNonce(), accountStateInParent.getNonce());
+        assertEquals(accountStateInChild.getBalance(), accountStateInParent.getBalance());
+        assertArrayEquals(accountStateInChild.getStateRoot(), accountStateInParent.getStateRoot());
+        assertArrayEquals(accountStateInChild.getCodeHash(), accountStateInParent.getCodeHash());
+    }
+
+    @Test
+    public void testContractDetailsObjectReference() {
+        AionRepositoryCache repositoryChild = (AionRepositoryCache) this.repository.startTracking();
+
+        Address account = randomAionAddress();
+        BigInteger nonce = BigInteger.TEN;
+        BigInteger balance = BigInteger.valueOf(11223344);
+        byte[] code = new byte[100];
+
+        System.out.println("testContractDetailsObjectReference using address: " + account);
+
+        // Create a new account state in the child, flush to the parent without clearing child
+        // state.
+        ByteArrayWrapper key = new DataWord(5).toWrapper();
+        ByteArrayWrapper value = new DoubleDataWord(13429765314L).toWrapper();
+
+        repositoryChild.createAccount(account);
+        repositoryChild.setNonce(account, nonce);
+        repositoryChild.addBalance(account, balance);
+        repositoryChild.saveCode(account, code);
+        repositoryChild.addStorageRow(account, key, value);
+        repositoryChild.flushCopiesTo(this.repository, false);
+
+        // Compare object references.
+        IContractDetails detailsInChild = repositoryChild.getContractDetails(account);
+        IContractDetails detailsInParent = this.repository.getContractDetails(account);
+
+        // These references must be different.
+        assertNotSame(detailsInChild, detailsInParent);
+
+        // Ensure that the essential state of the objects are equivalent.
+        assertArrayEquals(detailsInChild.getStorageHash(), detailsInParent.getStorageHash());
+        assertArrayEquals(detailsInChild.getCode(), detailsInParent.getCode());
+        assertEquals(detailsInChild.getAddress(), detailsInParent.getAddress());
+    }
+
+    @Test
+    public void testSiblingStateModificationsAreIndependentOfOneAnother() {
+        AionRepositoryCache firstChild = (AionRepositoryCache) this.repository.startTracking();
+
+        Address account = randomAionAddress();
+        BigInteger firstNonce = BigInteger.TEN;
+        BigInteger firstBalance = BigInteger.valueOf(11223344);
+        byte[] code = new byte[100];
+
+        System.out.println(
+                "testSiblingStateModificationsAreIndependentOfOneAnother using address: "
+                        + account);
+
+        // Create a new account state in the child, flush to the parent without clearing child
+        // state.
+        ByteArrayWrapper firstKey = new DataWord(5).toWrapper();
+        ByteArrayWrapper firstValue = new DoubleDataWord(13429765314L).toWrapper();
+
+        firstChild.createAccount(account);
+        firstChild.setNonce(account, firstNonce);
+        firstChild.addBalance(account, firstBalance);
+        firstChild.saveCode(account, code);
+        firstChild.addStorageRow(account, firstKey, firstValue);
+        firstChild.flushCopiesTo(this.repository, false);
+
+        byte[] firstStorageHash = firstChild.getContractDetails(account).getStorageHash();
+
+        // Now create a sibling, and make modifications to this same account in the sibling.
+        AionRepositoryCache secondChild = (AionRepositoryCache) this.repository.startTracking();
+
+        BigInteger secondNonce = firstNonce.multiply(BigInteger.TWO);
+        ByteArrayWrapper secondKey = new DoubleDataWord(289356).toWrapper();
+        ByteArrayWrapper secondValue = new DataWord(23674).toWrapper();
+
+        secondChild.setNonce(account, secondNonce);
+        secondChild.addBalance(account, firstBalance);
+        secondChild.addStorageRow(account, secondKey, secondValue);
+        secondChild.flushCopiesTo(this.repository, false);
+
+        // Ensure that the first child's state has not been modified by the second.
+        assertEquals(firstNonce, firstChild.getNonce(account));
+        assertEquals(firstBalance, firstChild.getBalance(account));
+        assertArrayEquals(firstStorageHash, firstChild.getContractDetails(account).getStorageHash());
+    }
+
+    private Address randomAionAddress() {
+        byte[] bytes = RandomUtils.nextBytes(Address.SIZE);
+        bytes[0] = (byte) 0xa0;
+        return new AionAddress(bytes);
+    }
+}

--- a/modAionImpl/test/org/aion/zero/impl/vm/ContractIntegTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/ContractIntegTest.java
@@ -49,6 +49,7 @@ import org.aion.vm.ExecutionBatch;
 import org.aion.vm.PostExecutionWork;
 import org.aion.vm.api.interfaces.Address;
 import org.aion.vm.api.interfaces.ResultCode;
+import org.aion.zero.db.AionRepositoryCache;
 import org.aion.zero.impl.BlockContext;
 import org.aion.zero.impl.StandaloneBlockchain;
 import org.aion.zero.impl.StandaloneBlockchain.Builder;
@@ -892,7 +893,7 @@ public class ContractIntegTest {
                         nonce.toByteArray(), null, value.toByteArray(), deployCode, nrg, nrgPrice);
 
         // Mock up the repo so that the contract address already exists.
-        IRepositoryCache repo = mock(IRepositoryCache.class);
+        AionRepositoryCache repo = mock(AionRepositoryCache.class);
         when(repo.hasAccountState(Mockito.any(Address.class))).thenReturn(true);
         when(repo.getNonce(Mockito.any(Address.class))).thenReturn(nonce);
         when(repo.getBalance(Mockito.any(Address.class))).thenReturn(Builder.DEFAULT_BALANCE);

--- a/modMcf/src/org/aion/mcf/core/AccountState.java
+++ b/modMcf/src/org/aion/mcf/core/AccountState.java
@@ -4,6 +4,7 @@ import static org.aion.crypto.HashUtil.EMPTY_DATA_HASH;
 import static org.aion.crypto.HashUtil.EMPTY_TRIE_HASH;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import org.aion.base.util.FastByteComparisons;
 import org.aion.rlp.RLP;
 import org.aion.rlp.RLPList;
@@ -260,6 +261,30 @@ public class AccountState extends AbstractState {
             this.balance = balance.subtract(value);
         }
         return this.balance;
+    }
+
+    /**
+     * Returns a deep copy of this account state.
+     *
+     * @return A deep copy of this object.
+     */
+    public AccountState copy() {
+        AccountState accountStateCopy = new AccountState();
+        accountStateCopy.balance = this.balance;
+        accountStateCopy.nonce = this.nonce;
+        accountStateCopy.dirty = this.dirty;
+        accountStateCopy.deleted = this.deleted;
+        accountStateCopy.codeHash =
+                (this.codeHash == null) ? null : Arrays.copyOf(this.codeHash, this.codeHash.length);
+        accountStateCopy.stateRoot =
+                (this.stateRoot == null)
+                        ? null
+                        : Arrays.copyOf(this.stateRoot, this.stateRoot.length);
+        accountStateCopy.rlpEncoded =
+                (this.rlpEncoded == null)
+                        ? null
+                        : Arrays.copyOf(this.rlpEncoded, this.rlpEncoded.length);
+        return accountStateCopy;
     }
 
     public byte[] getEncoded() {

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -1,9 +1,11 @@
 package org.aion.mcf.db;
 
 import java.util.Collection;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.util.ByteArrayWrapper;
@@ -223,5 +225,94 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
     @Override
     public void setDataSource(IByteArrayKeyValueStore dataSource) {
         throw new UnsupportedOperationException("Can't set datasource in cache implementation.");
+    }
+
+    /**
+     * Returns a sufficiently deep copy of this contract details object.
+     *
+     * <p>If this contract details object's "original contract" is of type {@link
+     * ContractDetailsCacheImpl}, and the same is true for all of its ancestors, then this method
+     * will return a perfectly deep copy of this contract details object.
+     *
+     * <p>Otherwise, the "original contract" copy will retain some references that are also held by
+     * the object it is a copy of. In particular, the following references will not be copied:
+     *
+     * <p>- The external storage data source. - The previous root of the trie will pass its original
+     * object reference if this root is not of type {@code byte[]}. - The current root of the trie
+     * will pass its original object reference if this root is not of type {@code byte[]}. - Each
+     * {@link org.aion.rlp.Value} object reference held by each of the {@link
+     * org.aion.mcf.trie.Node} objects in the underlying cache.
+     *
+     * @return A copy of this object.
+     */
+    @Override
+    public ContractDetailsCacheImpl copy() {
+        // TODO: better to move this check into all constructors instead.
+        if (this == this.origContract) {
+            throw new IllegalStateException(
+                    "Cannot copy a ContractDetailsCacheImpl whose original contract is itself!");
+        }
+
+        IContractDetails originalContractCopy =
+                (this.origContract == null) ? null : this.origContract.copy();
+        ContractDetailsCacheImpl contractDetailsCacheCopy =
+                new ContractDetailsCacheImpl(originalContractCopy);
+        contractDetailsCacheCopy.storage = getDeepCopyOfStorage();
+        contractDetailsCacheCopy.prune = this.prune;
+        contractDetailsCacheCopy.detailsInMemoryStorageLimit = this.detailsInMemoryStorageLimit;
+        contractDetailsCacheCopy.setCodes(getDeepCopyOfCodes());
+        contractDetailsCacheCopy.setDirty(this.isDirty());
+        contractDetailsCacheCopy.setDeleted(this.isDeleted());
+        return contractDetailsCacheCopy;
+    }
+
+    private Map<ByteArrayWrapper, byte[]> getDeepCopyOfCodes() {
+        Map<ByteArrayWrapper, byte[]> originalCodes = this.getCodes();
+
+        if (originalCodes == null) {
+            return null;
+        }
+
+        Map<ByteArrayWrapper, byte[]> copyOfCodes = new HashMap<>();
+        for (Entry<ByteArrayWrapper, byte[]> codeEntry : originalCodes.entrySet()) {
+
+            ByteArrayWrapper keyWrapper = null;
+            if (codeEntry.getKey() != null) {
+                byte[] keyBytes = codeEntry.getKey().getData();
+                keyWrapper = new ByteArrayWrapper(Arrays.copyOf(keyBytes, keyBytes.length));
+            }
+
+            byte[] copyOfValue =
+                    (codeEntry.getValue() == null)
+                            ? null
+                            : Arrays.copyOf(codeEntry.getValue(), codeEntry.getValue().length);
+            copyOfCodes.put(keyWrapper, copyOfValue);
+        }
+        return copyOfCodes;
+    }
+
+    private Map<ByteArrayWrapper, ByteArrayWrapper> getDeepCopyOfStorage() {
+        if (this.storage == null) {
+            return null;
+        }
+
+        Map<ByteArrayWrapper, ByteArrayWrapper> storageCopy = new HashMap<>();
+        for (Entry<ByteArrayWrapper, ByteArrayWrapper> storageEntry : this.storage.entrySet()) {
+            ByteArrayWrapper keyWrapper = null;
+            ByteArrayWrapper valueWrapper = null;
+
+            if (storageEntry.getKey() != null) {
+                byte[] keyBytes = storageEntry.getKey().getData();
+                keyWrapper = new ByteArrayWrapper(Arrays.copyOf(keyBytes, keyBytes.length));
+            }
+
+            if (storageEntry.getValue() != null) {
+                byte[] valueBytes = storageEntry.getValue().getData();
+                valueWrapper = new ByteArrayWrapper(Arrays.copyOf(valueBytes, valueBytes.length));
+            }
+
+            storageCopy.put(keyWrapper, valueWrapper);
+        }
+        return storageCopy;
     }
 }

--- a/modMcf/src/org/aion/mcf/trie/Cache.java
+++ b/modMcf/src/org/aion/mcf/trie/Cache.java
@@ -4,12 +4,14 @@ import static org.aion.base.util.ByteArrayWrapper.wrap;
 import static org.aion.rlp.Value.fromRlpEncoded;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import org.aion.base.db.IByteArrayKeyValueStore;
@@ -218,5 +220,64 @@ public class Cache {
 
     public int getSize() {
         return nodes.size();
+    }
+
+    /**
+     * Returns a copy of this cache.
+     *
+     * <p>The copied cache and this cache will each hold a reference to the same data source, and
+     * each copied {@link Node} object will retain the same reference to its {@link Value} object as
+     * its original.
+     *
+     * @return A copy of this cache.
+     */
+    public Cache copy() {
+        Cache cacheCopy = new Cache(this.dataSource);
+        cacheCopy.isDirty = this.isDirty;
+        cacheCopy.nodes = copyOfNodes();
+        cacheCopy.removedNodes = copyOfRemovedNodes();
+        return cacheCopy;
+    }
+
+    private Map<ByteArrayWrapper, Node> copyOfNodes() {
+        if (this.nodes == null) {
+            return null;
+        }
+
+        Map<ByteArrayWrapper, Node> nodesCopy = new HashMap<>();
+        for (Entry<ByteArrayWrapper, Node> nodesEntry : this.nodes.entrySet()) {
+            ByteArrayWrapper keyWrapper = null;
+
+            if (nodesEntry.getKey() != null) {
+                byte[] keyBytes = nodesEntry.getKey().getData();
+                keyWrapper = new ByteArrayWrapper(Arrays.copyOf(keyBytes, keyBytes.length));
+            }
+
+            nodesCopy.put(
+                    keyWrapper,
+                    (nodesEntry.getValue() == null) ? null : nodesEntry.getValue().copy());
+        }
+        return nodesCopy;
+    }
+
+    private Set<ByteArrayWrapper> copyOfRemovedNodes() {
+        if (this.removedNodes == null) {
+            return null;
+        }
+
+        Set<ByteArrayWrapper> removedNodesCopy = new HashSet<>();
+        for (ByteArrayWrapper removedNode : this.removedNodes) {
+            ByteArrayWrapper removedNodeWrapper = null;
+
+            if (removedNode != null) {
+                byte[] removedNodeBytes = removedNode.toBytes();
+                removedNodeWrapper =
+                        new ByteArrayWrapper(
+                                Arrays.copyOf(removedNodeBytes, removedNodeBytes.length));
+            }
+
+            removedNodesCopy.add(removedNodeWrapper);
+        }
+        return removedNodesCopy;
     }
 }

--- a/modMcf/src/org/aion/mcf/trie/SecureTrie.java
+++ b/modMcf/src/org/aion/mcf/trie/SecureTrie.java
@@ -2,9 +2,19 @@ package org.aion.mcf.trie;
 
 import static org.aion.crypto.HashUtil.h256;
 
+import java.util.Arrays;
 import org.aion.base.db.IByteArrayKeyValueStore;
 
 public class SecureTrie extends TrieImpl implements Trie {
+
+    /**
+     * A private constructor that initializes the db and root to null.
+     *
+     * Used by this class's copy() method.
+     */
+    private SecureTrie() {
+        super(null, null);
+    }
 
     public SecureTrie(IByteArrayKeyValueStore db) {
         this(db, "");
@@ -27,5 +37,55 @@ public class SecureTrie extends TrieImpl implements Trie {
     @Override
     public void delete(byte[] key) {
         super.delete(h256(key));
+    }
+
+    /**
+     * Returns a copy of this trie.
+     *
+     * The {@link Cache} object returned will be a copy of this object's cache, but the two will
+     * share the same references to their data sources ({@link IByteArrayKeyValueStore} objects) and
+     * each {@link Node} will retain the same references as the original node's
+     * {@link org.aion.rlp.Value} objects.
+     *
+     * The previous root and current root of this trie will return deep copies of these objects only
+     * if they are of type {@code byte[]}. Otherwise, the original references will be passed on. It
+     * is expected that they will indeed be byte arrays.
+     *
+     * @return A copy of this trie.
+     */
+    public SecureTrie copy() {
+        synchronized (super.getCache()) {
+            SecureTrie secureTrieCopy = new SecureTrie();
+
+            Object originalPreviousRoot = super.getPrevRoot();
+            Object originalRoot = super.getRoot();
+
+            Object previousRootCopy = null;
+            Object rootCopy = null;
+
+            // We should only be dealing in terms of byte arrays for the previous & current roots.
+            // But if we do not get a byte[] here, then we cannot make a deep copy of the object.
+            if (originalPreviousRoot instanceof byte[]) {
+                byte[] originalPreviousRootAsBytes = (byte[]) originalPreviousRoot;
+                previousRootCopy =
+                        Arrays.copyOf(
+                                originalPreviousRootAsBytes, originalPreviousRootAsBytes.length);
+            } else if (originalPreviousRoot != null) {
+                previousRootCopy = originalPreviousRoot;
+            }
+
+            if (originalRoot instanceof byte[]) {
+                byte[] originalRootAsBytes = (byte[]) originalRoot;
+                rootCopy = Arrays.copyOf(originalRootAsBytes, originalRootAsBytes.length);
+            } else if (originalRoot != null) {
+                rootCopy = originalRoot;
+            }
+
+            secureTrieCopy.setPrevRoot(previousRootCopy);
+            secureTrieCopy.setRoot(rootCopy);
+            secureTrieCopy.setCache(super.getCache().copy());
+            secureTrieCopy.setPruningEnabled(super.isPruningEnabled());
+            return secureTrieCopy;
+        }
     }
 }

--- a/modMcf/src/org/aion/mcf/trie/TrieImpl.java
+++ b/modMcf/src/org/aion/mcf/trie/TrieImpl.java
@@ -103,6 +103,10 @@ public class TrieImpl implements Trie {
         return prevRoot;
     }
 
+    public void setPrevRoot(Object previousRoot) {
+        prevRoot = previousRoot;
+    }
+
     public Object getRoot() {
         return root;
     }
@@ -131,6 +135,10 @@ public class TrieImpl implements Trie {
 
     public boolean isPruningEnabled() {
         return pruningEnabled;
+    }
+
+    public void setPruningEnabled(boolean pruningIsEnabled) {
+        pruningEnabled = pruningIsEnabled;
     }
 
     public TrieImpl withPruningEnabled(boolean pruningEnabled) {

--- a/modMcf/src/org/aion/mcf/vm/types/KernelInterfaceForFastVM.java
+++ b/modMcf/src/org/aion/mcf/vm/types/KernelInterfaceForFastVM.java
@@ -89,7 +89,9 @@ public class KernelInterfaceForFastVM implements KernelInterface {
 
     @Override
     public void deleteAccount(Address address) {
-        this.repositoryCache.deleteAccount(address);
+        if (!this.isLocalCall) {
+            this.repositoryCache.deleteAccount(address);
+        }
     }
 
     @Override
@@ -128,12 +130,16 @@ public class KernelInterfaceForFastVM implements KernelInterface {
 
     @Override
     public void refundAccount(Address address, BigInteger amount) {
-        // TODO: remove this placeholder for changes made in a reorganized commit
+        if (!this.isLocalCall) {
+            this.repositoryCache.addBalance(address, amount);
+        }
     }
 
     @Override
     public void payMiningFee(Address miner, BigInteger fee) {
-        // TODO: remove this placeholder for changes made in a reorganized commit
+        if (!this.isLocalCall) {
+            this.repositoryCache.addBalance(miner, fee);
+        }
     }
 
     @Override

--- a/modPrecompiled/src/org/aion/precompiled/contracts/ATB/BridgeStorageConnector.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/ATB/BridgeStorageConnector.java
@@ -215,7 +215,7 @@ public class BridgeStorageConnector {
         ByteArrayWrapper word = this.track.getStorageValue(contractAddress, key.toWrapper());
         // C1
         if (word == null || Arrays.equals(word.getData(), ByteUtil.EMPTY_HALFWORD)) return null;
-        return word.getData();
+        return alignBytes(word.getData());
     }
 
     private void setWORD(@Nonnull final DataWord key, @Nonnull final DataWord word) {
@@ -233,6 +233,16 @@ public class BridgeStorageConnector {
         if (word == null) return null;
 
         if (word.isZero()) return null;
-        return word.getData();
+        return alignBytes(word.getData());
+    }
+
+    private byte[] alignBytes(byte[] unalignedBytes) {
+        if (unalignedBytes == null) {
+            return null;
+        }
+
+        return (unalignedBytes.length > DataWord.BYTES)
+                ? new DoubleDataWord(unalignedBytes).getData()
+                : new DataWord(unalignedBytes).getData();
     }
 }

--- a/modPrecompiled/test/org/aion/precompiled/contracts/DummyRepo.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/DummyRepo.java
@@ -160,6 +160,9 @@ public class DummyRepo implements IRepositoryCache<AccountState, IBlockStoreBase
     public void flush() {}
 
     @Override
+    public void flushTo(IRepository repo, boolean clearStateAfterFlush) {}
+
+    @Override
     public void rollback() {}
 
     @Override

--- a/modVM/src/org/aion/vm/BulkExecutor.java
+++ b/modVM/src/org/aion/vm/BulkExecutor.java
@@ -154,7 +154,7 @@ public class BulkExecutor {
 
             // 3. Do any post execution work and update the remaining block energy.
             this.blockRemainingEnergy -=
-                    this.postExecutionWork.doExecutionWork(
+                    this.postExecutionWork.doPostExecutionWork(
                             this.repository,
                             this.repositoryChild,
                             summary,
@@ -190,9 +190,10 @@ public class BulkExecutor {
 
         ResultCode resultCode = result.getResultCode();
 
-        if (resultCode.isSuccess()) {
-            kernelFromVM.flush();
-        } else if (resultCode.isRejected()) {
+        // FastVirtualMachine guarantees us that we are always safe to flush its state changes.
+        ((KernelInterfaceForFastVM) kernelFromVM).getRepositoryCache().flushTo(this.repositoryChild, true);
+
+        if (resultCode.isRejected()) {
             builder.markAsRejected();
         } else if (resultCode.isFailed()) {
             builder.markAsFailed();

--- a/modVM/src/org/aion/vm/PostExecutionWork.java
+++ b/modVM/src/org/aion/vm/PostExecutionWork.java
@@ -8,8 +8,11 @@ import org.aion.zero.types.AionTransaction;
 import org.aion.zero.types.AionTxExecSummary;
 
 /**
- * A functional interface that specifies post-execution "work". That is, the that must be done
- * directly after a transaction has been executed.
+ * A functional interface that specifies post-execution "work" or logic that is to be applied
+ * immediately after a transaction has been executed. Or, if the transaction is being executed in
+ * bulk, then it is to be applied in such a manner that it appears to be logically applied immediately
+ * after the execution of the transaction so that from the perspective of the caller there is no
+ * difference between running the transactions in bulk or sequentially.
  */
 @FunctionalInterface
 public interface PostExecutionWork {
@@ -21,9 +24,11 @@ public interface PostExecutionWork {
      * <p>This work may do whatever it needs to the provided inputs.
      *
      * <p>The work must return the amount of energy that this transaction will use in its block so
-     * that the remaining block energy may be updated correctly. Note that this value may not always
-     * be relevant to the component of the kernel that wants this work done, and so it is also able
-     * to return 0 in that case.
+     * that the remaining block energy may be updated correctly.
+     *
+     * Note that this value may not always be relevant to the component of the kernel that wants
+     * this work done, in which case that component should define this method to return zero (0) so
+     * that no block energy usage deductions are made.
      *
      * @param repository The top-most level of the repository.
      * @param repositoryChild The child repository of repository.
@@ -33,7 +38,7 @@ public interface PostExecutionWork {
      *     execution.
      * @return The amount of energy that this transaction uses in its block.
      */
-    long doExecutionWork(
+    long doPostExecutionWork(
             IRepository repository,
             IRepositoryCache<AccountState, IBlockStoreBase<?, ?>> repositoryChild,
             AionTxExecSummary summary,


### PR DESCRIPTION
The Fast VM now processes transactions in bulk.

The commit that introduces the bulk processing logic is 382c96a

The remaining commits relate to a bug fix. Essentially, the contract details were not being deeply copied when one repository flushed to another, which allows for a critical object reference to leak across sibling repositories. A deep copy is now being performed, and some tests added.

The option to flush a deep copy as opposed to the regular flush is separate for now because it comes with a performance penalty, of course, and because it is only required when a sibling that wants to hold on to its state flushes. This happens only at one particular point, in the `FastVirtualMachine` class.

See [here](https://github.com/aionnetwork/aion_fastvm/pull/47) for the FVM changes.
