### PR TITLE
Allowing 0 as a transaction type for the FVM

### DIFF
--- a/modAionBase/src/org/aion/base/vm/VirtualMachineSpecs.java
+++ b/modAionBase/src/org/aion/base/vm/VirtualMachineSpecs.java
@@ -3,5 +3,6 @@ package org.aion.base.vm;
 public final class VirtualMachineSpecs {
 
     public static final byte AVM_CREATE_CODE = 0x0f;
+    public static final byte FVM_ALLOWED_TX_TYPE = 0x00;
     public static final byte FVM_DEFAULT_TX_TYPE = 0x01;
 }

--- a/modMcf/src/org/aion/mcf/valid/TransactionTypeRule.java
+++ b/modMcf/src/org/aion/mcf/valid/TransactionTypeRule.java
@@ -10,7 +10,8 @@ import org.aion.base.vm.VirtualMachineSpecs;
 public class TransactionTypeRule {
 
     public static boolean isValidFVMTransactionType(byte type) {
-        return type == VirtualMachineSpecs.FVM_DEFAULT_TX_TYPE;
+        return type == VirtualMachineSpecs.FVM_DEFAULT_TX_TYPE
+                || type == VirtualMachineSpecs.FVM_ALLOWED_TX_TYPE;
     }
 
     public static boolean isValidAVMTransactionType(byte type) {


### PR DESCRIPTION
## Description

Adding 0 as a valid transaction type value to avoid consensus breaks with Rust kernel.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

- the existing test suite and sync tests on `mastery`

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
