### PR TITLE
Allow solidity zip compilation over web3

### DIFF
--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -13,6 +13,7 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -1041,6 +1042,31 @@ public class ApiWeb3Aion extends ApiAion {
 
         @SuppressWarnings("unchecked")
         Map<String, CompiledContr> compiled = contract_compileSolidity(_contract);
+        JSONObject obj = new JSONObject();
+        for (String key : compiled.keySet()) {
+            CompiledContr cc = compiled.get(key);
+            obj.put(key, cc.toJSON());
+        }
+        return new RpcMsg(obj);
+    }
+
+    public RpcMsg eth_compileSolidityZip(Object _params) {
+        String _zipfile, _entrypoint;
+        if (_params instanceof JSONArray) {
+            _zipfile = ((JSONArray) _params).get(0) + "";
+            _entrypoint = ((JSONArray) _params).get(1) + "";
+        } else if (_params instanceof JSONObject) {
+            _zipfile = ((JSONObject) _params).get("zipfile") + "";
+            _entrypoint = ((JSONObject) _params).get("entrypoint") + "";
+        } else {
+            return new RpcMsg(null, RpcError.INVALID_PARAMS, "Invalid parameters");
+        }
+
+        byte[] _zippedBytes = Base64.getDecoder().decode(_zipfile);
+
+        @SuppressWarnings("unchecked")
+        Map<String, CompiledContr> compiled =
+                contract_compileSolidityZip(_zippedBytes, _entrypoint);
         JSONObject obj = new JSONObject();
         for (String key : compiled.keySet()) {
             CompiledContr cc = compiled.get(key);

--- a/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
@@ -186,7 +186,8 @@ public class RpcMethods {
     private final Map<String, RpcMethod> eth =
             Map.ofEntries(
                     Map.entry("eth_getCompilers", (params) -> api.eth_getCompilers()),
-                    Map.entry("eth_compileSolidity", (params) -> api.eth_compileSolidity(params)),
+                Map.entry("eth_compileSolidity", (params) -> api.eth_compileSolidity(params)),
+                Map.entry("eth_compileSolidityZip", (params) -> api.eth_compileSolidityZip(params)),
                     Map.entry(
                             "eth_accounts",
                             (params) -> api.eth_accounts()), // belongs to the personal api


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

PR #781 recently added the ability to send zips of solidity contracts to be compiled by the FVM using the Java API. This PR extends that functionality to Web3.

Fixes Issue #611 

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [x] Requires documentation update.

## Testing

The following script succeeds when run from the same directory as a directory `contracts.zip` that has valid Solidity contracts in it.

```
#!/bin/bash
base64txt=$(base64 contracts.zip)
bytes64=$(echo "$base64txt"|tr -d '\n'|tr -d ' ')
datafield='{"jsonrpc":"2.0","method":"eth_compileSolidityZip","params":["'"$bytes64"'","Import.sol"]}'
curl -X POST --data $datafield http://127.0.0.1:8545
```

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [x] Any dependent changes have been made.
