### PR TITLE
Add module-info for zmq (so IntelliJ doesn't complain)

### DIFF
--- a/3rdParty/libnzmq/src/module-info.java
+++ b/3rdParty/libnzmq/src/module-info.java
@@ -1,0 +1,3 @@
+module libnzmq {
+    exports org.zeromq;
+}

--- a/modApiServer/src/module-info.java
+++ b/modApiServer/src/module-info.java
@@ -20,6 +20,7 @@ module aion.apiserver {
     requires com.google.common;
     requires jdk.unsupported;
     requires aion.vm.api;
+    requires libnzmq;
 
     exports org.aion.api.server.pb;
     exports org.aion.api.server.zmq;

--- a/modBoot/src/module-info.java
+++ b/modBoot/src/module-info.java
@@ -9,6 +9,7 @@ module aion.boot {
     requires aion.p2p;
     requires aion.fastvm;
     requires aion.txpool.impl;
+    requires libnzmq;
 
     uses org.aion.evtmgr.EventMgrModule;
     uses org.aion.log.AionLoggerFactory;


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- After https://github.com/aionnetwork/aion/pull/801 was merged, I realized it caused problems for IntelliJ -- aion_api can't use ZMQ packages because the zmq Java Module did not export "libnzmq" and aion_api didn't require "libnzmq"
- It works fine in Gradle because of how jars are handled when they don't have module-info, and Gradle dependencies happen only through jars
- But IntelliJ doesn't necessarily use the jar of each module in order to make dependencies work, so it needs the module-info 
- Related: https://github.com/aionnetwork/aion_api/pull/61

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
