### PR TITLE
Step 11: kernel integration (put / delete split in contract details)

### DIFF
--- a/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
+++ b/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
@@ -70,20 +70,12 @@ public class AionContractDetailsImpl extends AbstractContractDetails {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
 
+        // The following must be done before making this call:
         // We strip leading zeros of a DataWord but not a DoubleDataWord so that when we call get
         // we can differentiate between the two.
 
-        if (value.isZero()) {
-            // storageTrie.delete(key.getData());
-
-            // TODO: remove when integrating the AVM
-            // used to ensure FVM correctness
-            throw new IllegalArgumentException(
-                    "Put with zero values is not allowed for the FVM. For deletions, explicit calls to delete are necessary.");
-        } else {
-            byte[] data = RLP.encodeElement(value.getData());
-            storageTrie.update(key.getData(), data);
-        }
+        byte[] data = RLP.encodeElement(value.getData());
+        storageTrie.update(key.getData(), data);
 
         this.setDirty(true);
         this.rlpEncoded = null;

--- a/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
+++ b/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.type.AionAddress;
@@ -79,6 +78,14 @@ public class AionContractDetailsImpl extends AbstractContractDetails {
             byte[] data = RLP.encodeElement(value.getData());
             storageTrie.update(key.getData(), data);
         }
+
+        this.setDirty(true);
+        this.rlpEncoded = null;
+    }
+
+    @Override
+    public void delete(ByteArrayWrapper key) {
+        storageTrie.delete(key.getData());
 
         this.setDirty(true);
         this.rlpEncoded = null;

--- a/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
+++ b/modAion/src/org/aion/zero/db/AionContractDetailsImpl.java
@@ -6,9 +6,7 @@ import static org.aion.crypto.HashUtil.EMPTY_TRIE_HASH;
 import static org.aion.crypto.HashUtil.h256;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.aion.base.db.IByteArrayKeyValueStore;
@@ -212,60 +210,6 @@ public class AionContractDetailsImpl extends AbstractContractDetails {
         }
 
         return rlpEncoded;
-    }
-
-    /**
-     * Returns a mapping of all the key-value pairs who have keys in the collection keys.
-     *
-     * @param keys The keys to query for.
-     * @return The associated mappings.
-     */
-    @Override
-    public Map<ByteArrayWrapper, ByteArrayWrapper> getStorage(Collection<ByteArrayWrapper> keys) {
-        Map<ByteArrayWrapper, ByteArrayWrapper> storage = new HashMap<>();
-        if (keys == null) {
-            throw new IllegalArgumentException("Input keys can't be null");
-        } else {
-            for (ByteArrayWrapper key : keys) {
-                ByteArrayWrapper value = get(key);
-
-                // we check if the value is not null,
-                // cause we keep all historical keys
-                if ((value != null) && (!value.isZero())) {
-                    storage.put(key, value);
-                }
-            }
-        }
-
-        return storage;
-    }
-
-    /**
-     * Sets the storage to contain the specified keys and values. This method creates pairings of
-     * the keys and values by mapping the i'th key in storageKeys to the i'th value in
-     * storageValues.
-     *
-     * @param storageKeys The keys.
-     * @param storageValues The values.
-     */
-    @Override
-    public void setStorage(
-            List<ByteArrayWrapper> storageKeys, List<ByteArrayWrapper> storageValues) {
-        for (int i = 0; i < storageKeys.size(); ++i) {
-            put(storageKeys.get(i), storageValues.get(i));
-        }
-    }
-
-    /**
-     * Sets the storage to contain the specified key-value mappings.
-     *
-     * @param storage The specified mappings.
-     */
-    @Override
-    public void setStorage(Map<ByteArrayWrapper, ByteArrayWrapper> storage) {
-        for (ByteArrayWrapper key : storage.keySet()) {
-            put(key, storage.get(key));
-        }
     }
 
     /**

--- a/modAionBase/src/org/aion/base/db/IContractDetails.java
+++ b/modAionBase/src/org/aion/base/db/IContractDetails.java
@@ -9,14 +9,19 @@ import org.aion.vm.api.interfaces.Address;
 public interface IContractDetails {
 
     /**
-     * Inserts key and value as a key-value pair. If the underlying byte array of value consists
-     * only of zero bytes then ay existing key-value pair that has the same key as key will be
-     * deleted.
+     * Inserts a key-value pair containing the given key and the given value.
      *
-     * @param key The key.
-     * @param value The value.
+     * @param key the key to be inserted
+     * @param value the value to be inserted
      */
     void put(ByteArrayWrapper key, ByteArrayWrapper value);
+
+    /**
+     * Deletes any key-value pair that matches the given key.
+     *
+     * @param key the key to be deleted
+     */
+    void delete(ByteArrayWrapper key);
 
     /**
      * Returns the value associated with key.
@@ -113,10 +118,10 @@ public interface IContractDetails {
     byte[] getEncoded();
 
     /**
-     * Returns a mapping of all the key-value pairs who have keys in the collection keys.
+     * Returns a mapping of all the key-value pairs that have keys in the given collection keys.
      *
-     * @param keys The keys to query for.
-     * @return The associated mappings.
+     * @param keys the keys to query for
+     * @return the associated mappings
      */
     Map<ByteArrayWrapper, ByteArrayWrapper> getStorage(Collection<ByteArrayWrapper> keys);
 
@@ -125,15 +130,19 @@ public interface IContractDetails {
      * the keys and values by mapping the i'th key in storageKeys to the i'th value in
      * storageValues.
      *
-     * @param storageKeys The keys.
-     * @param storageValues The values.
+     * @param storageKeys the list of keys
+     * @param storageValues the list of values
+     * @apiNote Used for testing.
+     * @implNote A {@code null} value is interpreted as deletion.
      */
     void setStorage(List<ByteArrayWrapper> storageKeys, List<ByteArrayWrapper> storageValues);
 
     /**
      * Sets the storage to contain the specified key-value mappings.
      *
-     * @param storage The specified mappings.
+     * @param storage the specified mappings
+     * @apiNote Used for testing.
+     * @implNote A {@code null} value is interpreted as deletion.
      */
     void setStorage(Map<ByteArrayWrapper, ByteArrayWrapper> storage);
 

--- a/modAionBase/src/org/aion/base/db/IContractDetails.java
+++ b/modAionBase/src/org/aion/base/db/IContractDetails.java
@@ -1,7 +1,6 @@
 package org.aion.base.db;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import org.aion.base.util.ByteArrayWrapper;
 import org.aion.vm.api.interfaces.Address;
@@ -124,18 +123,6 @@ public interface IContractDetails {
      * @return the associated mappings
      */
     Map<ByteArrayWrapper, ByteArrayWrapper> getStorage(Collection<ByteArrayWrapper> keys);
-
-    /**
-     * Sets the storage to contain the specified keys and values. This method creates pairings of
-     * the keys and values by mapping the i'th key in storageKeys to the i'th value in
-     * storageValues.
-     *
-     * @param storageKeys the list of keys
-     * @param storageValues the list of values
-     * @apiNote Used for testing.
-     * @implNote A {@code null} value is interpreted as deletion.
-     */
-    void setStorage(List<ByteArrayWrapper> storageKeys, List<ByteArrayWrapper> storageValues);
 
     /**
      * Sets the storage to contain the specified key-value mappings.

--- a/modAionBase/src/org/aion/base/db/IRepositoryCache.java
+++ b/modAionBase/src/org/aion/base/db/IRepositoryCache.java
@@ -76,10 +76,18 @@ public interface IRepositoryCache<AS, BSB> extends IRepository<AS, BSB> {
      * Store the given data at the given key in the account associated with the given address.
      *
      * @param address the address of the account of interest
-     * @param key the key at which the date will be stored
+     * @param key the key at which the data will be stored
      * @param value the data to be stored
      */
     void addStorageRow(Address address, ByteArrayWrapper key, ByteArrayWrapper value);
+
+    /**
+     * Remove the given storage key from the account associated with the given address.
+     *
+     * @param address the address of the account of interest
+     * @param key the key for which the data will be removed
+     */
+    void removeStorageRow(Address address, ByteArrayWrapper key);
 
     void flushTo(IRepository repo, boolean clearStateAfterFlush);
 }

--- a/modAionBase/src/org/aion/base/util/ByteArrayWrapper.java
+++ b/modAionBase/src/org/aion/base/util/ByteArrayWrapper.java
@@ -75,6 +75,15 @@ public class ByteArrayWrapper
         return true;
     }
 
+    /**
+     * Checks if the stored byte array is empty.
+     *
+     * @return {@code true} if empty, {@code false} otherwise
+     */
+    public boolean isEmpty() {
+        return data.length == 0;
+    }
+
     public ByteArrayWrapper copy() {
         int length = data.length;
         byte[] bs = new byte[length];

--- a/modAionImpl/src/org/aion/zero/impl/AionGenesis.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionGenesis.java
@@ -349,6 +349,7 @@ public class AionGenesis extends AionBlock {
             AionContractDetailsImpl networkBalanceStorage = new AionContractDetailsImpl();
 
             for (Map.Entry<Integer, BigInteger> entry : this.networkBalance.entrySet()) {
+                // we assume there are no deletions in the genesis
                 networkBalanceStorage.put(
                         new DataWord(entry.getKey()).toWrapper(),
                         wrapValueForPut(new DataWord(entry.getValue())));
@@ -370,7 +371,9 @@ public class AionGenesis extends AionBlock {
         }
 
         private static ByteArrayWrapper wrapValueForPut(DataWord value) {
-            return (value.isZero()) ? DataWord.ZERO.toWrapper() : new ByteArrayWrapper(value.getNoLeadZeroesData());
+            return (value.isZero())
+                    ? DataWord.ZERO.toWrapper()
+                    : new ByteArrayWrapper(value.getNoLeadZeroesData());
         }
 
         private static byte[] generateExtraData(int chainId) {

--- a/modAionImpl/src/org/aion/zero/impl/AionHubUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHubUtils.java
@@ -20,6 +20,7 @@ public class AionHubUtils {
         track.createAccount(networkBalanceAddress);
 
         for (Map.Entry<Integer, BigInteger> addr : genesis.getNetworkBalances().entrySet()) {
+            // assumes only additions are performed in the genesis
             track.addStorageRow(
                     networkBalanceAddress,
                     new DataWord(addr.getKey()).toWrapper(),
@@ -37,6 +38,8 @@ public class AionHubUtils {
     }
 
     private static ByteArrayWrapper wrapValueForPut(DataWord value) {
-        return (value.isZero()) ? value.toWrapper() : new ByteArrayWrapper(value.getNoLeadZeroesData());
+        return (value.isZero())
+                ? value.toWrapper()
+                : new ByteArrayWrapper(value.getNoLeadZeroesData());
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
@@ -324,6 +324,7 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
             track.createAccount(ContractFactory.getTotalCurrencyContractAddress());
 
             for (Map.Entry<Integer, BigInteger> key : genesis.getNetworkBalances().entrySet()) {
+                // assumes only additions can be made in the genesis
                 track.addStorageRow(
                         ContractFactory.getTotalCurrencyContractAddress(),
                         new DataWord(key.getKey()).toWrapper(),

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryDummy.java
@@ -139,23 +139,32 @@ public class AionRepositoryDummy extends AionRepositoryImpl {
     public ByteArrayWrapper getStorageValue(Address addr, ByteArrayWrapper key) {
         IContractDetails details = getContractDetails(addr);
         ByteArrayWrapper value = (details == null) ? null : details.get(key);
-        if (value == null) {
-            return null;
-        }
-        return (value.isZero()) ? null : value;
-    }
 
-    public void addStorageRow(Address addr, ByteArrayWrapper key, ByteArrayWrapper value) {
-        IContractDetails details = getContractDetails(addr);
-
-        if (details == null) {
-            createAccount(addr);
-            details = getContractDetails(addr);
+        if (value != null && value.isZero()) {
+            // TODO: remove when integrating the AVM
+            // used to ensure FVM correctness
+            throw new IllegalStateException(
+                    "The contract address "
+                            + addr.toString()
+                            + " returned a zero value for the key "
+                            + key.toString()
+                            + " which is not a valid stored value for the FVM. ");
         }
 
-        details.put(key, value);
-        detailsDB.put(ByteArrayWrapper.wrap(addr.toBytes()), details);
+        return value;
     }
+
+    // never used
+    //    public void addStorageRow(Address addr, ByteArrayWrapper key, ByteArrayWrapper value) {
+    //        IContractDetails details = getContractDetails(addr);
+    //
+    //        if (details == null) {
+    //            createAccount(addr);
+    //            details = getContractDetails(addr);
+    //        }
+    //        details.put(key, value);
+    //        detailsDB.put(ByteArrayWrapper.wrap(addr.toBytes()), details);
+    //    }
 
     public byte[] getCode(Address addr) {
         IContractDetails details = getContractDetails(addr);

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -314,11 +314,7 @@ public class AionRepositoryImpl
     @Override
     public ByteArrayWrapper getStorageValue(Address address, ByteArrayWrapper key) {
         IContractDetails details = getContractDetails(address);
-        ByteArrayWrapper value = (details == null) ? null : details.get(key);
-        if (value == null) {
-            return null;
-        }
-        return (value.isZero()) ? null : value;
+        return (details == null) ? null : details.get(key);
     }
 
     @Override

--- a/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
+++ b/modAionImpl/test/org/aion/db/AionContractDetailsTest.java
@@ -1,6 +1,7 @@
 package org.aion.db;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -120,13 +121,11 @@ public class AionContractDetailsTest {
         byte[] val_1 = ByteUtil.hexStringToBytes("0000000000000000000000000000000c");
 
         byte[] key_2 = ByteUtil.hexStringToBytes("5a448d1967513482947d1d3f6104316f");
-        byte[] val_2 = ByteUtil.hexStringToBytes("00000000000000000000000000000000");
 
         byte[] key_3 = ByteUtil.hexStringToBytes("5a448d1967513482947d1d3f61043171");
         byte[] val_3 = ByteUtil.hexStringToBytes("00000000000000000000000000000014");
 
         byte[] key_4 = ByteUtil.hexStringToBytes("18d63b70aa690ad37cb50908746c9a54");
-        byte[] val_4 = ByteUtil.hexStringToBytes("00000000000000000000000000000000");
 
         byte[] key_5 = ByteUtil.hexStringToBytes("5a448d1967513482947d1d3f61043170");
         byte[] val_5 = ByteUtil.hexStringToBytes("00000000000000000000000000000078");
@@ -160,9 +159,9 @@ public class AionContractDetailsTest {
         contractDetails.setAddress(address);
         contractDetails.put(new DataWord(key_0).toWrapper(), new DataWord(val_0).toWrapper());
         contractDetails.put(new DataWord(key_1).toWrapper(), new DataWord(val_1).toWrapper());
-        contractDetails.put(new DataWord(key_2).toWrapper(), new DataWord(val_2).toWrapper());
+        contractDetails.delete(new DataWord(key_2).toWrapper());
         contractDetails.put(new DataWord(key_3).toWrapper(), new DataWord(val_3).toWrapper());
-        contractDetails.put(new DataWord(key_4).toWrapper(), new DataWord(val_4).toWrapper());
+        contractDetails.delete(new DataWord(key_4).toWrapper());
         contractDetails.put(new DataWord(key_5).toWrapper(), new DataWord(val_5).toWrapper());
         contractDetails.put(new DataWord(key_6).toWrapper(), new DataWord(val_6).toWrapper());
         contractDetails.put(new DataWord(key_7).toWrapper(), new DataWord(val_7).toWrapper());
@@ -186,20 +185,14 @@ public class AionContractDetailsTest {
                 ByteUtil.toHexString(
                         contractDetails_.get(new DataWord(key_1).toWrapper()).getData()));
 
-        assertEquals(
-                ByteUtil.toHexString(val_2),
-                ByteUtil.toHexString(
-                        contractDetails_.get(new DataWord(key_2).toWrapper()).getData()));
+        assertNull(contractDetails_.get(new DataWord(key_2).toWrapper()));
 
         assertEquals(
                 ByteUtil.toHexString(val_3),
                 ByteUtil.toHexString(
                         contractDetails_.get(new DataWord(key_3).toWrapper()).getData()));
 
-        assertEquals(
-                ByteUtil.toHexString(val_4),
-                ByteUtil.toHexString(
-                        contractDetails_.get(new DataWord(key_4).toWrapper()).getData()));
+        assertNull(contractDetails_.get(new DataWord(key_4).toWrapper()));
 
         assertEquals(
                 ByteUtil.toHexString(val_5),
@@ -284,14 +277,15 @@ public class AionContractDetailsTest {
         assertEquals(ByteUtil.toHexString(code), ByteUtil.toHexString(deserialized.getCode()));
 
         for (DataWord key : elements.keySet()) {
-            assertEquals(elements.get(key).toWrapper(), wrapValueFromGet(deserialized.get(key.toWrapper())));
+            assertEquals(
+                    elements.get(key).toWrapper(),
+                    wrapValueFromGet(deserialized.get(key.toWrapper())));
         }
 
         DataWord deletedKey = elements.keySet().iterator().next();
 
-        deserialized.put(deletedKey.toWrapper(), DataWord.ZERO.toWrapper());
-        deserialized.put(
-                new DataWord(RandomUtils.nextBytes(16)).toWrapper(), DataWord.ZERO.toWrapper());
+        deserialized.delete(deletedKey.toWrapper());
+        deserialized.delete(new DataWord(RandomUtils.nextBytes(16)).toWrapper());
     }
 
     @Test
@@ -337,12 +331,16 @@ public class AionContractDetailsTest {
         deserialized = deserialize(deserialized.getEncoded(), externalStorage);
 
         for (DataWord key : elements.keySet()) {
-            assertEquals(elements.get(key).toWrapper(), wrapValueFromGet(deserialized.get(key.toWrapper())));
+            assertEquals(
+                    elements.get(key).toWrapper(),
+                    wrapValueFromGet(deserialized.get(key.toWrapper())));
         }
     }
 
     private static ByteArrayWrapper wrapValueForPut(DataWord value) {
-        return (value.isZero()) ? new ByteArrayWrapper(value.getData()) : new ByteArrayWrapper(value.getNoLeadZeroesData());
+        return (value.isZero())
+                ? new ByteArrayWrapper(value.getData())
+                : new ByteArrayWrapper(value.getNoLeadZeroesData());
     }
 
     private static ByteArrayWrapper wrapValueFromGet(ByteArrayWrapper value) {

--- a/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
@@ -4,6 +4,8 @@ import static org.aion.crypto.HashUtil.EMPTY_DATA_HASH;
 import static org.aion.crypto.HashUtil.h256;
 import static org.aion.util.bytes.ByteUtil.EMPTY_BYTE_ARRAY;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import org.aion.base.db.IContractDetails;
@@ -100,5 +102,41 @@ public abstract class AbstractContractDetails implements IContractDetails {
                         + "\n";
         ret += "  Storage: " + getStorageHash();
         return ret;
+    }
+
+    @VisibleForTesting
+    @Override
+    public void setStorage(Map<ByteArrayWrapper, ByteArrayWrapper> storage) {
+        for (Map.Entry<ByteArrayWrapper, ByteArrayWrapper> entry : storage.entrySet()) {
+            ByteArrayWrapper key = entry.getKey();
+            ByteArrayWrapper value = entry.getValue();
+
+            if (value != null) {
+                put(key, value);
+            } else {
+                delete(key);
+            }
+        }
+    }
+
+    @Override
+    public Map<ByteArrayWrapper, ByteArrayWrapper> getStorage(Collection<ByteArrayWrapper> keys) {
+        Map<ByteArrayWrapper, ByteArrayWrapper> storage = new HashMap<>();
+
+        if (keys == null) {
+            throw new IllegalArgumentException("Input keys cannot be null");
+        } else {
+            for (ByteArrayWrapper key : keys) {
+                ByteArrayWrapper value = get(key);
+
+                // we check if the value is not null,
+                // cause we keep all historical keys
+                if ((value != null) && (!value.isZero())) {
+                    storage.put(key, value);
+                }
+            }
+        }
+
+        return storage;
     }
 }

--- a/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
@@ -145,12 +145,6 @@ public abstract class AbstractContractDetails implements IContractDetails {
                 // we check if the value is not null,
                 // cause we keep all historical keys
                 if (value != null) {
-                    if (value.isZero()) {
-                        // TODO: remove when integrating the AVM
-                        // used to ensure FVM correctness
-                        throw new IllegalArgumentException(
-                                "Put with zero values is not allowed for the FVM. Explicit call to delete is necessary.");
-                    }
                     storage.put(key, value);
                 }
             }

--- a/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
@@ -144,7 +144,13 @@ public abstract class AbstractContractDetails implements IContractDetails {
 
                 // we check if the value is not null,
                 // cause we keep all historical keys
-                if ((value != null) && (!value.isZero())) {
+                if (value != null) {
+                    if (value.isZero()) {
+                        // TODO: remove when integrating the AVM
+                        // used to ensure FVM correctness
+                        throw new IllegalArgumentException(
+                                "Put with zero values is not allowed for the FVM. Explicit call to delete is necessary.");
+                    }
                     storage.put(key, value);
                 }
             }

--- a/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractContractDetails.java
@@ -94,13 +94,26 @@ public abstract class AbstractContractDetails implements IContractDetails {
 
     @Override
     public String toString() {
-        String ret =
-                "  Code: "
-                        + (codes.size() < 2
-                                ? Hex.toHexString(getCode())
-                                : codes.size() + " versions")
-                        + "\n";
-        ret += "  Storage: " + getStorageHash();
+        String ret;
+
+        if (codes != null) {
+            ret =
+                    "  Code: "
+                            + (codes.size() < 2
+                                    ? Hex.toHexString(getCode())
+                                    : codes.size() + " versions")
+                            + "\n";
+        } else {
+            ret = "  Code: null\n";
+        }
+
+        byte[] storage = getStorageHash();
+        if (storage != null) {
+            ret += "  Storage: " + Hex.toHexString(storage);
+        } else {
+            ret += "  Storage: null";
+        }
+
         return ret;
     }
 

--- a/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
@@ -310,6 +310,16 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     }
 
     @Override
+    public void removeStorageRow(Address address, ByteArrayWrapper key) {
+        lockDetails.writeLock().lock();
+        try {
+            getContractDetails(address).delete(key);
+        } finally {
+            lockDetails.writeLock().unlock();
+        }
+    }
+
+    @Override
     public ByteArrayWrapper getStorageValue(Address address, ByteArrayWrapper key) {
         ByteArrayWrapper value = getContractDetails(address).get(key);
         if (value == null) {

--- a/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
+++ b/modMcf/src/org/aion/mcf/db/AbstractRepositoryCache.java
@@ -303,12 +303,6 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
     public void addStorageRow(Address address, ByteArrayWrapper key, ByteArrayWrapper value) {
         lockDetails.writeLock().lock();
         try {
-            if (value.isZero()) {
-                // TODO: remove when integrating the AVM
-                // used to ensure FVM correctness
-                throw new IllegalArgumentException(
-                        "Put with zero values is not allowed for the FVM. For deletions, explicit calls to delete are necessary.");
-            }
             getContractDetails(address).put(key, value);
         } finally {
             lockDetails.writeLock().unlock();
@@ -327,15 +321,7 @@ public abstract class AbstractRepositoryCache<BSB extends IBlockStoreBase<?, ?>>
 
     @Override
     public ByteArrayWrapper getStorageValue(Address address, ByteArrayWrapper key) {
-        ByteArrayWrapper value = getContractDetails(address).get(key);
-
-        if (value != null && value.isZero()) {
-            // TODO: remove when integrating the AVM
-            // used to ensure FVM correctness
-            throw new IllegalStateException("Zero values should not be returned by contract.");
-        }
-
-        return value;
+        return getContractDetails(address).get(key);
     }
 
     @Override

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -1,9 +1,7 @@
 package org.aion.mcf.db;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.aion.base.db.IByteArrayKeyValueStore;
@@ -113,65 +111,6 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
     @Override
     public byte[] getEncoded() {
         throw new RuntimeException("Not supported by this implementation.");
-    }
-
-    /**
-     * Returns a mapping of all the key-value pairs who have keys in the collection keys.
-     *
-     * @param keys The keys to query for.
-     * @return The associated mappings.
-     */
-    @Override
-    public Map<ByteArrayWrapper, ByteArrayWrapper> getStorage(Collection<ByteArrayWrapper> keys) {
-        Map<ByteArrayWrapper, ByteArrayWrapper> storage = new HashMap<>();
-        if (keys == null) {
-            throw new IllegalArgumentException("Input keys can't be null");
-        } else {
-            for (ByteArrayWrapper key : keys) {
-                ByteArrayWrapper value = get(key);
-
-                // we check if the value is not null,
-                // cause we keep all historical keys
-                if ((value != null) && (!value.isZero())) {
-                    storage.put(key, value);
-                }
-            }
-        }
-
-        return storage;
-    }
-
-    /**
-     * Sets the storage to contain the specified keys and values. This method creates pairings of
-     * the keys and values by mapping the i'th key in storageKeys to the i'th value in
-     * storageValues.
-     *
-     * @param storageKeys The keys.
-     * @param storageValues The values.
-     */
-    @Override
-    public void setStorage(
-            List<ByteArrayWrapper> storageKeys, List<ByteArrayWrapper> storageValues) {
-
-        for (int i = 0; i < storageKeys.size(); ++i) {
-
-            ByteArrayWrapper key = storageKeys.get(i);
-            ByteArrayWrapper value = storageValues.get(i);
-
-            put(key, value);
-        }
-    }
-
-    /**
-     * Sets the storage to contain the specified key-value mappings.
-     *
-     * @param storage The specified mappings.
-     */
-    @Override
-    public void setStorage(Map<ByteArrayWrapper, ByteArrayWrapper> storage) {
-        for (Map.Entry<ByteArrayWrapper, ByteArrayWrapper> entry : storage.entrySet()) {
-            put(entry.getKey(), entry.getValue());
-        }
     }
 
     /**

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -1,12 +1,11 @@
 package org.aion.mcf.db;
 
-import java.util.Collection;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import org.aion.base.db.IByteArrayKeyValueStore;
 import org.aion.base.db.IContractDetails;
 import org.aion.base.util.ByteArrayWrapper;
@@ -51,6 +50,12 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
     @Override
     public void put(ByteArrayWrapper key, ByteArrayWrapper value) {
         storage.put(key, value);
+        setDirty(true);
+    }
+
+    @Override
+    public void delete(ByteArrayWrapper key) {
+        storage.put(key, null);
         setDirty(true);
     }
 

--- a/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
+++ b/modMcf/src/org/aion/mcf/db/ContractDetailsCacheImpl.java
@@ -51,13 +51,6 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
 
-        if (value.isZero()) {
-            // TODO: remove when integrating the AVM
-            // used to ensure FVM correctness
-            throw new IllegalArgumentException(
-                    "Put with zero values is not allowed for the FVM. For deletions, explicit calls to delete are necessary.");
-        }
-
         storage.put(key, value);
         setDirty(true);
     }
@@ -100,19 +93,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
                 value = value.copy();
             }
         }
-
-        if (value != null && value.isZero()) {
-            // TODO: remove when integrating the AVM
-            // used to ensure FVM correctness
-            throw new IllegalArgumentException(
-                    "Put with zero values is not allowed for the FVM. Explicit call to delete is necessary.");
-        }
-
-        if (value == null) {
-            return null;
-        } else {
-            return value;
-        }
+        return value;
     }
 
     /**

--- a/modMcf/src/org/aion/mcf/vm/types/KernelInterfaceForFastVM.java
+++ b/modMcf/src/org/aion/mcf/vm/types/KernelInterfaceForFastVM.java
@@ -81,7 +81,8 @@ public class KernelInterfaceForFastVM implements KernelInterface {
 
     @Override
     public void removeStorage(Address address, byte[] key) {
-        // TODO: remove this placeholder for changes made in a reorganized commit
+        ByteArrayWrapper storageKey = alignDataToWordSize(key);
+        this.repositoryCache.removeStorageRow(address, storageKey);
     }
 
     @Override

--- a/modMcf/test/org/aion/mcf/db/AionRepositoryCacheTest.java
+++ b/modMcf/test/org/aion/mcf/db/AionRepositoryCacheTest.java
@@ -77,11 +77,11 @@ public class AionRepositoryCacheTest {
     public void testGetStorageValueIsSingleZero() {
         Address address = getNewAddress();
         IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
-        cache.addStorageRow(address, key.toWrapper(), DataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, key.toWrapper());
         assertNull(cache.getStorageValue(address, key.toWrapper()));
 
         key = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
-        cache.addStorageRow(address, key.toWrapper(), DataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, key.toWrapper());
         assertNull(cache.getStorageValue(address, key.toWrapper()));
     }
 
@@ -89,11 +89,11 @@ public class AionRepositoryCacheTest {
     public void testGetStorageValueIsDoubleZero() {
         Address address = getNewAddress();
         IDataWord key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES));
-        cache.addStorageRow(address, key.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, key.toWrapper());
         assertNull(cache.getStorageValue(address, key.toWrapper()));
 
         key = new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES));
-        cache.addStorageRow(address, key.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, key.toWrapper());
         assertNull(cache.getStorageValue(address, key.toWrapper()));
     }
 
@@ -126,20 +126,19 @@ public class AionRepositoryCacheTest {
         Address address = getNewAddress();
 
         // single-single
-        cache.addStorageRow(address, DataWord.ZERO.toWrapper(), DataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, DataWord.ZERO.toWrapper());
         assertNull(cache.getStorageValue(address, DataWord.ZERO.toWrapper()));
 
         // single-double
-        cache.addStorageRow(address, DataWord.ZERO.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, DataWord.ZERO.toWrapper());
         assertNull(cache.getStorageValue(address, DataWord.ZERO.toWrapper()));
 
         // double-single
-        cache.addStorageRow(address, DoubleDataWord.ZERO.toWrapper(), DataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, DoubleDataWord.ZERO.toWrapper());
         assertNull(cache.getStorageValue(address, DoubleDataWord.ZERO.toWrapper()));
 
         // double-double
-        cache.addStorageRow(
-                address, DoubleDataWord.ZERO.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, DoubleDataWord.ZERO.toWrapper());
         assertNull(cache.getStorageValue(address, DoubleDataWord.ZERO.toWrapper()));
     }
 
@@ -151,7 +150,7 @@ public class AionRepositoryCacheTest {
                 new DoubleDataWord(RandomUtils.nextBytes(DoubleDataWord.BYTES)).toWrapper();
         cache.addStorageRow(address, key, value);
         assertEquals(value, cache.getStorageValue(address, key));
-        cache.addStorageRow(address, key, DataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, key);
         assertNull(cache.getStorageValue(address, key));
     }
 
@@ -163,7 +162,7 @@ public class AionRepositoryCacheTest {
         ByteArrayWrapper value = new DataWord(RandomUtils.nextBytes(DataWord.BYTES)).toWrapper();
         cache.addStorageRow(address, key, value);
         assertEquals(value, cache.getStorageValue(address, key));
-        cache.addStorageRow(address, key, DoubleDataWord.ZERO.toWrapper());
+        cache.removeStorageRow(address, key);
         assertNull(cache.getStorageValue(address, key));
     }
 
@@ -227,7 +226,7 @@ public class AionRepositoryCacheTest {
         int count = 1;
         for (ByteArrayWrapper key : keys) {
             if (count % n == 0) {
-                cache.addStorageRow(address, key, DataWord.ZERO.toWrapper());
+                cache.removeStorageRow(address, key);
             }
             count++;
         }

--- a/modMcf/test/org/aion/mcf/db/IContractDetailsTest.java
+++ b/modMcf/test/org/aion/mcf/db/IContractDetailsTest.java
@@ -1,9 +1,11 @@
 package org.aion.mcf.db;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -271,6 +273,44 @@ public class IContractDetailsTest {
             }
             count++;
         }
+    }
+
+    /**
+     * This test is specific to the ContractDetailsCacheImpl class, which at times holds a different
+     * storage value for contracts. This test checks that after an update to the cache object, the
+     * original value from the contract details is not returned for use.
+     */
+    @Test
+    public void testCacheUpdatedAndGetWithOriginalAionContract() {
+
+        ByteArrayWrapper key = getRandomWord(true).toWrapper();
+        ByteArrayWrapper value1 = getRandomWord(true).toWrapper();
+        ByteArrayWrapper value2 = getRandomWord(true).toWrapper();
+
+        // ensure the second value is different
+        // unlikely to be necessary
+        while (Arrays.equals(value1.getData(), value2.getData())) {
+            value2 = getRandomWord(true).toWrapper();
+        }
+
+        // ensure the initial cache has the value
+        cache1.put(key, value1);
+
+        ContractDetailsCacheImpl impl = new ContractDetailsCacheImpl(cache1);
+
+        // check that original value is retrieved
+        assertThat(impl.get(key)).isEqualTo(value1);
+
+        // delete and check that value is missing
+        impl.delete(key);
+        assertThat(impl.get(key)).isEqualTo(null);
+
+        // add new value and check correctness
+        impl.put(key, value2);
+        assertThat(impl.get(key)).isEqualTo(value2);
+
+        // clean-up
+        cache1.delete(key);
     }
 
     // <------------------------------------------HELPERS------------------------------------------->

--- a/modMcf/test/org/aion/mcf/db/IContractDetailsTest.java
+++ b/modMcf/test/org/aion/mcf/db/IContractDetailsTest.java
@@ -2,7 +2,6 @@ package org.aion.mcf.db;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -95,35 +94,31 @@ public class IContractDetailsTest {
     @Test
     public void testPutZeroKeyAndValue() {
         // Try single-single
-        cache1.put(DataWord.ZERO.toWrapper(), DataWord.ZERO.toWrapper());
+        cache1.delete(DataWord.ZERO.toWrapper());
         ByteArrayWrapper result = cache1.get(DataWord.ZERO.toWrapper());
-        assertTrue(result.isZero());
-        assertTrue(result instanceof ByteArrayWrapper);
-        cache2.put(DataWord.ZERO.toWrapper(), DataWord.ZERO.toWrapper());
+        assertNull(result);
+        cache2.delete(DataWord.ZERO.toWrapper());
         assertNull(cache2.get(DataWord.ZERO.toWrapper()));
 
         // Try single-double
-        cache1.put(DataWord.ZERO.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        cache1.delete(DataWord.ZERO.toWrapper());
         result = cache1.get(DataWord.ZERO.toWrapper());
-        assertTrue(result.isZero());
-        assertTrue(result instanceof ByteArrayWrapper);
-        cache2.put(DataWord.ZERO.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        assertNull(result);
+        cache2.delete(DataWord.ZERO.toWrapper());
         assertNull(cache2.get(DataWord.ZERO.toWrapper()));
 
         // Try double-single
-        cache1.put(DoubleDataWord.ZERO.toWrapper(), DataWord.ZERO.toWrapper());
+        cache1.delete(DoubleDataWord.ZERO.toWrapper());
         result = cache1.get(DoubleDataWord.ZERO.toWrapper());
-        assertTrue(result.isZero());
-        assertTrue(result instanceof ByteArrayWrapper);
-        cache2.put(DoubleDataWord.ZERO.toWrapper(), DataWord.ZERO.toWrapper());
+        assertNull(result);
+        cache2.delete(DoubleDataWord.ZERO.toWrapper());
         assertNull(cache2.get(DoubleDataWord.ZERO.toWrapper()));
 
         // Try double-double
-        cache1.put(DoubleDataWord.ZERO.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        cache1.delete(DoubleDataWord.ZERO.toWrapper());
         result = cache1.get(DoubleDataWord.ZERO.toWrapper());
-        assertTrue(result.isZero());
-        assertTrue(result instanceof ByteArrayWrapper);
-        cache2.put(DoubleDataWord.ZERO.toWrapper(), DoubleDataWord.ZERO.toWrapper());
+        assertNull(result);
+        cache2.delete(DoubleDataWord.ZERO.toWrapper());
         assertNull(cache2.get(DoubleDataWord.ZERO.toWrapper()));
     }
 
@@ -228,8 +223,7 @@ public class IContractDetailsTest {
             try {
                 if (count % deleteOdds == 0) {
                     assertNull(impl.get(key));
-                    assertTrue(cache1.get(key).isZero());
-                    assertTrue(cache1.get(key) instanceof ByteArrayWrapper);
+                    assertNull(cache1.get(key));
                 } else {
                     assertEquals(impl.get(key), cache1.get(key));
                 }
@@ -323,13 +317,13 @@ public class IContractDetailsTest {
         // Test DataWord.
         cache.put(key, value);
         assertEquals(value, cache.get(key));
-        cache.put(key, DataWord.ZERO.toWrapper());
+        cache.delete(key);
         checkGetNonExistentPairing(cache, key);
 
         // Test DoubleDataWord.
         cache.put(key, value);
         assertEquals(value, cache.get(key));
-        cache.put(key, DoubleDataWord.ZERO.toWrapper());
+        cache.delete(key);
         checkGetNonExistentPairing(cache, key);
     }
 
@@ -392,7 +386,7 @@ public class IContractDetailsTest {
         int count = 1;
         for (ByteArrayWrapper key : keys) {
             if (count % n == 0) {
-                cache.put(key, DataWord.ZERO.toWrapper());
+                cache.delete(key);
             }
             count++;
         }
@@ -405,7 +399,12 @@ public class IContractDetailsTest {
         int size = keys.size();
         assertEquals(size, values.size());
         for (int i = 0; i < size; i++) {
-            cache.put(keys.get(i), values.get(i));
+            ByteArrayWrapper value = values.get(i);
+            if (value == null || value.isZero()) {
+                cache.delete(keys.get(i));
+            } else {
+                cache.put(keys.get(i), values.get(i));
+            }
         }
     }
 
@@ -445,7 +444,7 @@ public class IContractDetailsTest {
     private void doSetZeroValueViaStorageTest(IContractDetails cache) {
         Map<ByteArrayWrapper, ByteArrayWrapper> storage = new HashMap<>();
         ByteArrayWrapper key = new DataWord(RandomUtils.nextBytes(DataWord.BYTES)).toWrapper();
-        storage.put(key, DataWord.ZERO.toWrapper());
+        storage.put(key, null);
         cache.setStorage(storage);
         checkGetNonExistentPairing(cache, key);
     }
@@ -456,7 +455,7 @@ public class IContractDetailsTest {
 
         for (ByteArrayWrapper key : storage.keySet()) {
             ByteArrayWrapper value = storage.get(key);
-            if (value.isZero()) {
+            if (value == null) {
                 checkGetNonExistentPairing(cache, key);
             } else {
                 assertEquals(value, cache.get(key));
@@ -477,7 +476,7 @@ public class IContractDetailsTest {
         assertEquals(size, values.size());
         for (int i = 0; i < size; i++) {
             if ((i + 1) % n == 0) {
-                storage.put(keys.get(i), DoubleDataWord.ZERO.toWrapper());
+                storage.put(keys.get(i), null);
             } else {
                 storage.put(keys.get(i), values.get(i));
             }
@@ -491,13 +490,7 @@ public class IContractDetailsTest {
      */
     private void checkGetNonExistentPairing(IContractDetails cache, ByteArrayWrapper key) {
         try {
-            if (cache instanceof AionContractDetailsImpl) {
-                ByteArrayWrapper result = cache.get(key);
-                assertTrue(result.isZero());
-                assertTrue(result instanceof ByteArrayWrapper);
-            } else {
-                assertNull(cache.get(key));
-            }
+            assertNull(cache.get(key));
         } catch (AssertionError e) {
             System.err.println("\nAssertion failed on key: " + Hex.toHexString(key.getData()));
             e.printStackTrace();

--- a/modPrecompiled/src/org/aion/precompiled/contracts/ATB/BridgeStorageConnector.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/ATB/BridgeStorageConnector.java
@@ -219,18 +219,24 @@ public class BridgeStorageConnector {
     }
 
     private void setWORD(@Nonnull final DataWord key, @Nonnull final DataWord word) {
-        this.track.addStorageRow(
-                contractAddress,
-                key.toWrapper(),
-                (word.isZero())
-                        ? word.toWrapper()
-                        : new ByteArrayWrapper(word.getNoLeadZeroesData()));
+        if (word.isZero()) {
+            this.track.removeStorageRow(contractAddress, key.toWrapper());
+        } else {
+            this.track.addStorageRow(
+                    contractAddress,
+                    key.toWrapper(),
+                    new ByteArrayWrapper(word.getNoLeadZeroesData()));
+        }
     }
 
     private void setDWORD(@Nonnull final DataWord key, @Nonnull final byte[] dword) {
         assert dword.length > 16;
-        this.track.addStorageRow(
-                contractAddress, key.toWrapper(), new DoubleDataWord(dword).toWrapper());
+        DoubleDataWord ddw = new DoubleDataWord(dword);
+        if (ddw.isZero()) {
+            this.track.removeStorageRow(contractAddress, key.toWrapper());
+        } else {
+            this.track.addStorageRow(contractAddress, key.toWrapper(), ddw.toWrapper());
+        }
     }
 
     private byte[] getDWORD(@Nonnull final DataWord key) {

--- a/modPrecompiled/src/org/aion/precompiled/contracts/AionAuctionContract.java
+++ b/modPrecompiled/src/org/aion/precompiled/contracts/AionAuctionContract.java
@@ -488,10 +488,8 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
         domainName = getNameFromStorage(auctionDomainsAddressName, domainAddress);
         addBigIntegerToStorage(domainAddress, BID_KEY_COUNTER, new BigInteger("0"));
         // remove from auction domains
-        this.track.addStorageRow(
-                auctionDomainsAddress,
-                new DataWord(blake128(domainAddress.toBytes())).toWrapper(),
-                DoubleDataWord.ZERO.toWrapper());
+        this.track.removeStorageRow(
+                auctionDomainsAddress, new DataWord(blake128(domainAddress.toBytes())).toWrapper());
         addToActiveDomains(domainAddress, winnerAddress, domainName, secondHighestBid);
         printWinner(domainAddress, winnerAddress, secondHighestBid, domainName);
     }
@@ -606,30 +604,23 @@ public class AionAuctionContract extends StatefulPrecompiledContract {
 
         printRemoveActiveDomain(domainAddress);
         // erase
-        this.track.addStorageRow(
+        this.track.removeStorageRow(
+                activeDomainsAddress, new DataWord(blake128(domainAddress.toBytes())).toWrapper());
+        this.track.removeStorageRow(
                 activeDomainsAddress,
-                new DataWord(blake128(domainAddress.toBytes())).toWrapper(),
-                DoubleDataWord.ZERO.toWrapper());
-        this.track.addStorageRow(
-                activeDomainsAddress,
-                new DataWord(blake128(blake128(domainAddress.toBytes()))).toWrapper(),
-                DoubleDataWord.ZERO.toWrapper());
-        this.track.addStorageRow(
+                new DataWord(blake128(blake128(domainAddress.toBytes()))).toWrapper());
+        this.track.removeStorageRow(
                 activeDomainsAddressName,
-                new DataWord(blake128(domainAddress.toBytes())).toWrapper(),
-                DoubleDataWord.ZERO.toWrapper());
-        this.track.addStorageRow(
+                new DataWord(blake128(domainAddress.toBytes())).toWrapper());
+        this.track.removeStorageRow(
                 activeDomainsAddressName,
-                new DataWord(blake128(blake128(domainAddress.toBytes()))).toWrapper(),
-                DoubleDataWord.ZERO.toWrapper());
-        this.track.addStorageRow(
+                new DataWord(blake128(blake128(domainAddress.toBytes()))).toWrapper());
+        this.track.removeStorageRow(
                 activeDomainsAddressValue,
-                new DataWord(blake128(domainAddress.toBytes())).toWrapper(),
-                DoubleDataWord.ZERO.toWrapper());
-        this.track.addStorageRow(
+                new DataWord(blake128(domainAddress.toBytes())).toWrapper());
+        this.track.removeStorageRow(
                 activeDomainsAddressTime,
-                new DataWord(blake128(domainAddress.toBytes())).toWrapper(),
-                DoubleDataWord.ZERO.toWrapper());
+                new DataWord(blake128(domainAddress.toBytes())).toWrapper());
     }
 
     /**

--- a/modPrecompiled/test/org/aion/precompiled/contracts/DummyRepo.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/DummyRepo.java
@@ -128,6 +128,9 @@ public class DummyRepo implements IRepositoryCache<AccountState, IBlockStoreBase
         Map<String, byte[]> map = storage.get(addr);
         if (map != null && map.containsKey(key.toString())) {
             byte[] res = map.get(key.toString());
+            if (res == null) {
+                return null;
+            }
             if (res.length <= DataWord.BYTES) {
                 return new DataWord(res).toWrapper();
             } else if (res.length == DoubleDataWord.BYTES) {

--- a/modPrecompiled/test/org/aion/precompiled/contracts/DummyRepo.java
+++ b/modPrecompiled/test/org/aion/precompiled/contracts/DummyRepo.java
@@ -118,6 +118,12 @@ public class DummyRepo implements IRepositoryCache<AccountState, IBlockStoreBase
     }
 
     @Override
+    public void removeStorageRow(Address addr, ByteArrayWrapper key) {
+        Map<String, byte[]> map = storage.computeIfAbsent(addr, k -> new HashMap<>());
+        map.put(key.toString(), null);
+    }
+
+    @Override
     public ByteArrayWrapper getStorageValue(Address addr, ByteArrayWrapper key) {
         Map<String, byte[]> map = storage.get(addr);
         if (map != null && map.containsKey(key.toString())) {


### PR DESCRIPTION
## Description

Last important integration step. Separating the put and delete in contract details to later allow the AVM to put bute arrays that are all 0 values.

Requires changes in [aion_fastvm](https://github.com/aionnetwork/aion_fastvm/pull/52).

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

- existing test suite
- an additional test to ensure that the `ContractDetailsCacheImpl` behaves correctly on put and delete

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
