### PR TITLE
Bug fix: using the repositoryChild to check for used VM

### DIFF
--- a/modAionImpl/test/org/aion/zero/impl/PendingStateTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/PendingStateTest.java
@@ -1,20 +1,32 @@
 package org.aion.zero.impl;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.math.BigInteger;
-import org.aion.types.Address;
+import java.util.Collections;
+import org.aion.avm.api.ABIEncoder;
+import org.aion.avm.core.dappreading.JarBuilder;
+import org.aion.avm.core.util.CodeAndArguments;
 import org.aion.crypto.ECKey;
 import org.aion.mcf.blockchain.TxResponse;
-
+import org.aion.mcf.core.ImportResult;
+import org.aion.mcf.tx.TransactionTypes;
+import org.aion.types.Address;
+import org.aion.vm.VirtualMachineProvider;
 import org.aion.zero.impl.config.CfgAion;
+import org.aion.zero.impl.types.AionBlock;
+import org.aion.zero.impl.types.AionBlockSummary;
+import org.aion.zero.impl.vm.contracts.AvmHelloWorld;
 import org.aion.zero.types.AionTransaction;
+import org.aion.zero.types.AionTxReceipt;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 public class PendingStateTest {
 
     @Test
-    public void TestAddPendingTransactionSuccess() {
+    public void testAddPendingTransactionSuccess() {
 
         StandaloneBlockchain.Bundle bundle =
                 new StandaloneBlockchain.Builder()
@@ -47,7 +59,7 @@ public class PendingStateTest {
     }
 
     @Test
-    public void TestAddPendingTransactionInvalidNrgPrice() {
+    public void testAddPendingTransactionInvalidNrgPrice() {
 
         StandaloneBlockchain.Bundle bundle =
                 new StandaloneBlockchain.Builder()
@@ -77,5 +89,114 @@ public class PendingStateTest {
 
         assertEquals(
                 hub.getPendingState().addPendingTransaction(tx), TxResponse.INVALID_TX_NRG_PRICE);
+    }
+
+    @Test
+    public void testAddPendingTransaction_AVMContractDeploy_Success() {
+        StandaloneBlockchain.Bundle bundle =
+                new StandaloneBlockchain.Builder()
+                        .withDefaultAccounts()
+                        .withValidatorConfiguration("simple")
+                        .withAvmEnabled()
+                        .build();
+        StandaloneBlockchain blockchain = bundle.bc;
+        ECKey deployerKey = bundle.privateKeys.get(0);
+
+        CfgAion.inst().setGenesis(blockchain.getGenesis());
+        VirtualMachineProvider.initializeAllVirtualMachines();
+
+        AionHub hub =
+                AionHub.createForTesting(CfgAion.inst(), blockchain, blockchain.getRepository());
+
+        // Successful transaction
+        byte[] jar =
+                new CodeAndArguments(
+                                JarBuilder.buildJarForMainAndClasses(AvmHelloWorld.class),
+                                new byte[0])
+                        .encodeToBytes();
+
+        AionTransaction transaction =
+                new AionTransaction(
+                        BigInteger.ZERO.toByteArray(),
+                        Address.wrap(deployerKey.getAddress()),
+                        null,
+                        BigInteger.ZERO.toByteArray(),
+                        jar,
+                        5_000_000,
+                        10_000_000_000L,
+                        TransactionTypes.AVM_CREATE_CODE);
+        transaction.sign(deployerKey);
+
+        assertEquals(hub.getPendingState().addPendingTransaction(transaction), TxResponse.SUCCESS);
+        VirtualMachineProvider.shutdownAllVirtualMachines();
+    }
+
+    @Test
+    public void testAddPendingTransaction_AVMContractCall_Success() {
+        StandaloneBlockchain.Bundle bundle =
+                new StandaloneBlockchain.Builder()
+                        .withDefaultAccounts()
+                        .withValidatorConfiguration("simple")
+                        .withAvmEnabled()
+                        .build();
+        StandaloneBlockchain blockchain = bundle.bc;
+        ECKey deployerKey = bundle.privateKeys.get(0);
+
+        CfgAion.inst().setGenesis(blockchain.getGenesis());
+        VirtualMachineProvider.initializeAllVirtualMachines();
+
+        // Successful transaction
+        byte[] jar =
+                new CodeAndArguments(
+                                JarBuilder.buildJarForMainAndClasses(AvmHelloWorld.class),
+                                new byte[0])
+                        .encodeToBytes();
+
+        AionTransaction transaction =
+                new AionTransaction(
+                        BigInteger.ZERO.toByteArray(),
+                        Address.wrap(deployerKey.getAddress()),
+                        null,
+                        BigInteger.ZERO.toByteArray(),
+                        jar,
+                        5_000_000,
+                        10_000_000_000L,
+                        TransactionTypes.AVM_CREATE_CODE);
+        transaction.sign(deployerKey);
+
+        AionBlock block =
+                blockchain.createNewBlock(
+                        blockchain.getBestBlock(), Collections.singletonList(transaction), false);
+        Pair<ImportResult, AionBlockSummary> connectResult =
+                blockchain.tryToConnectAndFetchSummary(block);
+        AionTxReceipt receipt = connectResult.getRight().getReceipts().get(0);
+
+        // Check the block was imported, the contract has the Avm prefix, and deployment succeeded.
+        assertThat(connectResult.getLeft()).isEqualTo(ImportResult.IMPORTED_BEST);
+        // verify that the output is indeed the contract address
+        assertThat(transaction.getContractAddress().toBytes())
+                .isEqualTo(receipt.getTransactionOutput());
+
+        AionHub hub =
+                AionHub.createForTesting(CfgAion.inst(), blockchain, blockchain.getRepository());
+
+        Address contract = Address.wrap(receipt.getTransactionOutput());
+
+        byte[] call = ABIEncoder.encodeMethodArguments("sayHello");
+        transaction =
+                new AionTransaction(
+                        BigInteger.ONE.toByteArray(),
+                        Address.wrap(deployerKey.getAddress()),
+                        contract,
+                        BigInteger.ZERO.toByteArray(),
+                        call,
+                        2_000_000,
+                        10_000_000_000L,
+                        TransactionTypes.DEFAULT);
+
+        transaction.sign(deployerKey);
+
+        assertEquals(hub.getPendingState().addPendingTransaction(transaction), TxResponse.SUCCESS);
+        VirtualMachineProvider.shutdownAllVirtualMachines();
     }
 }

--- a/modVM/src/org/aion/vm/BulkExecutor.java
+++ b/modVM/src/org/aion/vm/BulkExecutor.java
@@ -430,7 +430,7 @@ public class BulkExecutor {
                 return isValidAVMContractDeployment(transaction.getTargetVM());
             } else {
                 Address destination = transaction.getDestinationAddress();
-                return isValidAVMContractDeployment(repository.getVMUsed(destination))
+                return isValidAVMContractDeployment(repositoryChild.getVMUsed(destination))
                         || !isContractAddress(destination);
             }
         } else {


### PR DESCRIPTION
## Description

**Bug fix:** Replaced the use of the repository (which can be `null`) in the `BulkExecutor` with the `repositoryChild`.
**Unit tests:** Added tests for the pending state implementation (which instantiates the `BulkExecutor` with `null` repository) to expose incorrect calls to the repository in the future.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- already existing tests
- two additional tests for adding transactions to the pending state

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
