### PR TITLE
Add -Xmx8g into the launch script

### DIFF
--- a/aion.sh
+++ b/aion.sh
@@ -46,7 +46,7 @@ fi
 
 # to suppress illegal reflective access warning out of xnio and protobuf
 # (we depend on xnio transitively via undertow-core)
-JAVA_OPTS+=" --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED"
+JAVA_OPTS+=" -Xmx8g --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED"
 
 ####### WATCHGUARD IMPLEMENTATION #######
 #				    	#

--- a/aion.sh
+++ b/aion.sh
@@ -44,9 +44,14 @@ if [[ ! ${JAVA_OPTS} = *"-Xms"* ]]; then
   JAVA_OPTS+=" -Xms4g"
 fi
 
+if [[ ! ${JAVA_OPTS} = *"-Xmx"* ]]; then
+  JAVA_OPTS+=" -Xmx8g"
+fi
+
+
 # to suppress illegal reflective access warning out of xnio and protobuf
 # (we depend on xnio transitively via undertow-core)
-JAVA_OPTS+=" -Xmx8g --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED"
+JAVA_OPTS+=" --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED"
 
 ####### WATCHGUARD IMPLEMENTATION #######
 #				    	#


### PR DESCRIPTION
## Description

Add Xmx settings in the launch script for defining the jvm max heap size to prevent the java default settings will crash the deployed node has small memory resource.

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- N/A

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
