### PR TITLE
Response stats expansion

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/RequestCounter.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/RequestCounter.java
@@ -10,6 +10,9 @@ public class RequestCounter {
     private long status = 0;
     private long headers = 0;
     private long bodies = 0;
+    private long blocks = 0;
+    private long receipts = 0;
+    private long trieData = 0;
     private long total = 0;
 
     public RequestCounter(RequestType type) {
@@ -22,6 +25,15 @@ public class RequestCounter {
                 break;
             case BODIES:
                 incBodies();
+                break;
+            case BLOCKS:
+                incBlocks();
+                break;
+            case RECEIPTS:
+                incRecepts();
+                break;
+            case TRIE_DATA:
+                incTrieData();
                 break;
         }
     }
@@ -36,6 +48,18 @@ public class RequestCounter {
 
     public long getBodies() {
         return bodies;
+    }
+
+    public long getBlocks() {
+        return blocks;
+    }
+
+    public long getReceipts() {
+        return receipts;
+    }
+
+    public long getTrieData() {
+        return trieData;
     }
 
     public long getTotal() {
@@ -54,6 +78,21 @@ public class RequestCounter {
 
     public void incBodies() {
         this.bodies++;
+        this.total++;
+    }
+
+    public void incBlocks() {
+        this.blocks++;
+        this.total++;
+    }
+
+    public void incRecepts() {
+        this.receipts++;
+        this.total++;
+    }
+
+    public void incTrieData() {
+        this.trieData++;
         this.total++;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/RequestType.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/RequestType.java
@@ -8,5 +8,8 @@ package org.aion.zero.impl.sync;
 public enum RequestType {
     STATUS,
     HEADERS,
-    BODIES
+    BODIES,
+    BLOCKS,
+    RECEIPTS,
+    TRIE_DATA
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
@@ -374,39 +374,15 @@ public final class SyncStats {
         }
     }
 
-    public void updateStatusRequest(String displayId, long requestTime) {
+    public void updateRequestTime(String displayId, long requestTime, RequestType requestType) {
         if (responsesEnabled) {
-            responseTracker.updateStatusRequest(displayId, requestTime);
+            responseTracker.updateRequestTime(displayId, requestTime, requestType);
         }
     }
 
-    public void updateHeadersRequest(String displayId, long requestTime) {
+    public void updateResponseTime(String displayId, long responseTime, RequestType requestType) {
         if (responsesEnabled) {
-            responseTracker.updateHeadersRequest(displayId, requestTime);
-        }
-    }
-
-    public void updateBodiesRequest(String displayId, long requestTime) {
-        if (responsesEnabled) {
-            responseTracker.updateBodiesRequest(displayId, requestTime);
-        }
-    }
-
-    public void updateStatusResponse(String displayId, long responseTime) {
-        if (responsesEnabled) {
-            responseTracker.updateStatusResponse(displayId, responseTime);
-        }
-    }
-
-    public void updateHeadersResponse(String displayId, long responseTime) {
-        if (responsesEnabled) {
-            responseTracker.updateHeadersResponse(displayId, responseTime);
-        }
-    }
-
-    public void updateBodiesResponse(String displayId, long responseTime) {
-        if (responsesEnabled) {
-            responseTracker.updateBodiesResponse(displayId, responseTime);
+            responseTracker.updateResponseTime(displayId, responseTime, requestType);
         }
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncStats.java
@@ -159,6 +159,15 @@ public final class SyncStats {
                         case BODIES:
                             current.incBodies();
                             break;
+                        case BLOCKS:
+                            current.incBlocks();
+                            break;
+                        case RECEIPTS:
+                            current.incRecepts();
+                            break;
+                        case TRIE_DATA:
+                            current.incTrieData();
+                            break;
                     }
                 }
             } finally {
@@ -175,7 +184,7 @@ public final class SyncStats {
      *     requests made by the node
      */
     Map<String, Float> getPercentageOfRequestsToPeers() {
-        if (responsesEnabled) {
+        if (requestsEnabled) {
             requestsLock.lock();
 
             try {

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetBodies.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetBodies.java
@@ -87,7 +87,7 @@ final class TaskGetBodies implements Runnable {
                     new ReqBlocksBodies(
                             headers.stream().map(k -> k.getHash()).collect(Collectors.toList())));
             stats.updateTotalRequestsToPeer(displayId, RequestType.BODIES);
-            stats.updateBodiesRequest(displayId, System.nanoTime());
+            stats.updateRequestTime(displayId, System.nanoTime(), RequestType.BODIES);
 
             headersWithBodiesRequested.put(idHash, hw);
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetHeaders.java
@@ -172,7 +172,7 @@ final class TaskGetHeaders implements Runnable {
         ReqBlocksHeaders rbh = new ReqBlocksHeaders(from, size);
         this.p2p.send(node.getIdHash(), node.getIdShort(), rbh);
         stats.updateTotalRequestsToPeer(node.getIdShort(), RequestType.STATUS);
-        stats.updateHeadersRequest(node.getIdShort(), System.nanoTime());
+        stats.updateRequestTime(node.getIdShort(), System.nanoTime(), RequestType.HEADERS);
 
         // update timestamp
         state.setLastHeaderRequest(now);

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskGetStatus.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskGetStatus.java
@@ -46,7 +46,8 @@ final class TaskGetStatus implements Runnable {
                     // System.out.println("requesting-status from-node=" + n.getIdShort());
                     p2p.send(node.getIdHash(), node.getIdShort(), reqStatus);
                     stats.updateTotalRequestsToPeer(node.getIdShort(), RequestType.STATUS);
-                    stats.updateStatusRequest(node.getIdShort(), System.nanoTime());
+                    stats.updateRequestTime(
+                            node.getIdShort(), System.nanoTime(), RequestType.STATUS);
                 }
                 Thread.sleep(interval);
             } catch (Exception e) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksBodiesHandler.java
@@ -7,6 +7,7 @@ import org.aion.p2p.Handler;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.Ver;
 import org.aion.zero.impl.sync.Act;
+import org.aion.zero.impl.sync.RequestType;
 import org.aion.zero.impl.sync.SyncMgr;
 import org.aion.zero.impl.sync.msg.ResBlocksBodies;
 import org.slf4j.Logger;
@@ -44,7 +45,9 @@ public final class ResBlocksBodiesHandler extends Handler {
             }
 
         } else {
-            this.syncMgr.getSyncStats().updateBodiesResponse(_displayId, System.nanoTime());
+            this.syncMgr
+                    .getSyncStats()
+                    .updateResponseTime(_displayId, System.nanoTime(), RequestType.BODIES);
 
             if (bodies.isEmpty()) {
                 p2pMgr.errCheck(_nodeIdHashcode, _displayId);

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksHeadersHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksHeadersHandler.java
@@ -7,6 +7,7 @@ import org.aion.p2p.Handler;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.Ver;
 import org.aion.zero.impl.sync.Act;
+import org.aion.zero.impl.sync.RequestType;
 import org.aion.zero.impl.sync.SyncMgr;
 import org.aion.zero.impl.sync.msg.ResBlocksHeaders;
 import org.aion.zero.types.A0BlockHeader;
@@ -35,7 +36,9 @@ public final class ResBlocksHeadersHandler extends Handler {
         ResBlocksHeaders resHeaders = ResBlocksHeaders.decode(_msgBytes);
         if (resHeaders != null) {
 
-            this.syncMgr.getSyncStats().updateHeadersResponse(_displayId, System.nanoTime());
+            this.syncMgr
+                    .getSyncStats()
+                    .updateResponseTime(_displayId, System.nanoTime(), RequestType.HEADERS);
 
             List<A0BlockHeader> headers = resHeaders.getHeaders();
             if (headers != null && headers.size() > 0) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
@@ -8,6 +8,7 @@ import org.aion.p2p.INode;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.Ver;
 import org.aion.zero.impl.sync.Act;
+import org.aion.zero.impl.sync.RequestType;
 import org.aion.zero.impl.sync.SyncMgr;
 import org.aion.zero.impl.sync.msg.ResStatus;
 import org.slf4j.Logger;
@@ -41,7 +42,9 @@ public final class ResStatusHandler extends Handler {
             }
         }
 
-        this.syncMgr.getSyncStats().updateStatusResponse(_displayId, System.nanoTime());
+        this.syncMgr
+                .getSyncStats()
+                .updateResponseTime(_displayId, System.nanoTime(), RequestType.STATUS);
         this.syncMgr.getSyncStats().updatePeerTotalBlocks(_displayId, 1);
 
         INode node = this.p2pMgr.getActiveNodes().get(_nodeIdHashcode);

--- a/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStats.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/statistics/ResponseStats.java
@@ -42,7 +42,7 @@ public class ResponseStats {
      * @param nodeId peer display identifier
      * @param responseTime time when the response was received in nanoseconds
      */
-    public void updateResponseTime(String nodeId, long responseTime) {
+    public void updateResponseStats(String nodeId, long responseTime) {
         if (!requestTimeByPeers.containsKey(nodeId) || requestTimeByPeers.get(nodeId).isEmpty()) {
             return;
         }

--- a/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
@@ -91,12 +91,12 @@ public class SyncStatsTest {
     @Test
     public void testTotalRequestsToPeersStat() {
         List<String> peers = new ArrayList<>(this.peers);
-        while (peers.size() < 4) {
+        while (peers.size() < 7) {
             peers.add(UUID.randomUUID().toString().substring(0, 6));
         }
 
-        // this tests requires at least 3 peers in the list
-        assertThat(peers.size()).isAtLeast(4);
+        // this tests requires at least 6 peers in the list
+        assertThat(peers.size()).isAtLeast(6);
 
         StandaloneBlockchain chain = bundle.bc;
         SyncStats stats = new SyncStats(chain.getBestBlock().getNumber(), true);
@@ -107,24 +107,33 @@ public class SyncStatsTest {
 
         float processedRequests = 0;
 
-        String firstPeer = peers.get(0);
-        String secondPeer = peers.get(1);
-        String thirdPeer = peers.get(2);
-
         for (String peer : peers) {
             // status requests
             stats.updateTotalRequestsToPeer(peer, RequestType.STATUS);
             processedRequests++;
-
-            if (peer == firstPeer || peer == secondPeer) {
-                // header requests
+            // header requests
+            if (peers.subList(0, 5).contains(peer)) {
                 stats.updateTotalRequestsToPeer(peer, RequestType.HEADERS);
                 processedRequests++;
             }
-
             // bodies requests
-            if (peer == firstPeer) {
+            if (peers.subList(0, 4).contains(peer)) {
                 stats.updateTotalRequestsToPeer(peer, RequestType.BODIES);
+                processedRequests++;
+            }
+            // blocks requests
+            if (peers.subList(0, 3).contains(peer)) {
+                stats.updateTotalRequestsToPeer(peer, RequestType.BLOCKS);
+                processedRequests++;
+            }
+            // receipts requests
+            if (peers.subList(0, 2).contains(peer)) {
+                stats.updateTotalRequestsToPeer(peer, RequestType.RECEIPTS);
+                processedRequests++;
+            }
+            // trieData requests
+            if (peer == peers.get(0)) {
+                stats.updateTotalRequestsToPeer(peer, RequestType.TRIE_DATA);
                 processedRequests++;
             }
         }
@@ -134,20 +143,37 @@ public class SyncStatsTest {
         // makes sure no additional peers were created
         assertThat(reqToPeers.size()).isEqualTo(peers.size());
 
+        String firstPeer = peers.get(0);
+        String secondPeer = peers.get(1);
+        String thirdPeer = peers.get(2);
+        String fourthPeer = peers.get(3);
+        String fifthPeer = peers.get(4);
+        String sixthPeer = peers.get(5);
+
         // by design (the updates above are not symmetrical)
+        reqToPeers.get(peers.get(0));
         assertThat(reqToPeers.get(firstPeer)).isGreaterThan(reqToPeers.get(secondPeer));
-        assertThat(reqToPeers.get(firstPeer)).isEqualTo(3 / processedRequests);
+        assertThat(reqToPeers.get(firstPeer)).isEqualTo(6 / processedRequests);
 
         assertThat(reqToPeers.get(secondPeer)).isGreaterThan(reqToPeers.get(thirdPeer));
-        assertThat(reqToPeers.get(secondPeer)).isEqualTo(2 / processedRequests);
+        assertThat(reqToPeers.get(secondPeer)).isEqualTo(5 / processedRequests);
 
-        assertThat(reqToPeers.get(thirdPeer)).isEqualTo(1 / processedRequests);
+        assertThat(reqToPeers.get(thirdPeer)).isGreaterThan(reqToPeers.get(fourthPeer));
+        assertThat(reqToPeers.get(thirdPeer)).isEqualTo(4 / processedRequests);
 
-        for (String otherPeers : peers.subList(3, peers.size())) {
-            assertThat(reqToPeers.get(otherPeers)).isEqualTo(reqToPeers.get(thirdPeer));
+        assertThat(reqToPeers.get(fourthPeer)).isGreaterThan(reqToPeers.get(fifthPeer));
+        assertThat(reqToPeers.get(fourthPeer)).isEqualTo(3 / processedRequests);
+
+        assertThat(reqToPeers.get(fifthPeer)).isGreaterThan(reqToPeers.get(sixthPeer));
+        assertThat(reqToPeers.get(fifthPeer)).isEqualTo(2 / processedRequests);
+
+        assertThat(reqToPeers.get(sixthPeer)).isEqualTo(1 / processedRequests);
+
+        for (String otherPeers : peers.subList(6, peers.size())) {
+            assertThat(reqToPeers.get(otherPeers)).isEqualTo(reqToPeers.get(sixthPeer));
         }
 
-        int blocks = 3;
+        int blocks = 6;
 
         float lastPercentage = (float) 1;
         float diffThreshold = (float) 0.01;
@@ -164,32 +190,39 @@ public class SyncStatsTest {
     @Test
     public void testTotalRequestsToPeersStatDisabled() {
         List<String> peers = new ArrayList<>(this.peers);
-        while (peers.size() < 4) {
+        while (peers.size() < 7) {
             peers.add(UUID.randomUUID().toString().substring(0, 6));
         }
 
         // this tests requires at least 3 peers in the list
-        assertThat(peers.size()).isAtLeast(4);
+        assertThat(peers.size()).isAtLeast(6);
 
         StandaloneBlockchain chain = bundle.bc;
         // disables the stats
         SyncStats stats = new SyncStats(chain.getBestBlock().getNumber(), false);
 
-        String firstPeer = peers.get(0);
-        String secondPeer = peers.get(1);
-
         for (String peer : peers) {
             // status requests
             stats.updateTotalRequestsToPeer(peer, RequestType.STATUS);
-
-            if (peer == firstPeer || peer == secondPeer) {
-                // header requests
+            // header requests
+            if (peers.subList(0, 5).contains(peer)) {
                 stats.updateTotalRequestsToPeer(peer, RequestType.HEADERS);
             }
-
             // bodies requests
-            if (peer == firstPeer) {
+            if (peers.subList(0, 4).contains(peer)) {
                 stats.updateTotalRequestsToPeer(peer, RequestType.BODIES);
+            }
+            // blocks requests
+            if (peers.subList(0, 3).contains(peer)) {
+                stats.updateTotalRequestsToPeer(peer, RequestType.BLOCKS);
+            }
+            // receipts requests
+            if (peers.subList(0, 2).contains(peer)) {
+                stats.updateTotalRequestsToPeer(peer, RequestType.RECEIPTS);
+            }
+            // trieData requests
+            if (peer == peers.get(0)) {
+                stats.updateTotalRequestsToPeer(peer, RequestType.TRIE_DATA);
             }
         }
 

--- a/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/SyncStatsTest.java
@@ -436,18 +436,18 @@ public class SyncStatsTest {
         assertThat(stats.dumpResponseStats()).isEmpty();
 
         // request time is logged but no response is received
-        stats.updateStatusRequest("dummy", System.nanoTime());
-        stats.updateHeadersRequest("dummy", System.nanoTime());
-        stats.updateBodiesRequest("dummy", System.nanoTime());
+        stats.updateRequestTime("dummy", System.nanoTime(), RequestType.STATUS);
+        stats.updateRequestTime("dummy", System.nanoTime(), RequestType.HEADERS);
+        stats.updateRequestTime("dummy", System.nanoTime(), RequestType.BODIES);
         assertThat(stats.getResponseStats()).isNull();
         assertThat(stats.dumpResponseStats()).isEmpty();
 
         stats = new SyncStats(0L, true);
 
         // response time is logged but no request exists
-        stats.updateStatusResponse("dummy", System.nanoTime());
-        stats.updateHeadersResponse("dummy", System.nanoTime());
-        stats.updateBodiesResponse("dummy", System.nanoTime());
+        stats.updateResponseTime("dummy", System.nanoTime(), RequestType.STATUS);
+        stats.updateResponseTime("dummy", System.nanoTime(), RequestType.HEADERS);
+        stats.updateResponseTime("dummy", System.nanoTime(), RequestType.BODIES);
         assertThat(stats.getResponseStats()).isNull();
         assertThat(stats.dumpResponseStats()).isEmpty();
     }
@@ -467,16 +467,16 @@ public class SyncStatsTest {
                 time = System.nanoTime();
 
                 // status -> type of request 1
-                stats.updateStatusRequest(nodeId, time);
-                stats.updateStatusResponse(nodeId, time + 1_000_000);
+                stats.updateRequestTime(nodeId, time, RequestType.STATUS);
+                stats.updateResponseTime(nodeId, time + 1_000_000, RequestType.STATUS);
 
                 // headers -> type of request 2
-                stats.updateHeadersRequest(nodeId, time);
-                stats.updateHeadersResponse(nodeId, time + 1_000_000);
+                stats.updateRequestTime(nodeId, time, RequestType.HEADERS);
+                stats.updateResponseTime(nodeId, time + 1_000_000, RequestType.HEADERS);
 
                 // bodies -> type of request 3
-                stats.updateBodiesRequest(nodeId, time);
-                stats.updateBodiesResponse(nodeId, time + 1_000_000);
+                stats.updateRequestTime(nodeId, time, RequestType.BODIES);
+                stats.updateResponseTime(nodeId, time + 1_000_000, RequestType.BODIES);
 
                 count++;
             }
@@ -535,8 +535,8 @@ public class SyncStatsTest {
                 time = System.nanoTime();
 
                 // status
-                stats.updateStatusRequest(nodeId, time);
-                stats.updateStatusResponse(nodeId, time + 1_000_000);
+                stats.updateRequestTime(nodeId, time, RequestType.STATUS);
+                stats.updateResponseTime(nodeId, time + 1_000_000, RequestType.STATUS);
 
                 count++;
             }
@@ -594,8 +594,8 @@ public class SyncStatsTest {
                 time = System.nanoTime();
 
                 // headers
-                stats.updateHeadersRequest(nodeId, time);
-                stats.updateHeadersResponse(nodeId, time + 1_000_000);
+                stats.updateRequestTime(nodeId, time, RequestType.HEADERS);
+                stats.updateResponseTime(nodeId, time + 1_000_000, RequestType.HEADERS);
 
                 count++;
             }
@@ -653,8 +653,8 @@ public class SyncStatsTest {
                 time = System.nanoTime();
 
                 // bodies
-                stats.updateBodiesRequest(nodeId, time);
-                stats.updateBodiesResponse(nodeId, time + 1_000_000);
+                stats.updateRequestTime(nodeId, time, RequestType.BODIES);
+                stats.updateResponseTime(nodeId, time + 1_000_000, RequestType.BODIES);
 
                 count++;
             }
@@ -710,16 +710,16 @@ public class SyncStatsTest {
             while (count > 0) {
 
                 // status updates
-                stats.updateStatusRequest(nodeId, System.nanoTime());
-                stats.updateStatusResponse(nodeId, System.nanoTime());
+                stats.updateRequestTime(nodeId, System.nanoTime(), RequestType.STATUS);
+                stats.updateResponseTime(nodeId, System.nanoTime(), RequestType.STATUS);
 
                 // headers updates
-                stats.updateHeadersRequest(nodeId, System.nanoTime());
-                stats.updateHeadersResponse(nodeId, System.nanoTime());
+                stats.updateRequestTime(nodeId, System.nanoTime(), RequestType.HEADERS);
+                stats.updateResponseTime(nodeId, System.nanoTime(), RequestType.HEADERS);
 
                 // bodies updates
-                stats.updateBodiesRequest(nodeId, System.nanoTime());
-                stats.updateBodiesResponse(nodeId, System.nanoTime());
+                stats.updateRequestTime(nodeId, System.nanoTime(), RequestType.BODIES);
+                stats.updateResponseTime(nodeId, System.nanoTime(), RequestType.BODIES);
 
                 count--;
             }


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Added `BLOCKS`, `RECEIPTS` and `TRIE_DATA` to the enum RequestType
- Refactored ResponseStatsTracker to avoid code repetition
- Expanded Request & Response tracking to include the new request types.

**Todo**: Log statistics regarding the new types of messages from the corresponding handlers/tasks (After fast sync is merged)

Fixes Issue #837 

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Fixed and added tests in SyncStatsTest

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
