### PR TITLE
Minor enhancements to stats and kernel use

### DIFF
--- a/config/mainnet/config.xml
+++ b/config/mainnet/config.xml
@@ -66,7 +66,7 @@
         <!--Sets the physical location on disk where data will be stored.-->
         <path>database</path>
         <!--Boolean value. Enable/disable database integrity check run at startup.-->
-        <check_integrity>true</check_integrity>
+        <check_integrity>false</check_integrity>
         <!--Data pruning behavior for the state database. Options: FULL, TOP, SPREAD.-->
         <!--FULL: the state is not pruned-->
         <!--TOP: the state is kept only for the top K blocks; limits sync to branching only within the stored blocks-->

--- a/config/mastery/config.xml
+++ b/config/mastery/config.xml
@@ -62,7 +62,7 @@
         <!--Sets the physical location on disk where data will be stored.-->
         <path>database</path>
         <!--Boolean value. Enable/disable database integrity check run at startup.-->
-        <check_integrity>true</check_integrity>
+        <check_integrity>false</check_integrity>
         <!--Data pruning behavior for the state database. Options: FULL, TOP, SPREAD.-->
         <!--FULL: the state is not pruned-->
         <!--TOP: the state is kept only for the top K blocks; limits sync to branching only within the stored blocks-->

--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -171,7 +171,8 @@ public class AionHub {
                 cfg.getSync().getCompactEnabled()
                         ? cfg.getSync().getSlowImportTime()
                         : 0, // set to 0 when disabled
-                cfg.getSync().getCompactFrequency());
+                cfg.getSync().getCompactFrequency(),
+                cfg.getNet().getP2p().getMaxActiveNodes());
 
         ChainConfiguration chainConfig = new ChainConfiguration();
         this.propHandler =

--- a/modAionImpl/src/org/aion/zero/impl/sync/RequestCounter.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/RequestCounter.java
@@ -12,7 +12,19 @@ public class RequestCounter {
     private long bodies = 0;
     private long total = 0;
 
-    public RequestCounter() {}
+    public RequestCounter(RequestType type) {
+        switch (type) {
+            case STATUS:
+                incStatus();
+                break;
+            case HEADERS:
+                incHeaders();
+                break;
+            case BODIES:
+                incBodies();
+                break;
+        }
+    }
 
     public long getStatus() {
         return status;

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -168,7 +168,8 @@ public final class SyncMgr {
             final boolean _showStatus,
             final Set<StatsType> showStatistics,
             final int _slowImportTime,
-            final int _compactFrequency) {
+            final int _compactFrequency,
+            final int maxActivePeers) {
         p2pMgr = _p2pMgr;
         chain = _chain;
         evtMgr = _evtMgr;
@@ -178,7 +179,7 @@ public final class SyncMgr {
         blockHeaderValidator = new ChainConfiguration().createBlockHeaderValidator();
 
         long selfBest = chain.getBestBlock().getNumber();
-        stats = new SyncStats(selfBest, _showStatus, showStatistics);
+        stats = new SyncStats(selfBest, _showStatus, showStatistics, maxActivePeers);
 
         syncGb =
                 new Thread(

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
@@ -128,22 +128,21 @@ public final class SyncStats {
                 RequestCounter current = requestsToPeers.get(nodeId);
 
                 if (current == null) {
-                    current = new RequestCounter();
+                    current = new RequestCounter(type);
                     requestsToPeers.put(nodeId, current);
+                } else {
+                    switch (type) {
+                        case STATUS:
+                            current.incStatus();
+                            break;
+                        case HEADERS:
+                            current.incHeaders();
+                            break;
+                        case BODIES:
+                            current.incBodies();
+                            break;
+                    }
                 }
-
-                switch (type) {
-                    case STATUS:
-                        current.incStatus();
-                        break;
-                    case HEADERS:
-                        current.incHeaders();
-                        break;
-                    case BODIES:
-                        current.incBodies();
-                        break;
-                }
-
             } finally {
                 requestsLock.unlock();
             }
@@ -165,10 +164,13 @@ public final class SyncStats {
 
             float totalReq = 0f;
 
+            // if there are any values the total will be != 0 after this
             for (RequestCounter rc : requestsToPeers.values()) {
                 totalReq += rc.getTotal();
             }
 
+            // resources are locked so the requestsToPeers map is unchanged
+            // if we enter this loop the totalReq is not equal to 0
             for (Map.Entry<String, RequestCounter> entry : requestsToPeers.entrySet()) {
                 percentageReq.put(entry.getKey(), entry.getValue().getTotal() / totalReq);
             }

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskShowStatus.java
@@ -205,7 +205,7 @@ final class TaskShowStatus implements Runnable {
      * @return log stream with peers statistical data on seeds
      */
     private String dumpTopSeedsInfo() {
-        Map<String, Long> totalBlocksByPeer = this.stats.getTotalBlocksByPeer();
+        Map<String, Integer> totalBlocksByPeer = this.stats.getTotalBlocksByPeer();
 
         StringBuilder sb = new StringBuilder();
 
@@ -240,7 +240,7 @@ final class TaskShowStatus implements Runnable {
      * @return log stream with peers statistical data on leeches
      */
     private String dumpTopLeechesInfo() {
-        Map<String, Long> totalBlockReqByPeer = this.stats.getTotalBlockRequestsByPeer();
+        Map<String, Integer> totalBlockReqByPeer = this.stats.getTotalBlockRequestsByPeer();
 
         StringBuilder sb = new StringBuilder();
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStats.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class ResponseStats {
@@ -12,7 +13,7 @@ public class ResponseStats {
     private final Map<String, Deque<Long>> requestTimeByPeers = new HashMap<>();
 
     /** Records average response time of peers and number of aggregates data points. */
-    private final Map<String, Pair<Double, Integer>> responseStatsByPeers = new HashMap<>();
+    private final Map<String, Pair<Double, Integer>> responseStatsByPeers = new LRUMap<>(128);
 
     /**
      * Log the time of a request sent to a peer.

--- a/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStats.java
@@ -2,7 +2,6 @@ package org.aion.zero.impl.sync.statistics;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang3.tuple.Pair;
@@ -10,10 +9,15 @@ import org.apache.commons.lang3.tuple.Pair;
 public class ResponseStats {
 
     /** Records time of requests made to peers. */
-    private final Map<String, Deque<Long>> requestTimeByPeers = new HashMap<>();
+    private final Map<String, Deque<Long>> requestTimeByPeers;
 
     /** Records average response time of peers and number of aggregates data points. */
-    private final Map<String, Pair<Double, Integer>> responseStatsByPeers = new LRUMap<>(128);
+    private final Map<String, Pair<Double, Integer>> responseStatsByPeers;
+
+    public ResponseStats(int maxActivePeers) {
+        requestTimeByPeers = new LRUMap<>(maxActivePeers);
+        responseStatsByPeers = new LRUMap<>(maxActivePeers);
+    }
 
     /**
      * Log the time of a request sent to a peer.

--- a/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStatsTracker.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStatsTracker.java
@@ -30,11 +30,11 @@ public class ResponseStatsTracker {
     private final ResponseStats bodies;
     private final Lock lockBodies;
 
-    public ResponseStatsTracker() {
+    public ResponseStatsTracker(int maxActivePeers) {
         // instantiate objects for gathering stats
-        this.status = new ResponseStats();
-        this.headers = new ResponseStats();
-        this.bodies = new ResponseStats();
+        this.status = new ResponseStats(maxActivePeers);
+        this.headers = new ResponseStats(maxActivePeers);
+        this.bodies = new ResponseStats(maxActivePeers);
 
         // instantiate locks
         this.lockStatus = new ReentrantLock();

--- a/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
@@ -206,7 +206,7 @@ public class SyncStatsTest {
         SyncStats stats = new SyncStats(chain.getBestBlock().getNumber(), true);
 
         // ensures correct behaviour on empty stats
-        Map<String, Long> emptyTotalBlockReqByPeer = stats.getTotalBlocksByPeer();
+        Map<String, Integer> emptyTotalBlockReqByPeer = stats.getTotalBlocksByPeer();
         assertThat(emptyTotalBlockReqByPeer.isEmpty()).isTrue();
 
         int peerNo = 0;
@@ -223,17 +223,16 @@ public class SyncStatsTest {
             peerNo++;
         }
 
-        Map<String, Long> totalBlockReqByPeer = stats.getTotalBlocksByPeer();
+        Map<String, Integer> totalBlockReqByPeer = stats.getTotalBlocksByPeer();
         assertThat(totalBlockReqByPeer.size()).isEqualTo(peers.size());
 
         int total = 3;
-        long lastTotalBlocks = processedBlocks;
+        int lastTotalBlocks = processedBlocks;
         for (String nodeId : peers) {
             // ensures desc order
             assertThat(lastTotalBlocks >= totalBlockReqByPeer.get(nodeId)).isTrue();
             lastTotalBlocks = totalBlockReqByPeer.get(nodeId);
-            assertEquals(Long.valueOf(total), totalBlockReqByPeer.get(nodeId));
-
+            assertThat(totalBlockReqByPeer.get(nodeId)).isEqualTo(total);
             total--;
         }
     }
@@ -385,7 +384,7 @@ public class SyncStatsTest {
         SyncStats stats = new SyncStats(0L, true);
 
         // ensures correct behaviour on empty stats
-        Map<String, Long> emptyTotalBlocksByPeer = stats.getTotalBlockRequestsByPeer();
+        Map<String, Integer> emptyTotalBlocksByPeer = stats.getTotalBlockRequestsByPeer();
         assertThat(emptyTotalBlocksByPeer.isEmpty()).isTrue();
 
         int blocks = 3;
@@ -398,10 +397,10 @@ public class SyncStatsTest {
             blocks--;
         }
 
-        Map<String, Long> totalBlocksByPeer = stats.getTotalBlockRequestsByPeer();
+        Map<String, Integer> totalBlocksByPeer = stats.getTotalBlockRequestsByPeer();
         assertThat(totalBlocksByPeer.size()).isEqualTo(peers.size());
 
-        Long lastTotalBlocks = (long) peers.size();
+        int lastTotalBlocks = peers.size();
         for (String nodeId : totalBlocksByPeer.keySet()) {
             // ensures desc order
             assertThat(lastTotalBlocks >= totalBlocksByPeer.get(nodeId)).isTrue();


### PR DESCRIPTION
## Description

This PR solves several issues:

1. Bug fix: The number of peers stored when gathering stats is bounded using an LRU map.
2. Fixes issue #825 by switching from using `long` to `int` in the maps used by the stats.
3. A minor refactoring makes it more clear that division by zero is not possible in computing the percentages of requests made to peers.
4. Changing the default config for performing integrity checks.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing tests

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
