### PR TITLE
Remove aion_api submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
     path = aion_fastvm
     url = https://github.com/aionnetwork/aion_fastvm
     branch = master
-[submodule "aion_api"]
-    path = aion_api
-    url = https://github.com/aionnetwork/aion_api
-    branch = master
 [submodule "aion_gui"]
 	path = aion_gui
 	url = https://github.com/aionnetwork/aion_gui

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,13 @@ allprojects {
 
         flatDir {
             dirs './lib' // does not recurse, don't make subdirectories in here
+<<<<<<< 92e6cf91cfbdd12f87e42993d2e956af3527ddc3
+=======
+        }
+
+        maven { 
+            url "${rootDir}/lib/maven_repo"
+>>>>>>> Gradle build logic for publishing to arbitrary local Maven repo and consuming from one
         }
     }
 }
@@ -390,23 +397,21 @@ configure(subprojects.findAll { it.name != 'aion_api' })  {
     // Configuration(s) specified but the install task does not exist in project :aion_api.
     // Publication mavenPublication not found in project :aion_api.
     
-    apply plugin: 'maven-publish'
-    publishing {
-        publications {
-            mavenJava(MavenPublication) {
-                groupId = 'network.aion'
+	apply plugin: 'maven-publish'
+	publishing {
+		publications {
+			mavenJava(MavenPublication) {
+				groupId = 'network.aion'
+				artifactId = project.hasProperty('mavenPubArtifactId')
+                                ? mavenPubArtifactId
+                                : project.name
+				version = project.hasProperty('mavenPubVersion')
+                                ? mavenPubVersion
+                                : kernelVersionFromSrc();
 
-                afterEvaluate {
-                    artifactId = project.hasProperty('mavenPubArtifactId')
-                                    ? mavenPubArtifactId
-                                    : project.name
-                    version = project.hasProperty('mavenPubVersion')
-                                    ? mavenPubVersion
-                                    : kernelVersionFromSrc();
-                }
-                from components.java
-            }   
-        }   
+				from components.java
+			}   
+		}   
 
         repositories {
             maven {
@@ -450,5 +455,9 @@ configure(subprojects.findAll { it.name != 'aion_api' })  {
             }
         }
 
+<<<<<<< 92e6cf91cfbdd12f87e42993d2e956af3527ddc3
     } //publishing
+=======
+	} //publishing
+>>>>>>> Gradle build logic for publishing to arbitrary local Maven repo and consuming from one
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,10 @@ allprojects {
 
         flatDir {
             dirs './lib' // does not recurse, don't make subdirectories in here
-<<<<<<< 92e6cf91cfbdd12f87e42993d2e956af3527ddc3
-=======
         }
 
         maven { 
             url "${rootDir}/lib/maven_repo"
->>>>>>> Gradle build logic for publishing to arbitrary local Maven repo and consuming from one
         }
     }
 }
@@ -254,9 +251,6 @@ build {
 }
 
 task prePack(type:Exec)  {
-    dependsOn ':aion_api:cleanPack' 
-    dependsOn ':aion_api:build'
-
     if(findProject(":modGui") != null && gradle.useGui) { 
         dependsOn ':modGui:setupAionRootProject';
         environment "useGui", "true"
@@ -319,7 +313,6 @@ task packDevDocker(type: Exec) {
 }
 
 clean { 
-    dependsOn ':aion_api:clean' 
     dependsOn 'cleanJars'
     delete dirPack
     delete file('report')
@@ -370,7 +363,7 @@ task fixIdea {
     // this task puts those files where IDEA expects them by running build and test
 
     dependsOn build
-    configure(subprojects.findAll { it.name != 'aion_api' }) {
+    subprojects {
         dependsOn test
     }
 }
@@ -390,13 +383,7 @@ def kernelVersionFromSrc() {
     return version;
 }
 
-configure(subprojects.findAll { it.name != 'aion_api' })  { 
-    // it makes the following harmless warning message, but that will not be a problem once aion_api
-    // is no longer a submodule:
-    //
-    // Configuration(s) specified but the install task does not exist in project :aion_api.
-    // Publication mavenPublication not found in project :aion_api.
-    
+subprojects  { 
 	apply plugin: 'maven-publish'
 	publishing {
 		publications {
@@ -455,9 +442,5 @@ configure(subprojects.findAll { it.name != 'aion_api' })  {
             }
         }
 
-<<<<<<< 92e6cf91cfbdd12f87e42993d2e956af3527ddc3
-    } //publishing
-=======
 	} //publishing
->>>>>>> Gradle build logic for publishing to arbitrary local Maven repo and consuming from one
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,6 @@ include 'modAionBase', 'modAion', 'modAionImpl',
     'modVM',
     'modApiServer',
     'aion_fastvm/modFastVM',
-    'aion_api',
     'aion_vm_api',
     'modBoot'
 


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Remove aion_api as a submodule from aion
- `./gradlew pack` will no longer have the aion api (it will be distributed separately in the future)
- Related: https://github.com/aionnetwork/aion_api/pull/60 

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- compiled and did pack build, then made sure the new pack output's kernel can start up 

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
