### PR TITLE
Removed the unnecessary MIN_NORMAL_PEERS restriction

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -3,7 +3,6 @@ package org.aion.zero.impl.sync;
 import static org.aion.p2p.P2pConstant.COEFFICIENT_NORMAL_PEERS;
 import static org.aion.p2p.P2pConstant.LARGE_REQUEST_SIZE;
 import static org.aion.p2p.P2pConstant.MAX_NORMAL_PEERS;
-import static org.aion.p2p.P2pConstant.MIN_NORMAL_PEERS;
 import static org.aion.zero.impl.sync.PeerState.Mode.BACKWARD;
 import static org.aion.zero.impl.sync.PeerState.Mode.FORWARD;
 import static org.aion.zero.impl.sync.PeerState.Mode.LIGHTNING;
@@ -315,13 +314,9 @@ final class TaskImportBlocks implements Runnable {
                             }
                         case NORMAL:
                             {
-                                // requiring a minimum number of normal states
-                                if (countStates(getBestBlockNumber(), NORMAL, peerStates.values())
-                                        > MIN_NORMAL_PEERS) {
-                                    // switch to backward mode
-                                    state.setMode(BACKWARD);
-                                    state.setBase(b.getNumber());
-                                }
+                                // switch to backward mode
+                                state.setMode(BACKWARD);
+                                state.setBase(b.getNumber());
                                 break;
                             }
                         case BACKWARD:
@@ -457,12 +452,10 @@ final class TaskImportBlocks implements Runnable {
                     countStates(best, NORMAL, states) + countStates(best, THUNDER, states);
             long fastStates = countStates(best, LIGHTNING, states);
 
-            // requiring a minimum number of normal states
-            if (normalStates > MIN_NORMAL_PEERS
-                    // the fast vs normal states balance depends on the give coefficient
-                    && (fastStates < COEFFICIENT_NORMAL_PEERS * normalStates
-                            // with a maximum number of normal states
-                            || normalStates > MAX_NORMAL_PEERS)) {
+            // the fast vs normal states balance depends on the give coefficient
+            if (fastStates < COEFFICIENT_NORMAL_PEERS * normalStates
+                    // with a maximum number of normal states
+                    || normalStates > MAX_NORMAL_PEERS) {
 
                 // select the base to be used
                 long nextBase = selectBase(best, state.getLastBestBlock(), baseSet, chain);

--- a/modAionImpl/test/org/aion/zero/impl/sync/TaskImportBlocksTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/TaskImportBlocksTest.java
@@ -10,7 +10,6 @@ import static org.aion.mcf.core.ImportResult.NO_PARENT;
 import static org.aion.p2p.P2pConstant.COEFFICIENT_NORMAL_PEERS;
 import static org.aion.p2p.P2pConstant.LARGE_REQUEST_SIZE;
 import static org.aion.p2p.P2pConstant.MAX_NORMAL_PEERS;
-import static org.aion.p2p.P2pConstant.MIN_NORMAL_PEERS;
 import static org.aion.zero.impl.BlockchainTestUtils.generateAccounts;
 import static org.aion.zero.impl.BlockchainTestUtils.generateNewBlock;
 import static org.aion.zero.impl.BlockchainTestUtils.generateNextBlock;
@@ -39,14 +38,14 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.aion.interfaces.db.ContractDetails;
-import org.aion.interfaces.db.PruneConfig;
-import org.aion.interfaces.db.RepositoryConfig;
-import org.aion.types.ByteArrayWrapper;
 import org.aion.crypto.ECKey;
 import org.aion.db.impl.DBVendor;
 import org.aion.db.impl.DatabaseFactory;
+import org.aion.interfaces.db.ContractDetails;
+import org.aion.interfaces.db.PruneConfig;
+import org.aion.interfaces.db.RepositoryConfig;
 import org.aion.mcf.core.ImportResult;
+import org.aion.types.ByteArrayWrapper;
 import org.aion.zero.impl.AionBlockchainImpl;
 import org.aion.zero.impl.StandaloneBlockchain;
 import org.aion.zero.impl.db.ContractDetailsAion;
@@ -92,9 +91,7 @@ public class TaskImportBlocksTest {
             parameters.add(new Object[] {0L, 200L, mode, set2});
             List<PeerState> set3 =
                     new ArrayList<>(set2)
-                            .stream()
-                            .filter(s -> s.getMode() != mode)
-                            .collect(Collectors.toList());
+                            .stream().filter(s -> s.getMode() != mode).collect(Collectors.toList());
             parameters.add(new Object[] {0L, -1L, mode, set3});
         }
 
@@ -393,25 +390,6 @@ public class TaskImportBlocksTest {
     @SuppressWarnings("unused")
     private Object allModesExceptLightning() {
         return new Object[] {NORMAL, THUNDER, BACKWARD, FORWARD};
-    }
-
-    @Test
-    @Parameters(method = "allModesExceptLightning")
-    public void testAttemptLightningJump_wMinNormalPeers(Mode mode) {
-        // checking that the test assumptions are met
-        assertThat(MIN_NORMAL_PEERS).isGreaterThan(0);
-
-        // normalStates == MIN_NORMAL_PEERS
-        List<PeerState> states = new ArrayList<>();
-        addStates(states, MIN_NORMAL_PEERS, NORMAL, 100L);
-
-        PeerState input = new PeerState(mode, 100L);
-        PeerState expected = new PeerState(input);
-
-        // expecting no change in the input value
-        SortedSet<Long> baseSet = new TreeSet<>();
-        assertThat(attemptLightningJump(-1L, input, states, baseSet, null)).isEqualTo(expected);
-        assertThat(baseSet.size()).isEqualTo(0);
     }
 
     @Test

--- a/modP2p/src/org/aion/p2p/P2pConstant.java
+++ b/modP2p/src/org/aion/p2p/P2pConstant.java
@@ -33,7 +33,6 @@ public class P2pConstant {
              */
             CLOSE_OVERLAPPING_BLOCKS = 15,
             STEP_COUNT = 6,
-            MIN_NORMAL_PEERS = 4,
             MAX_NORMAL_PEERS = 16,
             COEFFICIENT_NORMAL_PEERS = 2,
 


### PR DESCRIPTION
## Description

The restriction of `MIN_NORMAL_PEERS` is overly cautious. The behavior during `THUNDER` states (which were introduced after) makes the min peers restriction unnecessarily.

Removing this restriction speeds up sync significantly in environments like the current `mastery` network and local test networks where acquiring that minimum number of peers is more difficult.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite
- kernel execution on mastery

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
