### PR TITLE
Helper CLI for checking consensus

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -538,9 +538,10 @@ public class AionBlockchainImpl implements IAionBlockchain {
 
     // TEMPORARY: here to support the ConsensusTest
     public Pair<ImportResult, AionBlockSummary> tryToConnectAndFetchSummary(
-            AionBlock block, long currTimeSeconds) {
+            AionBlock block, long currTimeSeconds, boolean doExistCheck) {
         // Check block exists before processing more rules
-        if (getBlockStore().getMaxNumber() >= block.getNumber()
+        if (doExistCheck // skipped when re-importing
+                && getBlockStore().getMaxNumber() >= block.getNumber()
                 && getBlockStore().isBlockExist(block.getHash())) {
 
             if (LOG.isDebugEnabled()) {
@@ -646,7 +647,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
      * can feed timestamps manually
      */
     ImportResult tryToConnectInternal(final AionBlock block, long currTimeSeconds) {
-        return tryToConnectAndFetchSummary(block, currTimeSeconds).getLeft();
+        return tryToConnectAndFetchSummary(block, currTimeSeconds, true).getLeft();
     }
 
     /**

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -540,7 +540,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
     public Pair<ImportResult, AionBlockSummary> tryToConnectAndFetchSummary(
             AionBlock block, long currTimeSeconds, boolean doExistCheck) {
         // Check block exists before processing more rules
-        if (doExistCheck // skipped when re-importing
+        if (doExistCheck // skipped when redoing imports
                 && getBlockStore().getMaxNumber() >= block.getNumber()
                 && getBlockStore().isBlockExist(block.getHash())) {
 

--- a/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
@@ -385,7 +385,7 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
     // TEMPORARY: here to support the ConsensusTest
     public synchronized Pair<ImportResult, AionBlockSummary> tryToConnectAndFetchSummary(
             AionBlock block) {
-        return tryToConnectAndFetchSummary(block, System.currentTimeMillis() / 1000);
+        return tryToConnectAndFetchSummary(block, System.currentTimeMillis() / 1000, true);
     }
 
     /** Uses the createNewBlockInternal functionality to avoid time-stamping issues. */

--- a/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
@@ -152,12 +152,12 @@ public class Arguments {
     private boolean dbCompact;
 
     @Option(
-            names = {"--re-import"},
+            names = {"--redo-import"},
             arity = "0..1",
             paramLabel = "<start_height>",
             description =
-                    "drops all databases except for block and index when not given a parameter or starting from 0 and re-imports all blocks")
-    private String reImport = null;
+                    "drops all databases except for block and index when not given a parameter or starting from 0 and redoes import of all known main chain blocks")
+    private String redoImport = null;
 
     /** Compacts the account options into specific commands. */
     public static String[] preProcess(String[] arguments) {
@@ -267,7 +267,7 @@ public class Arguments {
         return dbCompact;
     }
 
-    public String isReImport() {
-        return reImport;
+    public String isRedoImport() {
+        return redoImport;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
@@ -151,6 +151,14 @@ public class Arguments {
             description = "if using leveldb, it triggers its database compaction processes")
     private boolean dbCompact;
 
+    @Option(
+            names = {"--re-import"},
+            arity = "0..1",
+            paramLabel = "<start_height>",
+            description =
+                    "drops all databases except for block and index when not given a parameter or starting from 0 and re-imports all blocks")
+    private String reImport = null;
+
     /** Compacts the account options into specific commands. */
     public static String[] preProcess(String[] arguments) {
         List<String> list = new ArrayList<>();
@@ -257,5 +265,9 @@ public class Arguments {
 
     public boolean isDbCompact() {
         return dbCompact;
+    }
+
+    public String isReImport() {
+        return reImport;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -79,7 +79,8 @@ public class Cli {
         DUMP_STATE_SIZE,
         DUMP_STATE,
         DUMP_BLOCKS,
-        DB_COMPACT
+        DB_COMPACT,
+        RE_IMPORT
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -515,11 +516,33 @@ public class Cli {
                 return EXIT;
             }
 
+            if (options.isReImport() != null) {
+                long height = 0L;
+                String parameter = options.isReImport();
+
+                if (parameter.isEmpty()) {
+                    RecoveryUtils.reimportMainChain(height);
+                    return EXIT;
+                } else {
+                    try {
+                        height = Long.parseLong(parameter);
+                    } catch (NumberFormatException e) {
+                        System.out.println(
+                                "The given argument «"
+                                        + parameter
+                                        + "» cannot be converted to a number.");
+                        return ERROR;
+                    }
+                    RecoveryUtils.reimportMainChain(height);
+                    return EXIT;
+                }
+            }
+
             // if no return happened earlier, run the kernel
             return RUN;
         } catch (Exception e) {
             // TODO: should be moved to individual procedures
-            System.out.println("");
+            System.out.println();
             e.printStackTrace();
             return ERROR;
         }
@@ -912,6 +935,9 @@ public class Cli {
         if (options.isDbCompact()) {
             return TaskPriority.DB_COMPACT;
         }
+        if (options.isReImport() != null) {
+            return TaskPriority.RE_IMPORT;
+        }
         return TaskPriority.NONE;
     }
 
@@ -990,6 +1016,10 @@ public class Cli {
         }
         if (breakingTaskPriority.compareTo(TaskPriority.DB_COMPACT) < 0 && options.isDbCompact()) {
             skippedTasks.add("--db-compact");
+        }
+        if (breakingTaskPriority.compareTo(TaskPriority.RE_IMPORT) < 0
+                && options.isReImport() != null) {
+            skippedTasks.add("--re-import");
         }
         return skippedTasks;
     }

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -80,7 +80,7 @@ public class Cli {
         DUMP_STATE,
         DUMP_BLOCKS,
         DB_COMPACT,
-        RE_IMPORT
+        REDO_IMPORT
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -516,12 +516,12 @@ public class Cli {
                 return EXIT;
             }
 
-            if (options.isReImport() != null) {
+            if (options.isRedoImport() != null) {
                 long height = 0L;
-                String parameter = options.isReImport();
+                String parameter = options.isRedoImport();
 
                 if (parameter.isEmpty()) {
-                    RecoveryUtils.reimportMainChain(height);
+                    RecoveryUtils.redoMainChainImport(height);
                     return EXIT;
                 } else {
                     try {
@@ -533,7 +533,7 @@ public class Cli {
                                         + "» cannot be converted to a number.");
                         return ERROR;
                     }
-                    RecoveryUtils.reimportMainChain(height);
+                    RecoveryUtils.redoMainChainImport(height);
                     return EXIT;
                 }
             }
@@ -935,8 +935,8 @@ public class Cli {
         if (options.isDbCompact()) {
             return TaskPriority.DB_COMPACT;
         }
-        if (options.isReImport() != null) {
-            return TaskPriority.RE_IMPORT;
+        if (options.isRedoImport() != null) {
+            return TaskPriority.REDO_IMPORT;
         }
         return TaskPriority.NONE;
     }
@@ -1017,9 +1017,9 @@ public class Cli {
         if (breakingTaskPriority.compareTo(TaskPriority.DB_COMPACT) < 0 && options.isDbCompact()) {
             skippedTasks.add("--db-compact");
         }
-        if (breakingTaskPriority.compareTo(TaskPriority.RE_IMPORT) < 0
-                && options.isReImport() != null) {
-            skippedTasks.add("--re-import");
+        if (breakingTaskPriority.compareTo(TaskPriority.REDO_IMPORT) < 0
+                && options.isRedoImport() != null) {
+            skippedTasks.add("--redo-import");
         }
         return skippedTasks;
     }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -789,8 +789,9 @@ public class AionRepositoryImpl
     public void dropDatabasesExcept(List<String> names) {
         for (IByteArrayKeyValueDatabase db : databaseGroup) {
             if (!names.contains(db.getName().get())) {
-                LOG.warn("Dropping database " + db.toString());
+                LOG.warn("Dropping database " + db.toString() + " ...");
                 db.drop();
+                LOG.warn(db.toString() + " successfully dropped and reopened.");
             }
         }
     }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -780,6 +780,21 @@ public class AionRepositoryImpl
                 + '}';
     }
 
+    /**
+     * Calls {@link IByteArrayKeyValueDatabase#drop()} on all the current databases except for the
+     * ones given in the list by name.
+     *
+     * @param names the names of the databases that should not be dropped
+     */
+    public void dropDatabasesExcept(List<String> names) {
+        for (IByteArrayKeyValueDatabase db : databaseGroup) {
+            if (!names.contains(db.getName().get())) {
+                LOG.warn("Dropping database " + db.toString());
+                db.drop();
+            }
+        }
+    }
+
     @Override
     public void compact() {
         rwLock.writeLock().lock();

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -395,7 +395,7 @@ public class RecoveryUtils {
         CfgAion cfg = CfgAion.inst();
         cfg.dbFromXML();
         cfg.getConsensus().setMining(false);
-        cfg.getDb().setHeapCacheEnabled(false);
+        cfg.getDb().setHeapCacheEnabled(true);
 
         System.out.println("\nRe-importing stored blocks INITIATED...\n");
 

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -528,7 +528,7 @@ public class RecoveryUtils {
                     }
 
                     if (currentBlock % stepSize == 0) {
-                        long time = System.currentTimeMillis() - start;
+                        double time = System.currentTimeMillis() - start;
 
                         double timePerBlock = time / (currentBlock - startHeight + 1);
                         long remainingBlocks = topBlockNumber - currentBlock;
@@ -538,9 +538,9 @@ public class RecoveryUtils {
                                 "Finished with blocks up to "
                                         + currentBlock
                                         + " in "
-                                        + time
+                                        + String.format("%.0f", time)
                                         + " ms (under "
-                                        + (time / 60_000 + 1)
+                                        + String.format("%.0f", time / 60_000 + 1)
                                         + " min). The average time per block is < "
                                         + String.format("%.0f", timePerBlock + 1)
                                         + " ms. Completion for remaining "

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -391,6 +391,11 @@ public class RecoveryUtils {
      *     them differently.
      */
     public static void redoMainChainImport(long startHeight) {
+        if (startHeight < 0) {
+            System.out.println("Negative values are not valid as starting height. Nothing to do.");
+            return;
+        }
+
         // ensure mining is disabled
         CfgAion cfg = CfgAion.inst();
         cfg.dbFromXML();
@@ -440,104 +445,113 @@ public class RecoveryUtils {
                 currentBlock = startHeight;
             }
 
-            chain.setBestBlock(startBlock);
-
-            long topBlockNumber = block.getNumber();
-            long stepSize = 10_000L;
-
-            Pair<ImportResult, AionBlockSummary> result;
-            final int THOUSAND_MS = 1000;
-
             boolean fail = false;
 
-            long start = System.currentTimeMillis();
+            if (startBlock == null) {
+                System.out.println(
+                        "The main chain block at level "
+                                + currentBlock
+                                + " is missing from the database. Cannot continue importing stored blocks.");
+                fail = true;
+            } else {
+                chain.setBestBlock(startBlock);
 
-            // import in increments of 10k blocks
-            while (currentBlock <= topBlockNumber) {
-                block = store.getChainBlockByNumber(currentBlock);
-                if (block == null) {
-                    System.out.println(
-                            "The main chain block at level "
-                                    + currentBlock
-                                    + " is missing from the database. Cannot continue importing stored blocks.");
-                    fail = true;
-                    break;
-                }
+                long topBlockNumber = block.getNumber();
+                long stepSize = 10_000L;
 
-                try {
-                    result =
-                            chain.tryToConnectAndFetchSummary(
-                                    block, System.currentTimeMillis() / THOUSAND_MS, false);
-                } catch (Throwable t) {
-                    // we want to see the exception and the block where it occurred
-                    t.printStackTrace();
-                    if (t.getMessage() != null
-                            && t.getMessage().contains("Invalid Trie state, missing node ")) {
+                Pair<ImportResult, AionBlockSummary> result;
+                final int THOUSAND_MS = 1000;
+
+                long start = System.currentTimeMillis();
+
+                // import in increments of 10k blocks
+                while (currentBlock <= topBlockNumber) {
+                    block = store.getChainBlockByNumber(currentBlock);
+                    if (block == null) {
                         System.out.println(
-                                "The exception above is likely due to a pruned database and NOT a consensus problem.\n"
-                                        + "Rebuild the full state by editing the config.xml file or running ./aion.sh --state FULL.\n");
-                    }
-                    result =
-                            new Pair<>() {
-                                @Override
-                                public AionBlockSummary setValue(AionBlockSummary value) {
-                                    return null;
-                                }
-
-                                @Override
-                                public ImportResult getLeft() {
-                                    return ImportResult.INVALID_BLOCK;
-                                }
-
-                                @Override
-                                public AionBlockSummary getRight() {
-                                    return null;
-                                }
-                            };
-
-                    fail = true;
-                }
-
-                if (!result.getLeft().isSuccessful()) {
-                    System.out.println("Consensus break at block:\n" + block);
-                    System.out.println(
-                            "Import attempt returned result "
-                                    + result.getLeft()
-                                    + " with summary\n"
-                                    + result.getRight());
-
-                    if (repo.isValidRoot(store.getBestBlock().getStateRoot())) {
-                        System.out.println("The repository state trie was:\n");
-                        System.out.println(repo.getTrieDump());
+                                "The main chain block at level "
+                                        + currentBlock
+                                        + " is missing from the database. Cannot continue importing stored blocks.");
+                        fail = true;
+                        break;
                     }
 
-                    fail = true;
-                    break;
+                    try {
+                        result =
+                                chain.tryToConnectAndFetchSummary(
+                                        block, System.currentTimeMillis() / THOUSAND_MS, false);
+                    } catch (Throwable t) {
+                        // we want to see the exception and the block where it occurred
+                        t.printStackTrace();
+                        if (t.getMessage() != null
+                                && t.getMessage().contains("Invalid Trie state, missing node ")) {
+                            System.out.println(
+                                    "The exception above is likely due to a pruned database and NOT a consensus problem.\n"
+                                            + "Rebuild the full state by editing the config.xml file or running ./aion.sh --state FULL.\n");
+                        }
+                        result =
+                                new Pair<>() {
+                                    @Override
+                                    public AionBlockSummary setValue(AionBlockSummary value) {
+                                        return null;
+                                    }
+
+                                    @Override
+                                    public ImportResult getLeft() {
+                                        return ImportResult.INVALID_BLOCK;
+                                    }
+
+                                    @Override
+                                    public AionBlockSummary getRight() {
+                                        return null;
+                                    }
+                                };
+
+                        fail = true;
+                    }
+
+                    if (!result.getLeft().isSuccessful()) {
+                        System.out.println("Consensus break at block:\n" + block);
+                        System.out.println(
+                                "Import attempt returned result "
+                                        + result.getLeft()
+                                        + " with summary\n"
+                                        + result.getRight());
+
+                        if (repo.isValidRoot(store.getBestBlock().getStateRoot())) {
+                            System.out.println("The repository state trie was:\n");
+                            System.out.println(repo.getTrieDump());
+                        }
+
+                        fail = true;
+                        break;
+                    }
+
+                    if (currentBlock % stepSize == 0) {
+                        long time = System.currentTimeMillis() - start;
+
+                        double timePerBlock = time / currentBlock;
+                        long remainingBlocks = topBlockNumber - currentBlock;
+                        double estimate =
+                                (timePerBlock * remainingBlocks) / 60_000 + 1; // in minutes
+                        System.out.println(
+                                "Finished with blocks up to "
+                                        + currentBlock
+                                        + " in "
+                                        + time
+                                        + " ms (under "
+                                        + (time / 60_000 + 1)
+                                        + " min). The average time per block is < "
+                                        + String.format("%.0f", timePerBlock + 1)
+                                        + " ms. Completion for remaining "
+                                        + remainingBlocks
+                                        + " blocks estimated to take "
+                                        + String.format("%.0f", estimate)
+                                        + " min.");
+                    }
+
+                    currentBlock++;
                 }
-
-                if (currentBlock % stepSize == 0) {
-                    long time = System.currentTimeMillis() - start;
-
-                    double timePerBlock = time / currentBlock;
-                    long remainingBlocks = topBlockNumber - currentBlock;
-                    double estimate = (timePerBlock * remainingBlocks) / 60_000 + 1; // in minutes
-                    System.out.println(
-                            "Finished with blocks up to "
-                                    + currentBlock
-                                    + " in "
-                                    + time
-                                    + " ms (under "
-                                    + (time / 60_000 + 1)
-                                    + " min). The average time per block is < "
-                                    + String.format("%.0f", timePerBlock + 1)
-                                    + " ms. Completion for remaining "
-                                    + remainingBlocks
-                                    + " blocks estimated to take "
-                                    + String.format("%.0f", estimate)
-                                    + " min.");
-                }
-
-                currentBlock++;
             }
 
             if (fail) {

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -530,7 +530,7 @@ public class RecoveryUtils {
                     if (currentBlock % stepSize == 0) {
                         long time = System.currentTimeMillis() - start;
 
-                        double timePerBlock = time / currentBlock;
+                        double timePerBlock = time / (currentBlock - startHeight + 1);
                         long remainingBlocks = topBlockNumber - currentBlock;
                         double estimate =
                                 (timePerBlock * remainingBlocks) / 60_000 + 1; // in minutes

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -496,6 +496,12 @@ public class RecoveryUtils {
                                     + result.getLeft()
                                     + " with summary\n"
                                     + result.getRight());
+
+                    if (repo.isValidRoot(store.getBestBlock().getStateRoot())) {
+                        System.out.println("The repository state trie was:\n");
+                        System.out.println(repo.getTrieDump());
+                    }
+
                     fail = true;
                     break;
                 }

--- a/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/RecoveryUtils.java
@@ -414,7 +414,7 @@ public class RecoveryUtils {
         AionBlock block = store.getBestBlock();
         AionBlock startBlock;
         long currentBlock;
-        if (startHeight <= block.getNumber()) {
+        if (block != null && startHeight <= block.getNumber()) {
             System.out.println(
                     "\nRe-importing the main chain from block #"
                             + startHeight
@@ -501,12 +501,17 @@ public class RecoveryUtils {
                 System.out.println("Re-importing stored blocks SUCCESSFUL.");
             }
         } else {
-            System.out.println(
-                    "The given height "
-                            + startHeight
-                            + " is above the best known block "
-                            + block.getNumber()
-                            + ". Nothing to do.");
+            if (block == null) {
+                System.out.println(
+                        "The best known block in null. The given database is likely empty. Nothing to do.");
+            } else {
+                System.out.println(
+                        "The given height "
+                                + startHeight
+                                + " is above the best known block "
+                                + block.getNumber()
+                                + ". Nothing to do.");
+            }
         }
 
         System.out.println("Closing databases...");

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -373,7 +373,7 @@ public class CfgDb {
             props.setProperty(Props.DB_CACHE_SIZE, String.valueOf(128 * (int) Utils.MEGA_BYTE));
 
             props.setProperty(Props.ENABLE_AUTO_COMMIT, "true");
-            props.setProperty(Props.ENABLE_HEAP_CACHE, "false");
+            props.setProperty(Props.ENABLE_HEAP_CACHE, String.valueOf(heap_cache));
             props.setProperty(Props.MAX_HEAP_CACHE_SIZE, "32");
             props.setProperty(Props.ENABLE_HEAP_CACHE_STATS, "false");
 
@@ -388,12 +388,16 @@ public class CfgDb {
         return propSet;
     }
 
+    private boolean heap_cache = false;
+
     public void setHeapCacheEnabled(boolean value) {
         // already disabled when expert==false
         if (expert) {
             for (Map.Entry<String, CfgDbDetails> entry : specificConfig.entrySet()) {
                 entry.getValue().enable_heap_cache = value;
             }
+        } else {
+            heap_cache = true;
         }
     }
 


### PR DESCRIPTION
## Description

Adding a new CLI option `--redo-import` / `--redo-import <start_height>` that imports all the blocks from the genesis block or the given starting block till the top of the chain performing all the consensus checks.

When starting from the genesis block all the other databases are dropped before the reimport starts.

Fixes Issue #560.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [x] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing unit tests + manual tests

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
