### PR TITLE
Jenkinsfile: put back cleanWs() otherwise, each subsequent run for a …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
         always {
             sh('([ -d FunctionalTests ] && cp -r FunctionalTests/report/FunctionalTests report/) || true')
             junit "report/**/*.xml"
+            cleanWs()
     }
 
     success {


### PR DESCRIPTION
…branch finds the files from the previous run

## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Recently we took our cleanWs() from Jenkins post-pipeline actions so we could see the workspace from its web UI to analyze failures
- It had an unintended consequence of making it so that every run for a particular branch/PR sees the leftover workspace files from the previous run
- So, putting back cleanWs() until we figure out a smarter way to keep old workspaces 

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
