### PR TITLE
Step 9: kernel integration (move to canonical vm_api build)

### DIFF
--- a/modAion/src/org/aion/zero/types/AionTransaction.java
+++ b/modAion/src/org/aion/zero/types/AionTransaction.java
@@ -251,7 +251,7 @@ public class AionTransaction extends AbstractTransaction {
     }
 
     @Override
-    public byte getTransactionType() {
+    public byte getTargetVM() {
         if (!parsed) {
             rlpParse();
         }

--- a/modAion/test/org/aion/types/AionTransactionTest.java
+++ b/modAion/test/org/aion/types/AionTransactionTest.java
@@ -20,7 +20,7 @@ public class AionTransactionTest {
         assertArrayEquals(tx.getData(), tx2.getData());
         assertEquals(tx.getEnergyLimit(), tx2.getEnergyLimit());
         assertEquals(tx.getEnergyPrice(), tx2.getEnergyPrice());
-        assertEquals(tx.getTransactionType(), tx2.getTransactionType());
+        assertEquals(tx.getTargetVM(), tx2.getTargetVM());
 
         assertArrayEquals(tx.getTimeStamp(), tx2.getTimeStamp());
         assertArrayEquals(tx.getSignature().toBytes(), tx2.getSignature().toBytes());

--- a/modAionImpl/src/org/aion/zero/impl/valid/TransactionTypeValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/TransactionTypeValidator.java
@@ -24,7 +24,7 @@ public class TransactionTypeValidator {
 
     public boolean isValid(AionTransaction tx) {
         // verify transaction type
-        byte type = tx.getTransactionType();
+        byte type = tx.getTargetVM();
         // the type must be either valid for the FVM
         // or for the AVM when the AVM is enabled
         return isValidFVMTransactionType(type) || (avmEnabled && isValidAVMTransactionType(type));

--- a/modAionImpl/test/org/aion/zero/impl/vm/OpcodeIntegTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/OpcodeIntegTest.java
@@ -121,18 +121,18 @@ public class OpcodeIntegTest {
         // Check that the logs from our internal transactions are as we expect.
         List<IExecutionLog> logs = summary.getReceipt().getLogInfoList();
         assertEquals(12, logs.size());
-        assertArrayEquals(new DataWord(0).getData(), logs.get(0).getLogData());
-        assertArrayEquals(new DataWord(6).getData(), logs.get(1).getLogData());
-        assertArrayEquals(new DataWord(5).getData(), logs.get(2).getLogData());
-        assertArrayEquals(new DataWord(4).getData(), logs.get(3).getLogData());
-        assertArrayEquals(new DataWord(3).getData(), logs.get(4).getLogData());
-        assertArrayEquals(new DataWord(2).getData(), logs.get(5).getLogData());
-        assertArrayEquals(new DataWord(1).getData(), logs.get(6).getLogData());
-        assertArrayEquals(new DataWord(1).getData(), logs.get(7).getLogData());
-        assertArrayEquals(new DataWord(1).getData(), logs.get(8).getLogData());
-        assertArrayEquals(new DataWord(1).getData(), logs.get(9).getLogData());
-        assertArrayEquals(new DataWord(1).getData(), logs.get(10).getLogData());
-        assertArrayEquals(new DataWord(1).getData(), logs.get(11).getLogData());
+        assertArrayEquals(new DataWord(0).getData(), logs.get(0).getData());
+        assertArrayEquals(new DataWord(6).getData(), logs.get(1).getData());
+        assertArrayEquals(new DataWord(5).getData(), logs.get(2).getData());
+        assertArrayEquals(new DataWord(4).getData(), logs.get(3).getData());
+        assertArrayEquals(new DataWord(3).getData(), logs.get(4).getData());
+        assertArrayEquals(new DataWord(2).getData(), logs.get(5).getData());
+        assertArrayEquals(new DataWord(1).getData(), logs.get(6).getData());
+        assertArrayEquals(new DataWord(1).getData(), logs.get(7).getData());
+        assertArrayEquals(new DataWord(1).getData(), logs.get(8).getData());
+        assertArrayEquals(new DataWord(1).getData(), logs.get(9).getData());
+        assertArrayEquals(new DataWord(1).getData(), logs.get(10).getData());
+        assertArrayEquals(new DataWord(1).getData(), logs.get(11).getData());
     }
 
     @Test
@@ -166,14 +166,14 @@ public class OpcodeIntegTest {
         // Check that the logs from our internal transactions are as we expect.
         List<IExecutionLog> logs = summary.getReceipt().getLogInfoList();
         assertEquals(8, logs.size());
-        assertArrayEquals(new DataWord(0).getData(), logs.get(0).getLogData());
-        assertArrayEquals(new DataWord(5).getData(), logs.get(1).getLogData());
-        assertArrayEquals(new DataWord(4).getData(), logs.get(2).getLogData());
-        assertArrayEquals(new DataWord(3).getData(), logs.get(3).getLogData());
-        assertArrayEquals(new DataWord(2).getData(), logs.get(4).getLogData());
-        assertArrayEquals(new DataWord(2).getData(), logs.get(5).getLogData());
-        assertArrayEquals(new DataWord(2).getData(), logs.get(6).getLogData());
-        assertArrayEquals(new DataWord(2).getData(), logs.get(7).getLogData());
+        assertArrayEquals(new DataWord(0).getData(), logs.get(0).getData());
+        assertArrayEquals(new DataWord(5).getData(), logs.get(1).getData());
+        assertArrayEquals(new DataWord(4).getData(), logs.get(2).getData());
+        assertArrayEquals(new DataWord(3).getData(), logs.get(3).getData());
+        assertArrayEquals(new DataWord(2).getData(), logs.get(4).getData());
+        assertArrayEquals(new DataWord(2).getData(), logs.get(5).getData());
+        assertArrayEquals(new DataWord(2).getData(), logs.get(6).getData());
+        assertArrayEquals(new DataWord(2).getData(), logs.get(7).getData());
     }
 
     @Test
@@ -207,14 +207,14 @@ public class OpcodeIntegTest {
         // Check that the logs from our internal transactions are as we expect.
         List<IExecutionLog> logs = summary.getReceipt().getLogInfoList();
         assertEquals(8, logs.size());
-        assertArrayEquals(new DataWord(0).getData(), logs.get(0).getLogData());
-        assertArrayEquals(new DataWord(7).getData(), logs.get(1).getLogData());
-        assertArrayEquals(new DataWord(6).getData(), logs.get(2).getLogData());
-        assertArrayEquals(new DataWord(5).getData(), logs.get(3).getLogData());
-        assertArrayEquals(new DataWord(4).getData(), logs.get(4).getLogData());
-        assertArrayEquals(new DataWord(4).getData(), logs.get(5).getLogData());
-        assertArrayEquals(new DataWord(4).getData(), logs.get(6).getLogData());
-        assertArrayEquals(new DataWord(4).getData(), logs.get(7).getLogData());
+        assertArrayEquals(new DataWord(0).getData(), logs.get(0).getData());
+        assertArrayEquals(new DataWord(7).getData(), logs.get(1).getData());
+        assertArrayEquals(new DataWord(6).getData(), logs.get(2).getData());
+        assertArrayEquals(new DataWord(5).getData(), logs.get(3).getData());
+        assertArrayEquals(new DataWord(4).getData(), logs.get(4).getData());
+        assertArrayEquals(new DataWord(4).getData(), logs.get(5).getData());
+        assertArrayEquals(new DataWord(4).getData(), logs.get(6).getData());
+        assertArrayEquals(new DataWord(4).getData(), logs.get(7).getData());
     }
 
     // ======================================= test CALLCODE =======================================
@@ -583,9 +583,9 @@ public class OpcodeIntegTest {
         // DELEGATECALL     -->     CALLER-DEPLOYER-DEPLOYER-ZERO
         List<IExecutionLog> logs = summary.getReceipt().getLogInfoList();
         assertEquals(3, logs.size());
-        verifyLogData(logs.get(0).getLogData(), calleeContract, callerContract, deployer);
-        verifyLogData(logs.get(1).getLogData(), callerContract, callerContract, deployer);
-        verifyLogData(logs.get(2).getLogData(), callerContract, deployer, deployer);
+        verifyLogData(logs.get(0).getData(), calleeContract, callerContract, deployer);
+        verifyLogData(logs.get(1).getData(), callerContract, callerContract, deployer);
+        verifyLogData(logs.get(2).getData(), callerContract, deployer, deployer);
     }
 
     // ======================================= test SUICIDE ========================================

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -121,7 +121,7 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         txr.getLogInfoList()
                                 .forEach(
                                         bi ->
-                                                bi.getLogTopics()
+                                                bi.getTopics()
                                                         .forEach(
                                                                 lg -> {
                                                                     if (_fltr.isFor(
@@ -151,10 +151,10 @@ public class ApiAion0 extends ApiAion implements IApiAion {
 
                                                                         EvtContract ec =
                                                                                 new EvtContract(
-                                                                                        bi.getLogSourceAddress()
+                                                                                        bi.getSourceAddress()
                                                                                                 .toBytes(),
                                                                                         bi
-                                                                                                .getLogData(),
+                                                                                                .getData(),
                                                                                         blk
                                                                                                 .getHash(),
                                                                                         blk
@@ -2578,17 +2578,17 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                         .map(
                                 log -> {
                                     List<String> topics = new ArrayList<>();
-                                    for (int i = 0; i < log.getLogTopics().size(); i++) {
+                                    for (int i = 0; i < log.getTopics().size(); i++) {
                                         topics.add(
-                                                TypeConverter.toJsonHex(log.getLogTopics().get(i)));
+                                                TypeConverter.toJsonHex(log.getTopics().get(i)));
                                     }
 
                                     return Message.t_LgEle
                                             .newBuilder()
-                                            .setData(ByteString.copyFrom(log.getLogData()))
+                                            .setData(ByteString.copyFrom(log.getData()))
                                             .setAddress(
                                                     ByteString.copyFrom(
-                                                            log.getLogSourceAddress().toBytes()))
+                                                            log.getSourceAddress().toBytes()))
                                             .addAllTopics(topics)
                                             .build();
                                 })
@@ -2710,10 +2710,10 @@ public class ApiAion0 extends ApiAion implements IApiAion {
         JSONArray logs = new JSONArray();
         for (IExecutionLog l : _logs) {
             JSONArray log = new JSONArray();
-            log.put(l.getLogSourceAddress().toString()); // address
-            log.put(ByteUtil.toHexString(l.getLogData())); // data
+            log.put(l.getSourceAddress().toString()); // address
+            log.put(ByteUtil.toHexString(l.getData())); // data
             JSONArray topics = new JSONArray();
-            for (byte[] topic : l.getLogTopics()) {
+            for (byte[] topic : l.getTopics()) {
                 topics.put(ByteUtil.toHexString(topic));
             }
             log.put(topics); // topics
@@ -2847,13 +2847,13 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                                                                                     new ArrayList<>();
                                                                                     for (int i = 0;
                                                                                             i
-                                                                                                    < log.getLogTopics()
+                                                                                                    < log.getTopics()
                                                                                                             .size();
                                                                                             i++) {
                                                                                         topics.add(
                                                                                                 TypeConverter
                                                                                                         .toJsonHex(
-                                                                                                                log.getLogTopics()
+                                                                                                                log.getTopics()
                                                                                                                         .get(
                                                                                                                                 i)));
                                                                                     }
@@ -2865,11 +2865,11 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                                                                                     ByteString
                                                                                                             .copyFrom(
                                                                                                                     log
-                                                                                                                            .getLogData()))
+                                                                                                                            .getData()))
                                                                                             .setAddress(
                                                                                                     ByteString
                                                                                                             .copyFrom(
-                                                                                                                    log.getLogSourceAddress()
+                                                                                                                    log.getSourceAddress()
                                                                                                                             .toBytes()))
                                                                                             .addAllTopics(
                                                                                                     topics)

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -2145,10 +2145,10 @@ public class ApiWeb3Aion extends ApiAion {
         JSONArray logs = new JSONArray();
         for (IExecutionLog l : txInfo.getReceipt().getLogInfoList()) {
             JSONObject log = new JSONObject();
-            log.put("address", l.getLogSourceAddress().toString());
-            log.put("data", TypeConverter.toJsonHex(l.getLogData()));
+            log.put("address", l.getSourceAddress().toString());
+            log.put("data", TypeConverter.toJsonHex(l.getData()));
             JSONArray topics = new JSONArray();
-            for (byte[] topic : l.getLogTopics()) {
+            for (byte[] topic : l.getTopics()) {
                 topics.put(TypeConverter.toJsonHex(topic));
             }
             log.put("topics", topics);

--- a/modApiServer/src/org/aion/api/server/types/FltrLg.java
+++ b/modApiServer/src/org/aion/api/server/types/FltrLg.java
@@ -159,8 +159,8 @@ public final class FltrLg extends Fltr {
 
     public boolean matchesExactly(IExecutionLog logInfo) {
         initBlooms();
-        if (!matchesContractAddress(logInfo.getLogSourceAddress().toBytes())) return false;
-        List<byte[]> logTopics = logInfo.getLogTopics();
+        if (!matchesContractAddress(logInfo.getSourceAddress().toBytes())) return false;
+        List<byte[]> logTopics = logInfo.getTopics();
         for (int i = 0; i < this.topics.size(); i++) {
             if (i >= logTopics.size()) return false;
             byte[][] orTopics = topics.get(i);

--- a/modApiServer/src/org/aion/api/server/types/TxRecptLg.java
+++ b/modApiServer/src/org/aion/api/server/types/TxRecptLg.java
@@ -35,13 +35,13 @@ public class TxRecptLg {
         this.transactionIndex =
                 (b == null || txIndex == null) ? null : TypeConverter.toJsonHex(txIndex);
         this.transactionHash = TypeConverter.toJsonHex(tx.getTransactionHash());
-        this.address = TypeConverter.toJsonHex(logInfo.getLogSourceAddress().toString());
-        this.data = TypeConverter.toJsonHex(logInfo.getLogData());
+        this.address = TypeConverter.toJsonHex(logInfo.getSourceAddress().toString());
+        this.data = TypeConverter.toJsonHex(logInfo.getData());
         this.removed = !isMainchain;
 
-        this.topics = new String[logInfo.getLogTopics().size()];
+        this.topics = new String[logInfo.getTopics().size()];
         for (int i = 0, m = this.topics.length; i < m; i++) {
-            this.topics[i] = TypeConverter.toJsonHex(logInfo.getLogTopics().get(i));
+            this.topics[i] = TypeConverter.toJsonHex(logInfo.getTopics().get(i));
         }
     }
 }

--- a/modMcf/src/org/aion/mcf/types/AbstractTransaction.java
+++ b/modMcf/src/org/aion/mcf/types/AbstractTransaction.java
@@ -106,7 +106,7 @@ public abstract class AbstractTransaction implements ITransaction {
 
     public abstract void setNrgConsume(long consume);
 
-    public abstract byte getTransactionType();
+    public abstract byte getTargetVM();
 
     public abstract BigInteger getNonceBI();
 

--- a/modMcf/src/org/aion/mcf/vm/types/KernelInterfaceForFastVM.java
+++ b/modMcf/src/org/aion/mcf/vm/types/KernelInterfaceForFastVM.java
@@ -29,14 +29,19 @@ public class KernelInterfaceForFastVM implements KernelInterface {
     // These 4 methods are temporary. Really any of this type of functionality should be moved out
     // into the kernel.
     @Override
-    public KernelInterfaceForFastVM startTracking() {
+    public KernelInterfaceForFastVM makeChildKernelInterface() {
         return new KernelInterfaceForFastVM(
                 this.repositoryCache.startTracking(), this.allowNonceIncrement, this.isLocalCall);
     }
 
     @Override
-    public void flush() {
+    public void commit() {
         this.repositoryCache.flush();
+    }
+
+    @Override
+    public void commitTo(KernelInterface target) {
+        this.repositoryCache.flushTo(((KernelInterfaceForFastVM) target).repositoryCache, false);
     }
 
     public void rollback() {

--- a/modMcf/src/org/aion/mcf/vm/types/Log.java
+++ b/modMcf/src/org/aion/mcf/vm/types/Log.java
@@ -44,17 +44,17 @@ public class Log implements IExecutionLog {
     }
 
     @Override
-    public Address getLogSourceAddress() {
+    public Address getSourceAddress() {
         return addr;
     }
 
     @Override
-    public List<byte[]> getLogTopics() {
+    public List<byte[]> getTopics() {
         return topics;
     }
 
     @Override
-    public byte[] getLogData() {
+    public byte[] getData() {
         return data;
     }
 

--- a/modPrecompiled/src/org/aion/precompiled/PrecompiledTransactionResult.java
+++ b/modPrecompiled/src/org/aion/precompiled/PrecompiledTransactionResult.java
@@ -123,7 +123,7 @@ public class PrecompiledTransactionResult implements TransactionResult {
     }
 
     @Override
-    public void setOutput(byte[] output) {
+    public void setReturnData(byte[] output) {
         this.output = (output == null) ? new byte[0] : output;
     }
 
@@ -138,7 +138,7 @@ public class PrecompiledTransactionResult implements TransactionResult {
     }
 
     @Override
-    public byte[] getOutput() {
+    public byte[] getReturnData() {
         return this.output;
     }
 

--- a/modPrecompiled/test/org/aion/precompiled/TRS/TRShelpers.java
+++ b/modPrecompiled/test/org/aion/precompiled/TRS/TRShelpers.java
@@ -89,7 +89,7 @@ class TRShelpers {
         if (!res.getResultCode().equals(PrecompiledResultCode.SUCCESS)) {
             fail("Unable to create contract!");
         }
-        Address contract = new AionAddress(res.getOutput());
+        Address contract = new AionAddress(res.getReturnData());
         tempAddrs.add(contract);
         repo.incrementNonce(owner);
         repo.flush();
@@ -895,7 +895,7 @@ class TRShelpers {
         for (Address acc : contributors) {
             PrecompiledTransactionResult res = newTRSqueryContract(acc).execute(input, COST);
             assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-            BigDecimal frac = new BigDecimal(new BigInteger(res.getOutput())).movePointLeft(18);
+            BigDecimal frac = new BigDecimal(new BigInteger(res.getReturnData())).movePointLeft(18);
             assertEquals(expectedFraction, frac);
         }
     }

--- a/modPrecompiled/test/org/aion/precompiled/TRS/TRSqueryContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/TRS/TRSqueryContractTest.java
@@ -137,7 +137,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
 
         // Test on a contract address that looks real, uses TRS prefix.
         byte[] phony = acct.toBytes();
@@ -146,7 +146,7 @@ public class TRSqueryContractTest extends TRShelpers {
         res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -157,7 +157,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -168,7 +168,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -179,7 +179,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getTrueContractOutput(), res.getOutput());
+        assertArrayEquals(getTrueContractOutput(), res.getReturnData());
     }
 
     // <------------------------------------IS LOCKED TRS TESTS------------------------------------>
@@ -212,7 +212,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
 
         // Test on a contract address that looks real, uses TRS prefix.
         byte[] phony = acct.toBytes();
@@ -221,7 +221,7 @@ public class TRSqueryContractTest extends TRShelpers {
         res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -232,7 +232,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -243,7 +243,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getTrueContractOutput(), res.getOutput());
+        assertArrayEquals(getTrueContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -254,7 +254,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getTrueContractOutput(), res.getOutput());
+        assertArrayEquals(getTrueContractOutput(), res.getReturnData());
     }
 
     // <------------------------------IS DIR DEPO ENABLED TRS TESTS-------------------------------->
@@ -287,7 +287,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
 
         // Test on a contract address that looks real, uses TRS prefix.
         byte[] phony = acct.toBytes();
@@ -296,7 +296,7 @@ public class TRSqueryContractTest extends TRShelpers {
         res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -307,7 +307,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test
@@ -318,7 +318,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertArrayEquals(getTrueContractOutput(), res.getOutput());
+        assertArrayEquals(getTrueContractOutput(), res.getReturnData());
     }
 
     // <--------------------------------------PERIOD TESTS----------------------------------------->
@@ -361,7 +361,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = getPeriodInput(contract);
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(BigInteger.ZERO, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ZERO, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -373,7 +373,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = getPeriodInput(contract);
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(BigInteger.ZERO, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ZERO, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -385,7 +385,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = getPeriodInput(contract);
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(BigInteger.ZERO, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ZERO, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -397,19 +397,19 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = getPeriodInput(contract);
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        int period1 = new BigInteger(res.getOutput()).intValue();
+        int period1 = new BigInteger(res.getReturnData()).intValue();
 
         // Now we should be in period 1 forever.
         AbstractTRS trs = newTRSqueryContract(AION);
         mockBlockchain(getContractTimestamp(trs, contract) + 2);
         res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        int period2 = new BigInteger(res.getOutput()).intValue();
+        int period2 = new BigInteger(res.getReturnData()).intValue();
 
         mockBlockchain(getContractTimestamp(trs, contract) + 5);
         res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        int period3 = new BigInteger(res.getOutput()).intValue();
+        int period3 = new BigInteger(res.getReturnData()).intValue();
 
         assertEquals(0, period1);
         assertTrue(period2 > period1);
@@ -429,18 +429,18 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = getPeriodInput(contract);
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        int period1 = new BigInteger(res.getOutput()).intValue();
+        int period1 = new BigInteger(res.getReturnData()).intValue();
 
         // We are in last period now.
         mockBlockchain(getContractTimestamp(trs, contract) + 4);
         res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        int period2 = new BigInteger(res.getOutput()).intValue();
+        int period2 = new BigInteger(res.getReturnData()).intValue();
 
         mockBlockchain(getContractTimestamp(trs, contract) + 9);
         res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        int period3 = new BigInteger(res.getOutput()).intValue();
+        int period3 = new BigInteger(res.getReturnData()).intValue();
 
         assertTrue(period1 > 0);
         assertTrue(period2 > period1);
@@ -514,7 +514,7 @@ public class TRSqueryContractTest extends TRShelpers {
         byte[] input = getPeriodAtInput(contract, numBlocks);
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(BigInteger.ZERO, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ZERO, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -531,7 +531,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertEquals(expectedPeriod, new BigInteger(res.getOutput()));
+        assertEquals(expectedPeriod, new BigInteger(res.getReturnData()));
 
         blockNum = 2;
         timestamp++;
@@ -541,7 +541,7 @@ public class TRSqueryContractTest extends TRShelpers {
         res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertEquals(expectedPeriod, new BigInteger(res.getOutput()));
+        assertEquals(expectedPeriod, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -563,7 +563,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertEquals(BigInteger.valueOf(periods), new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.valueOf(periods), new BigInteger(res.getReturnData()));
 
         blockNum = numBlocks;
         timestamp += 15;
@@ -572,7 +572,7 @@ public class TRSqueryContractTest extends TRShelpers {
         res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertEquals(BigInteger.valueOf(periods), new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.valueOf(periods), new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -590,7 +590,7 @@ public class TRSqueryContractTest extends TRShelpers {
         PrecompiledTransactionResult res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertEquals(BigInteger.ONE, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ONE, new BigInteger(res.getReturnData()));
 
         blockNum = numBlocks;
         timestamp += 4;
@@ -599,7 +599,7 @@ public class TRSqueryContractTest extends TRShelpers {
         res = newTRSqueryContract(AION).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertEquals(BigInteger.ONE, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ONE, new BigInteger(res.getReturnData()));
     }
 
     // <-------------------------AVAILABLE FOR WITHDRAWAL AT TRS TESTS----------------------------->
@@ -704,7 +704,7 @@ public class TRSqueryContractTest extends TRShelpers {
         for (Address acc : contributors) {
             PrecompiledTransactionResult res = newTRSqueryContract(acc).execute(input, COST);
             assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-            BigDecimal frac = new BigDecimal(new BigInteger(res.getOutput())).movePointLeft(18);
+            BigDecimal frac = new BigDecimal(new BigInteger(res.getReturnData())).movePointLeft(18);
             assertEquals(expectedFraction, frac);
         }
     }
@@ -744,7 +744,7 @@ public class TRSqueryContractTest extends TRShelpers {
         for (Address acc : contributors) {
             PrecompiledTransactionResult res = newTRSqueryContract(acc).execute(input, COST);
             assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-            BigDecimal frac = new BigDecimal(new BigInteger(res.getOutput())).movePointLeft(18);
+            BigDecimal frac = new BigDecimal(new BigInteger(res.getReturnData())).movePointLeft(18);
             assertEquals(expectedFraction, frac);
         }
     }

--- a/modPrecompiled/test/org/aion/precompiled/TRS/TRSstateContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/TRS/TRSstateContractTest.java
@@ -169,13 +169,13 @@ public class TRSstateContractTest extends TRShelpers {
         Address caller = getNewExistentAccount(BigInteger.ZERO);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = new AionAddress(res.getOutput());
+        Address contract = new AionAddress(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(caller, getOwner(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -183,12 +183,12 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(true, false, 1, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(AION);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        assertEquals(AION, getOwner(trs, new AionAddress(res.getOutput())));
+        assertEquals(AION, getOwner(trs, new AionAddress(res.getReturnData())));
     }
 
     @Test
@@ -199,13 +199,13 @@ public class TRSstateContractTest extends TRShelpers {
         Address caller = getNewExistentAccount(BigInteger.ZERO);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(periods, getPeriods(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -214,13 +214,13 @@ public class TRSstateContractTest extends TRShelpers {
         periods = 1200;
         input = getCreateInput(false, false, periods, BigInteger.ZERO, 0);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(periods, getPeriods(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -230,13 +230,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(true, false, periods, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(AION);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(periods, getPeriods(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(AION);
         repo.flush();
@@ -245,13 +245,13 @@ public class TRSstateContractTest extends TRShelpers {
         periods = 1200;
         input = getCreateInput(true, false, periods, BigInteger.ZERO, 0);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(periods, getPeriods(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -266,39 +266,39 @@ public class TRSstateContractTest extends TRShelpers {
         Address caller = getNewExistentAccount(BigInteger.ZERO);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(periods, getPeriods(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
 
         input = getCreateInput(false, false, periods2, BigInteger.ZERO, 0);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(periods2, getPeriods(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
 
         input = getCreateInput(false, false, periods3, BigInteger.ZERO, 0);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(periods3, getPeriods(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -308,26 +308,26 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(isTest, false, 1, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(getNewExistentAccount(BigInteger.ZERO));
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(isTest, isTestContract(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         // When true
         isTest = true;
         input = getCreateInput(isTest, false, 1, BigInteger.ZERO, 0);
         trs = newTRSstateContract(AION);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(isTest, isTestContract(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -338,13 +338,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, isDirectDeposit, 1, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(isDirectDeposit, isDirectDepositEnabled(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -353,13 +353,13 @@ public class TRSstateContractTest extends TRShelpers {
         isDirectDeposit = true;
         input = getCreateInput(false, isDirectDeposit, 1, BigInteger.ZERO, 0);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(isDirectDeposit, isDirectDepositEnabled(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -369,13 +369,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(BigDecimal.ZERO, getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -383,13 +383,13 @@ public class TRSstateContractTest extends TRShelpers {
         // Test 18 shifts.
         input = getCreateInput(false, false, 1, BigInteger.ZERO, 18);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(BigDecimal.ZERO.movePointLeft(18), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -400,13 +400,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, raw, 0);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -415,13 +415,13 @@ public class TRSstateContractTest extends TRShelpers {
         raw = new BigInteger("100000000000000000000");
         input = getCreateInput(false, false, 1, raw, 18);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw).movePointLeft(18), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -477,13 +477,13 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, raw, 18);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw).movePointLeft(18), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -493,13 +493,13 @@ public class TRSstateContractTest extends TRShelpers {
         input = getCreateInput(false, false, 1, raw, 18);
         trs = newTRSstateContract(caller);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw).movePointLeft(18), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -509,13 +509,13 @@ public class TRSstateContractTest extends TRShelpers {
         input = getCreateInput(false, false, 1, raw, 18);
         trs = newTRSstateContract(caller);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw).movePointLeft(18), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -543,13 +543,13 @@ public class TRSstateContractTest extends TRShelpers {
         input = getCreateInput(false, false, 1, raw, shifts);
         trs = newTRSstateContract(caller);
         res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw).movePointLeft(shifts), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -559,13 +559,13 @@ public class TRSstateContractTest extends TRShelpers {
         input = getCreateInput(false, false, 1, raw, shifts);
         trs = newTRSstateContract(caller);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw).movePointLeft(shifts), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
         repo.incrementNonce(caller);
         repo.flush();
@@ -575,13 +575,13 @@ public class TRSstateContractTest extends TRShelpers {
         input = getCreateInput(false, false, 1, raw, shifts);
         trs = newTRSstateContract(caller);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         assertEquals(new BigDecimal(raw).movePointLeft(shifts), getPercentage(trs, contract));
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
     }
 
     @Test
@@ -591,7 +591,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
         tempAddrs.add(contract);
@@ -605,9 +605,9 @@ public class TRSstateContractTest extends TRShelpers {
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertNotEquals(contract, AionAddress.wrap(res.getOutput()));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
-        contract = AionAddress.wrap(res.getOutput());
+        assertNotEquals(contract, AionAddress.wrap(res.getReturnData()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
+        contract = AionAddress.wrap(res.getReturnData());
 
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
@@ -615,10 +615,10 @@ public class TRSstateContractTest extends TRShelpers {
         // Same caller as original & nonce hasn't changed, should be same contract addr returned.
         trs = newTRSstateContract(caller);
         res = trs.execute(input, COST);
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertEquals(contract, AionAddress.wrap(res.getOutput()));
+        assertEquals(contract, AionAddress.wrap(res.getReturnData()));
 
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
@@ -630,10 +630,10 @@ public class TRSstateContractTest extends TRShelpers {
         res = trs.execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(0, res.getEnergyRemaining());
-        assertNotEquals(contract, AionAddress.wrap(res.getOutput()));
-        tempAddrs.add(AionAddress.wrap(res.getOutput()));
+        assertNotEquals(contract, AionAddress.wrap(res.getReturnData()));
+        tempAddrs.add(AionAddress.wrap(res.getReturnData()));
 
-        contract = AionAddress.wrap(res.getOutput());
+        contract = AionAddress.wrap(res.getReturnData());
         assertFalse(isContractLocked(trs, contract));
         assertFalse(isContractLive(trs, contract));
     }
@@ -645,7 +645,7 @@ public class TRSstateContractTest extends TRShelpers {
         byte[] input = getCreateInput(false, false, 1, BigInteger.ZERO, 0);
         TRSstateContract trs = newTRSstateContract(caller);
         PrecompiledTransactionResult res = trs.execute(input, COST + diff);
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(diff, res.getEnergyRemaining());
         tempAddrs.add(contract);
@@ -665,7 +665,7 @@ public class TRSstateContractTest extends TRShelpers {
         long after = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        Address contract = AionAddress.wrap(res.getOutput());
+        Address contract = AionAddress.wrap(res.getReturnData());
         long timestamp = getContractTimestamp(trs, contract);
 
         assertTrue(timestamp >= before);
@@ -1539,12 +1539,12 @@ public class TRSstateContractTest extends TRShelpers {
         input = getIsLockedInput(contract);
         PrecompiledTransactionResult res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
 
         input = getIsLiveInput(contract);
         res = newTRSqueryContract(acct).execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertArrayEquals(getFalseContractOutput(), res.getOutput());
+        assertArrayEquals(getFalseContractOutput(), res.getReturnData());
     }
 
     @Test

--- a/modPrecompiled/test/org/aion/precompiled/contracts/ATB/BridgeControllerOwnerTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/ATB/BridgeControllerOwnerTest.java
@@ -60,9 +60,9 @@ public class BridgeControllerOwnerTest {
         assertThat(logs.size()).isEqualTo(1);
 
         IExecutionLog changedOwnerLog = logs.get(0);
-        assertThat(changedOwnerLog.getLogData()).isEqualTo(ByteUtil.EMPTY_BYTE_ARRAY);
-        assertThat(changedOwnerLog.getLogTopics().get(0)).isEqualTo(transferOwnership);
-        assertThat(changedOwnerLog.getLogTopics().get(1)).isEqualTo(newOwner);
+        assertThat(changedOwnerLog.getData()).isEqualTo(ByteUtil.EMPTY_BYTE_ARRAY);
+        assertThat(changedOwnerLog.getTopics().get(0)).isEqualTo(transferOwnership);
+        assertThat(changedOwnerLog.getTopics().get(1)).isEqualTo(newOwner);
     }
 
     @Test

--- a/modPrecompiled/test/org/aion/precompiled/contracts/ATB/BridgeTransferTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/ATB/BridgeTransferTest.java
@@ -318,9 +318,9 @@ public class BridgeTransferTest {
         // check status of result
         assertThat(tuple.results.controllerResult).isEqualTo(ErrCode.NO_ERROR);
         assertThat(this.context.getSideEffects().getExecutionLogs().size()).isEqualTo(1);
-        assertThat(this.context.getSideEffects().getExecutionLogs().get(0).getLogTopics().get(0))
+        assertThat(this.context.getSideEffects().getExecutionLogs().get(0).getTopics().get(0))
                 .isEqualTo(BridgeEventSig.SUCCESSFUL_TXHASH.getHashed());
-        assertThat(this.context.getSideEffects().getExecutionLogs().get(0).getLogTopics().get(1))
+        assertThat(this.context.getSideEffects().getExecutionLogs().get(0).getTopics().get(1))
                 .isEqualTo(aionTransactionHash);
 
         // one transfer should have gone through, second shouldn't
@@ -362,7 +362,7 @@ public class BridgeTransferTest {
 
         List<IExecutionLog> logs = this.context.getSideEffects().getExecutionLogs();
         for (int i = 0; i < 511; i++) {
-            List<byte[]> topics = logs.get(i).getLogTopics();
+            List<byte[]> topics = logs.get(i).getTopics();
             assertThat(topics.get(0)).isEqualTo(BridgeEventSig.DISTRIBUTED.getHashed());
             assertThat(topics.get(1)).isEqualTo(transfers[i].getSourceTransactionHash());
             assertThat(topics.get(2)).isEqualTo(transfers[i].getRecipient());
@@ -373,7 +373,7 @@ public class BridgeTransferTest {
 
         // for the last element
         {
-            List<byte[]> topics = logs.get(511).getLogTopics();
+            List<byte[]> topics = logs.get(511).getTopics();
             assertThat(topics.get(0)).isEqualTo(BridgeEventSig.PROCESSED_BUNDLE.getHashed());
             assertThat(topics.get(1)).isEqualTo(blockHash);
             assertThat(topics.get(2)).isEqualTo(tuple.bundleHash);

--- a/modPrecompiled/test/org/aion/precompiled/contracts/ATB/TokenBridgeContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/ATB/TokenBridgeContractTest.java
@@ -78,7 +78,7 @@ public class TokenBridgeContractTest {
         assertThat(this.connector.getInitialized()).isFalse();
         PrecompiledTransactionResult result =
                 this.contract.execute(BridgeFuncSig.PURE_OWNER.getBytes(), DEFAULT_NRG);
-        assertThat(result.getOutput()).isEqualTo(OWNER_ADDR.toBytes());
+        assertThat(result.getReturnData()).isEqualTo(OWNER_ADDR.toBytes());
         assertThat(result.getEnergyRemaining()).isEqualTo(0L);
         assertThat(this.connector.getInitialized()).isTrue();
     }
@@ -110,7 +110,7 @@ public class TokenBridgeContractTest {
 
         PrecompiledTransactionResult result =
                 this.contract.execute(BridgeFuncSig.PURE_NEW_OWNER.getBytes(), DEFAULT_NRG);
-        assertThat(result.getOutput()).isEqualTo(newOwner);
+        assertThat(result.getReturnData()).isEqualTo(newOwner);
         assertThat(result.getEnergyRemaining()).isEqualTo(0L);
     }
 
@@ -270,7 +270,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         byte[][] signatures = new byte[members.length][];
@@ -327,7 +327,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(submitBundleContext.getTransactionHash());
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
@@ -369,22 +369,22 @@ public class TokenBridgeContractTest {
         i = 0;
         for (IExecutionLog l : submitBundleContext.getSideEffects().getExecutionLogs()) {
             // verify address is correct
-            assertThat(l.getLogSourceAddress()).isEqualTo(CONTRACT_ADDR);
+            assertThat(l.getSourceAddress()).isEqualTo(CONTRACT_ADDR);
 
             // on the 11th log, it should be the processed bundle event
             if (i == 10) {
-                assertThat(l.getLogTopics().get(0))
+                assertThat(l.getTopics().get(0))
                         .isEqualTo(BridgeEventSig.PROCESSED_BUNDLE.getHashed());
-                assertThat(l.getLogTopics().get(1)).isEqualTo(blockHash);
-                assertThat(l.getLogTopics().get(2)).isEqualTo(payloadHash);
+                assertThat(l.getTopics().get(1)).isEqualTo(blockHash);
+                assertThat(l.getTopics().get(2)).isEqualTo(payloadHash);
                 continue;
             }
 
             // otherwise we expect a Distributed event
-            assertThat(l.getLogTopics().get(0)).isEqualTo(BridgeEventSig.DISTRIBUTED.getHashed());
-            assertThat(l.getLogTopics().get(1)).isEqualTo(transfers[i].getSourceTransactionHash());
-            assertThat(l.getLogTopics().get(2)).isEqualTo(transfers[i].getRecipient());
-            assertThat(new BigInteger(1, l.getLogTopics().get(3)))
+            assertThat(l.getTopics().get(0)).isEqualTo(BridgeEventSig.DISTRIBUTED.getHashed());
+            assertThat(l.getTopics().get(1)).isEqualTo(transfers[i].getSourceTransactionHash());
+            assertThat(l.getTopics().get(2)).isEqualTo(transfers[i].getRecipient());
+            assertThat(new BigInteger(1, l.getTopics().get(3)))
                     .isEqualTo(transfers[i].getTransferValue());
             i++;
         }
@@ -463,7 +463,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         byte[][] signatures = new byte[members.length][];
@@ -520,7 +520,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(submitBundleContext.getTransactionHash());
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
@@ -562,22 +562,22 @@ public class TokenBridgeContractTest {
         i = 0;
         for (IExecutionLog l : submitBundleContext.getSideEffects().getExecutionLogs()) {
             // verify address is correct
-            assertThat(l.getLogSourceAddress()).isEqualTo(CONTRACT_ADDR);
+            assertThat(l.getSourceAddress()).isEqualTo(CONTRACT_ADDR);
 
             // on the 11th log, it should be the processed bundle event
             if (i == 10) {
-                assertThat(l.getLogTopics().get(0))
+                assertThat(l.getTopics().get(0))
                         .isEqualTo(BridgeEventSig.PROCESSED_BUNDLE.getHashed());
-                assertThat(l.getLogTopics().get(1)).isEqualTo(blockHash);
-                assertThat(l.getLogTopics().get(2)).isEqualTo(payloadHash);
+                assertThat(l.getTopics().get(1)).isEqualTo(blockHash);
+                assertThat(l.getTopics().get(2)).isEqualTo(payloadHash);
                 continue;
             }
 
             // otherwise we expect a Distributed event
-            assertThat(l.getLogTopics().get(0)).isEqualTo(BridgeEventSig.DISTRIBUTED.getHashed());
-            assertThat(l.getLogTopics().get(1)).isEqualTo(transfers[i].getSourceTransactionHash());
-            assertThat(l.getLogTopics().get(2)).isEqualTo(transfers[i].getRecipient());
-            assertThat(new BigInteger(1, l.getLogTopics().get(3)))
+            assertThat(l.getTopics().get(0)).isEqualTo(BridgeEventSig.DISTRIBUTED.getHashed());
+            assertThat(l.getTopics().get(1)).isEqualTo(transfers[i].getSourceTransactionHash());
+            assertThat(l.getTopics().get(2)).isEqualTo(transfers[i].getRecipient());
+            assertThat(new BigInteger(1, l.getTopics().get(3)))
                     .isEqualTo(transfers[i].getTransferValue());
             i++;
         }
@@ -656,7 +656,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         byte[][] signatures = new byte[members.length][];
@@ -959,7 +959,7 @@ public class TokenBridgeContractTest {
                                 .getSideEffects()
                                 .getExecutionLogs()
                                 .get(0)
-                                .getLogTopics()
+                                .getTopics()
                                 .get(0))
                 .isEqualTo(BridgeEventSig.SUCCESSFUL_TXHASH.getHashed());
 
@@ -968,7 +968,7 @@ public class TokenBridgeContractTest {
                                 .getSideEffects()
                                 .getExecutionLogs()
                                 .get(0)
-                                .getLogTopics()
+                                .getTopics()
                                 .get(1))
                 .isEqualTo(submitBundleContext.getTransactionHash());
     }
@@ -1044,7 +1044,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         byte[][] signatures = new byte[members.length][];
@@ -1099,7 +1099,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(new byte[32]);
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.FAILURE);
@@ -1179,7 +1179,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         byte[][] signatures = new byte[members.length][];
@@ -1234,7 +1234,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(new byte[32]);
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.FAILURE);
@@ -1323,7 +1323,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         // only give 2/5 signatures
@@ -1377,7 +1377,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(new byte[32]);
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.FAILURE);
@@ -1466,7 +1466,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         // only give 3/5 signatures
@@ -1522,7 +1522,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(new byte[32]);
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.FAILURE);
@@ -1612,7 +1612,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(ByteUtil.EMPTY_WORD);
 
         byte[][] signatures = new byte[members.length][];
@@ -1671,7 +1671,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(new byte[32]);
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.FAILURE);
@@ -1772,22 +1772,22 @@ public class TokenBridgeContractTest {
         i = 0;
         for (IExecutionLog l : submitBundleContext.getSideEffects().getExecutionLogs()) {
             // verify address is correct
-            assertThat(l.getLogSourceAddress()).isEqualTo(CONTRACT_ADDR);
+            assertThat(l.getSourceAddress()).isEqualTo(CONTRACT_ADDR);
 
             // on the 11th log, it should be the processed bundle event
             if (i == 10) {
-                assertThat(l.getLogTopics().get(0))
+                assertThat(l.getTopics().get(0))
                         .isEqualTo(BridgeEventSig.PROCESSED_BUNDLE.getHashed());
-                assertThat(l.getLogTopics().get(1)).isEqualTo(blockHash);
-                assertThat(l.getLogTopics().get(2)).isEqualTo(payloadHash);
+                assertThat(l.getTopics().get(1)).isEqualTo(blockHash);
+                assertThat(l.getTopics().get(2)).isEqualTo(payloadHash);
                 continue;
             }
 
             // otherwise we expect a Distributed event
-            assertThat(l.getLogTopics().get(0)).isEqualTo(BridgeEventSig.DISTRIBUTED.getHashed());
-            assertThat(l.getLogTopics().get(1)).isEqualTo(transfers[i].getSourceTransactionHash());
-            assertThat(l.getLogTopics().get(2)).isEqualTo(transfers[i].getRecipient());
-            assertThat(new BigInteger(1, l.getLogTopics().get(3)))
+            assertThat(l.getTopics().get(0)).isEqualTo(BridgeEventSig.DISTRIBUTED.getHashed());
+            assertThat(l.getTopics().get(1)).isEqualTo(transfers[i].getSourceTransactionHash());
+            assertThat(l.getTopics().get(2)).isEqualTo(transfers[i].getRecipient());
+            assertThat(new BigInteger(1, l.getTopics().get(3)))
                     .isEqualTo(transfers[i].getTransferValue());
             i++;
         }
@@ -1828,7 +1828,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(new byte[32]);
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.FAILURE);
@@ -1878,7 +1878,7 @@ public class TokenBridgeContractTest {
                                                 BridgeFuncSig.PURE_ACTION_MAP.getBytes(),
                                                 payloadHash),
                                         21000L)
-                                .getOutput())
+                                .getReturnData())
                 .isEqualTo(new byte[32]);
 
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.FAILURE);
@@ -2121,7 +2121,7 @@ public class TokenBridgeContractTest {
         PrecompiledTransactionResult transferResult =
                 this.contract.execute(callPayload, DEFAULT_NRG);
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
-        assertThat(transferResult.getOutput()).isEqualTo(DataWord.ONE.getData());
+        assertThat(transferResult.getReturnData()).isEqualTo(DataWord.ONE.getData());
 
         // lock the ring
         this.connector.setRingLocked(false);
@@ -2133,7 +2133,7 @@ public class TokenBridgeContractTest {
         PrecompiledTransactionResult transferResult2 =
                 this.contract.execute(callPayload2, DEFAULT_NRG);
         assertThat(transferResult2.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
-        assertThat(transferResult2.getOutput()).isEqualTo(DataWord.ZERO.getData());
+        assertThat(transferResult2.getReturnData()).isEqualTo(DataWord.ZERO.getData());
     }
 
     @Test
@@ -2166,7 +2166,7 @@ public class TokenBridgeContractTest {
         PrecompiledTransactionResult transferResult =
                 this.contract.execute(callPayload, DEFAULT_NRG);
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
-        assertThat(transferResult.getOutput())
+        assertThat(transferResult.getReturnData())
                 .isEqualTo(new DataWord(new BigInteger("3")).getData());
 
         // explicitly set the min threshold to 5
@@ -2179,7 +2179,7 @@ public class TokenBridgeContractTest {
         PrecompiledTransactionResult transferResult2 =
                 this.contract.execute(callPayload2, DEFAULT_NRG);
         assertThat(transferResult2.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
-        assertThat(transferResult2.getOutput())
+        assertThat(transferResult2.getReturnData())
                 .isEqualTo(new DataWord(new BigInteger("5")).getData());
 
         // try setting threshold greater than number of validator members
@@ -2192,7 +2192,7 @@ public class TokenBridgeContractTest {
         PrecompiledTransactionResult transferResult3 =
                 this.contract.execute(callPayload3, DEFAULT_NRG);
         assertThat(transferResult3.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
-        assertThat(transferResult3.getOutput())
+        assertThat(transferResult3.getReturnData())
                 .isEqualTo(new DataWord(new BigInteger("10")).getData());
     }
 
@@ -2226,7 +2226,7 @@ public class TokenBridgeContractTest {
         PrecompiledTransactionResult transferResult =
                 this.contract.execute(callPayload, DEFAULT_NRG);
         assertThat(transferResult.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
-        assertThat(transferResult.getOutput())
+        assertThat(transferResult.getReturnData())
                 .isEqualTo(new DataWord(new BigInteger("5")).getData());
 
         // explicitly set the member count to 10
@@ -2239,7 +2239,7 @@ public class TokenBridgeContractTest {
         PrecompiledTransactionResult transferResult2 =
                 this.contract.execute(callPayload2, DEFAULT_NRG);
         assertThat(transferResult2.getResultCode()).isEqualTo(PrecompiledResultCode.SUCCESS);
-        assertThat(transferResult2.getOutput())
+        assertThat(transferResult2.getReturnData())
                 .isEqualTo(new DataWord(new BigInteger("10")).getData());
     }
 

--- a/modPrecompiled/test/org/aion/precompiled/contracts/AionAuctionContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/AionAuctionContractTest.java
@@ -156,7 +156,7 @@ public class AionAuctionContractTest {
         AionNameServiceContract ansc2 =
                 new AionNameServiceContract(
                         repo,
-                        AionAddress.wrap(result.getOutput()),
+                        AionAddress.wrap(result.getReturnData()),
                         AionAddress.wrap(k4.getAddress()));
         assertEquals(PrecompiledResultCode.SUCCESS, result.getResultCode());
     }
@@ -405,7 +405,7 @@ public class AionAuctionContractTest {
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
 
         assertEquals(PrecompiledResultCode.FAILURE, res2.getResultCode());
-        Assert.assertArrayEquals("already been extended".getBytes(), res2.getOutput());
+        Assert.assertArrayEquals("already been extended".getBytes(), res2.getReturnData());
 
         // uncomment to see extension output
         //        try {
@@ -540,7 +540,7 @@ public class AionAuctionContractTest {
         AionAuctionContract aac = new AionAuctionContract(repo, AION, blockchain);
         PrecompiledTransactionResult result = aac.execute(combined, DEFAULT_INPUT_NRG);
         assertEquals(PrecompiledResultCode.FAILURE, result.getResultCode());
-        Assert.assertArrayEquals("bidder account does not exist".getBytes(), result.getOutput());
+        Assert.assertArrayEquals("bidder account does not exist".getBytes(), result.getReturnData());
     }
 
     @Test
@@ -557,7 +557,7 @@ public class AionAuctionContractTest {
                         poorKey);
         PrecompiledTransactionResult result = testAAC.execute(combined3, DEFAULT_INPUT_NRG);
         assertEquals(PrecompiledResultCode.FAILURE, result.getResultCode());
-        Assert.assertArrayEquals("insufficient balance".getBytes(), result.getOutput());
+        Assert.assertArrayEquals("insufficient balance".getBytes(), result.getReturnData());
     }
 
     @Test
@@ -582,7 +582,7 @@ public class AionAuctionContractTest {
 
         assertEquals(PrecompiledResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getEnergyRemaining(), 4000);
-        Assert.assertArrayEquals("incorrect input length".getBytes(), result.getOutput());
+        Assert.assertArrayEquals("incorrect input length".getBytes(), result.getReturnData());
 
         wrongInput3[0] = -1;
         System.arraycopy(input, 0, wrongInput4, 0, input.length - 2);
@@ -604,7 +604,7 @@ public class AionAuctionContractTest {
 
         assertEquals(PrecompiledResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getEnergyRemaining(), 4000);
-        Assert.assertArrayEquals("incorrect signature".getBytes(), result.getOutput());
+        Assert.assertArrayEquals("incorrect signature".getBytes(), result.getReturnData());
     }
 
     @Test
@@ -621,7 +621,7 @@ public class AionAuctionContractTest {
 
         assertEquals(PrecompiledResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getEnergyRemaining(), 4000);
-        Assert.assertArrayEquals("incorrect key".getBytes(), result.getOutput());
+        Assert.assertArrayEquals("incorrect key".getBytes(), result.getReturnData());
     }
 
     @Test
@@ -636,7 +636,7 @@ public class AionAuctionContractTest {
 
         assertEquals(PrecompiledResultCode.OUT_OF_NRG, result.getResultCode());
         assertEquals(result.getEnergyRemaining(), 0);
-        Assert.assertArrayEquals("insufficient energy".getBytes(), result.getOutput());
+        Assert.assertArrayEquals("insufficient energy".getBytes(), result.getReturnData());
     }
 
     @Test
@@ -652,7 +652,7 @@ public class AionAuctionContractTest {
 
         assertEquals(PrecompiledResultCode.FAILURE, result.getResultCode());
         assertEquals(result.getEnergyRemaining(), 4000);
-        Assert.assertArrayEquals("negative bid value".getBytes(), result.getOutput());
+        Assert.assertArrayEquals("negative bid value".getBytes(), result.getReturnData());
     }
 
     @Test
@@ -687,7 +687,7 @@ public class AionAuctionContractTest {
         assertEquals(PrecompiledResultCode.FAILURE, result2.getResultCode());
         assertEquals(result2.getEnergyRemaining(), 4000);
         Assert.assertArrayEquals(
-                "requested domain is already active".getBytes(), result2.getOutput());
+                "requested domain is already active".getBytes(), result2.getReturnData());
     }
 
     @Test
@@ -804,7 +804,7 @@ public class AionAuctionContractTest {
 
         assertEquals(PrecompiledResultCode.SUCCESS, result2.getResultCode());
         assertEquals(result2.getEnergyRemaining(), 4000);
-        assertEquals(32, result2.getOutput().length); // check that an address was returned
+        assertEquals(32, result2.getReturnData().length); // check that an address was returned
     }
 
     private byte[] setupInputs(String domainName, Address ownerAddress, byte[] amount, ECKey k) {

--- a/modPrecompiled/test/org/aion/precompiled/contracts/AionNameServiceContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/AionNameServiceContractTest.java
@@ -162,8 +162,8 @@ public class AionNameServiceContractTest {
             e.printStackTrace();
         }
 
-        defaultAddress = AionAddress.wrap(result.getOutput());
-        defaultAddress2 = AionAddress.wrap(result2.getOutput());
+        defaultAddress = AionAddress.wrap(result.getReturnData());
+        defaultAddress2 = AionAddress.wrap(result2.getReturnData());
     }
 
     @After
@@ -731,7 +731,7 @@ public class AionNameServiceContractTest {
                         k);
         AionAuctionContract aac = new AionAuctionContract(repo, AION, blockchain);
         PrecompiledTransactionResult result = aac.execute(combined, DEFAULT_INPUT_NRG);
-        Address addr = AionAddress.wrap(result.getOutput());
+        Address addr = AionAddress.wrap(result.getReturnData());
 
         byte[] combined2 =
                 setupInputs(

--- a/modPrecompiled/test/org/aion/precompiled/contracts/Blake2bHashTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/Blake2bHashTest.java
@@ -59,7 +59,7 @@ public class Blake2bHashTest {
     @Test
     public void testBlake256() {
         PrecompiledTransactionResult res = blake2bHasher.execute(byteArray1, INPUT_NRG);
-        byte[] output = res.getOutput();
+        byte[] output = res.getReturnData();
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(32, output.length);
@@ -70,7 +70,7 @@ public class Blake2bHashTest {
     @Test
     public void testBlake256_2() {
         PrecompiledTransactionResult res = blake2bHasher.execute(byteArray2, INPUT_NRG);
-        byte[] output = res.getOutput();
+        byte[] output = res.getReturnData();
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(32, output.length);
@@ -82,7 +82,7 @@ public class Blake2bHashTest {
     @Test
     public void testBlake256_3() {
         PrecompiledTransactionResult res = blake2bHasher.execute(bigByteArray, 2_000_000L);
-        byte[] output = res.getOutput();
+        byte[] output = res.getReturnData();
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(32, output.length);
@@ -130,8 +130,8 @@ public class Blake2bHashTest {
         PrecompiledTransactionResult res1Copy = blake2bHasher.execute(input1Copy, INPUT_NRG);
         PrecompiledTransactionResult res2 = blake2bHasher.execute(input2, INPUT_NRG);
 
-        assertThat(res1.getOutput()).isEqualTo(res1Copy.getOutput());
-        assertThat(res1.getOutput()).isNotEqualTo(res2.getOutput());
+        assertThat(res1.getReturnData()).isEqualTo(res1Copy.getReturnData());
+        assertThat(res1.getReturnData()).isNotEqualTo(res2.getReturnData());
     }
 
     @Test

--- a/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/EDVerifyContractTest.java
@@ -112,7 +112,7 @@ public class EDVerifyContractTest {
         assertNotNull(contract);
         TransactionResult result = contract.execute(input, 21000L);
         assertThat(result.getResultCode().isSuccess());
-        assertThat(Arrays.equals(result.getOutput(), pubKey));
+        assertThat(Arrays.equals(result.getReturnData(), pubKey));
     }
 
     @Test
@@ -143,7 +143,7 @@ public class EDVerifyContractTest {
         assertNotNull(contract);
         TransactionResult result = contract.execute(input, 21000L);
         assertThat(result.getResultCode().isSuccess());
-        assertThat(Arrays.equals(result.getOutput(), pubKey));
+        assertThat(Arrays.equals(result.getReturnData(), pubKey));
     }
 
     @Test
@@ -178,7 +178,7 @@ public class EDVerifyContractTest {
         assertNotNull(contract);
         TransactionResult result = contract.execute(input, 21000L);
         assertThat(result.getResultCode().isSuccess());
-        assertThat(Arrays.equals(result.getOutput(), AionAddress.ZERO_ADDRESS().toBytes()));
+        assertThat(Arrays.equals(result.getReturnData(), AionAddress.ZERO_ADDRESS().toBytes()));
     }
 
     @Test

--- a/modPrecompiled/test/org/aion/precompiled/contracts/KeccakHashTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/KeccakHashTest.java
@@ -23,7 +23,7 @@ public class KeccakHashTest {
     @Test
     public void testKeccak256() {
         PrecompiledTransactionResult res = keccakHasher.execute(byteArray1, INPUT_NRG);
-        byte[] output = res.getOutput();
+        byte[] output = res.getReturnData();
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
         assertEquals(32, output.length);

--- a/modPrecompiled/test/org/aion/precompiled/contracts/MultiSignatureContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/MultiSignatureContractTest.java
@@ -273,7 +273,7 @@ public class MultiSignatureContractTest {
         MultiSignatureContract msc = new MultiSignatureContract(repo, ownerAddrs.get(0));
         PrecompiledTransactionResult res = msc.execute(input, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        Address wallet = new AionAddress(res.getOutput());
+        Address wallet = new AionAddress(res.getReturnData());
         repo.addBalance(wallet, balance);
         addrsToClean.add(wallet);
         repo.flush();
@@ -301,7 +301,7 @@ public class MultiSignatureContractTest {
     // threshold and consists of all the owners in owners and no more.
     private void checkCreateResult(
             PrecompiledTransactionResult res, long threshold, List<Address> owners) {
-        Address walletId = new AionAddress(res.getOutput());
+        Address walletId = new AionAddress(res.getReturnData());
         addrsToClean.add(walletId);
         assertEquals(BigInteger.ZERO, repo.getBalance(walletId));
         assertEquals(BigInteger.ZERO, repo.getNonce(walletId));
@@ -631,7 +631,7 @@ public class MultiSignatureContractTest {
         PrecompiledTransactionResult res =
                 execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
 
-        Address walletCaller = new AionAddress(res.getOutput());
+        Address walletCaller = new AionAddress(res.getReturnData());
         addrsToClean.add(walletCaller);
         checkAccountState(walletCaller, BigInteger.ZERO, BigInteger.ZERO);
 
@@ -659,7 +659,7 @@ public class MultiSignatureContractTest {
         PrecompiledTransactionResult res =
                 execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
 
-        Address wallet = new AionAddress(res.getOutput());
+        Address wallet = new AionAddress(res.getReturnData());
         addrsToClean.add(wallet);
         checkAccountState(wallet, BigInteger.ZERO, BigInteger.ZERO);
 
@@ -689,7 +689,7 @@ public class MultiSignatureContractTest {
         PrecompiledTransactionResult res =
                 execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
         checkCreateResult(res, threshold, owners);
-        checkAccountState(new AionAddress(res.getOutput()), BigInteger.ZERO, BigInteger.ZERO);
+        checkAccountState(new AionAddress(res.getReturnData()), BigInteger.ZERO, BigInteger.ZERO);
 
         // Test using max legal number of owners.
         owners =
@@ -700,7 +700,7 @@ public class MultiSignatureContractTest {
 
         res = execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
         checkCreateResult(res, threshold, owners);
-        checkAccountState(new AionAddress(res.getOutput()), BigInteger.ZERO, BigInteger.ZERO);
+        checkAccountState(new AionAddress(res.getReturnData()), BigInteger.ZERO, BigInteger.ZERO);
     }
 
     @Test
@@ -714,10 +714,10 @@ public class MultiSignatureContractTest {
 
         PrecompiledTransactionResult res =
                 execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
-        Address wallet1 = new AionAddress(res.getOutput());
+        Address wallet1 = new AionAddress(res.getReturnData());
 
         res = execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
-        Address wallet2 = new AionAddress(res.getOutput());
+        Address wallet2 = new AionAddress(res.getReturnData());
 
         assertEquals(wallet1, wallet2);
     }
@@ -733,7 +733,7 @@ public class MultiSignatureContractTest {
 
         PrecompiledTransactionResult res =
                 execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
-        Address wallet = new AionAddress(res.getOutput());
+        Address wallet = new AionAddress(res.getReturnData());
         assertTrue(wallet.toString().startsWith("a0"));
     }
 
@@ -750,7 +750,7 @@ public class MultiSignatureContractTest {
         PrecompiledTransactionResult res =
                 execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
         checkCreateResult(res, threshold, owners);
-        checkAccountState(new AionAddress(res.getOutput()), BigInteger.ZERO, BigInteger.ZERO);
+        checkAccountState(new AionAddress(res.getReturnData()), BigInteger.ZERO, BigInteger.ZERO);
 
         // Test using max legal number of owners.
         owners =
@@ -761,7 +761,7 @@ public class MultiSignatureContractTest {
 
         res = execute(caller, input, NRG_LIMIT, PrecompiledResultCode.SUCCESS, NRG_LIMIT - COST);
         checkCreateResult(res, threshold, owners);
-        checkAccountState(new AionAddress(res.getOutput()), BigInteger.ZERO, BigInteger.ZERO);
+        checkAccountState(new AionAddress(res.getReturnData()), BigInteger.ZERO, BigInteger.ZERO);
     }
 
     // <----------------------------------SEND TRANSACTION TESTS----------------------------------->

--- a/modPrecompiled/test/org/aion/precompiled/contracts/TXHashContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/TXHashContractTest.java
@@ -80,7 +80,7 @@ public class TXHashContractTest {
         TransactionResult res = tXHashContract.execute(null, INPUT_NRG);
 
         System.out.println(res.toString());
-        assertTrue(Arrays.equals(txHash, res.getOutput()));
+        assertTrue(Arrays.equals(txHash, res.getReturnData()));
     }
 
     @Test

--- a/modPrecompiled/test/org/aion/precompiled/contracts/TotalCurrencyContractTest.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/TotalCurrencyContractTest.java
@@ -122,7 +122,7 @@ public class TotalCurrencyContractTest {
         res = tcc.execute(input, COST);
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(AMT, new BigInteger(res.getOutput()));
+        assertEquals(AMT, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class TotalCurrencyContractTest {
         res = tcc.execute(new byte[] {(byte) 0x1}, COST); // query a diff chainID
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(BigInteger.ZERO, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ZERO, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class TotalCurrencyContractTest {
         PrecompiledTransactionResult res = tcc.execute(new byte[] {(byte) 0x0}, COST);
 
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(AMT.multiply(BigInteger.valueOf(4)), new BigInteger(res.getOutput()));
+        assertEquals(AMT.multiply(BigInteger.valueOf(4)), new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -223,14 +223,14 @@ public class TotalCurrencyContractTest {
 
         PrecompiledTransactionResult res = tcc.execute(new byte[] {(byte) 0x0}, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(AMT.multiply(BigInteger.valueOf(2)), new BigInteger(res.getOutput()));
+        assertEquals(AMT.multiply(BigInteger.valueOf(2)), new BigInteger(res.getReturnData()));
 
         tcc.execute(input, COST);
         tcc.execute(input, COST);
 
         res = tcc.execute(new byte[] {(byte) 0x0}, COST);
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(BigInteger.ZERO, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ZERO, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -245,7 +245,7 @@ public class TotalCurrencyContractTest {
 
         // Verify total amount is non-negative.
         res = tcc.execute(new byte[] {(byte) 0x0}, COST);
-        assertEquals(BigInteger.ZERO, new BigInteger(res.getOutput()));
+        assertEquals(BigInteger.ZERO, new BigInteger(res.getReturnData()));
     }
 
     @Test
@@ -278,14 +278,14 @@ public class TotalCurrencyContractTest {
         PrecompiledTransactionResult res =
                 tcc.execute(new byte[] {(byte) 0x0}, COST); // get chain 0.
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(AMT, new BigInteger(res.getOutput()));
+        assertEquals(AMT, new BigInteger(res.getReturnData()));
 
         res = tcc.execute(new byte[] {(byte) 0x1}, COST); // get chain 1.
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(AMT.multiply(BigInteger.valueOf(2)), new BigInteger(res.getOutput()));
+        assertEquals(AMT.multiply(BigInteger.valueOf(2)), new BigInteger(res.getReturnData()));
 
         res = tcc.execute((new byte[] {(byte) 0x10}), COST); // get chain 16.
         assertEquals(PrecompiledResultCode.SUCCESS, res.getResultCode());
-        assertEquals(AMT.multiply(BigInteger.valueOf(4)), new BigInteger(res.getOutput()));
+        assertEquals(AMT.multiply(BigInteger.valueOf(4)), new BigInteger(res.getReturnData()));
     }
 }

--- a/modVM/src/org/aion/vm/BulkExecutor.java
+++ b/modVM/src/org/aion/vm/BulkExecutor.java
@@ -144,7 +144,7 @@ public class BulkExecutor {
             if (energyUsed > this.blockRemainingEnergy) {
                 result.setResultCode(FastVmResultCode.INVALID_NRG_LIMIT);
                 result.setEnergyRemaining(0);
-                result.setOutput(new byte[0]);
+                result.setReturnData(new byte[0]);
             }
 
             // 2. build the transaction summary and update the repository (the one backing
@@ -186,7 +186,7 @@ public class BulkExecutor {
                         .logs(sideEffects.getExecutionLogs())
                         .deletedAccounts(sideEffects.getAddressesToBeDeleted())
                         .internalTransactions(sideEffects.getInternalTransactions())
-                        .result(result.getOutput());
+                        .result(result.getReturnData());
 
         ResultCode resultCode = result.getResultCode();
 
@@ -217,7 +217,7 @@ public class BulkExecutor {
         receipt.setTransaction(transaction);
         receipt.setLogs(logs);
         receipt.setNrgUsed(computeEnergyUsed(transaction.getEnergyLimit(), result));
-        receipt.setExecutionResult(result.getOutput());
+        receipt.setExecutionResult(result.getReturnData());
         receipt.setError(result.getResultCode().isSuccess() ? "" : result.getResultCode().name());
 
         return receipt;

--- a/modVM/src/org/aion/vm/KernelTransactionContext.java
+++ b/modVM/src/org/aion/vm/KernelTransactionContext.java
@@ -3,6 +3,7 @@ package org.aion.vm;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import org.aion.base.type.AionAddress;
 import org.aion.base.vm.IDataWord;
 import org.aion.fastvm.SideEffects;
 import org.aion.mcf.vm.types.DataWord;
@@ -154,6 +155,13 @@ public class KernelTransactionContext implements TransactionContext {
     @Override
     public Address getDestinationAddress() {
         return address;
+    }
+
+    @Override
+    public Address getContractAddress() {
+        byte[] rawBytes = this.transaction.getContractAddress().toBytes();
+        rawBytes[0] = 0x0f;
+        return AionAddress.wrap(rawBytes);
     }
 
     /** @return the origination address, which is the sender of original transaction. */


### PR DESCRIPTION
This moves us to the last vm_api commit so that we are compatible with the AVM.

This final vm_api commit just makes some name changes (to make merging easier in the AVM in certain cases, and because the names are often better anyway).

There is also one new method introduced, `getContractAddress()` in the `KernelInterface`.

This PR has corresponding changes in:
- [aion_api](https://github.com/aionnetwork/aion_api/pull/58)
- [aion_fastvm](https://github.com/aionnetwork/aion_fastvm/pull/50)