### PR TITLE
Reduce log level for some tests

### DIFF
--- a/modAionImpl/test/org/aion/zero/impl/BlockchainImplementationTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/BlockchainImplementationTest.java
@@ -6,10 +6,13 @@ import static org.aion.zero.impl.BlockchainTestUtils.generateRandomChainWithoutT
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.HashUtil;
+import org.aion.log.AionLoggerFactory;
 import org.aion.mcf.config.CfgPrune;
 import org.aion.mcf.core.FastImportResult;
 import org.aion.mcf.core.ImportResult;
@@ -23,6 +26,7 @@ import org.aion.zero.types.AionTransaction;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -35,6 +39,13 @@ public class BlockchainImplementationTest {
 
     private static final List<ECKey> accounts = BlockchainTestUtils.generateAccounts(10);
     private static final int MAX_TX_PER_BLOCK = 30;
+
+    @BeforeClass
+    public static void beforeClass() {
+        Map<String, String> cfg = new HashMap<>();
+        cfg.put("ROOT", "ERROR");
+        AionLoggerFactory.init(cfg);
+    }
 
     @Before
     public void setup() {

--- a/modAionImpl/test/org/aion/zero/impl/vm/OldTxExecutorTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/OldTxExecutorTest.java
@@ -30,7 +30,9 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.aion.crypto.ECKeyFac;
 import org.aion.interfaces.db.RepositoryCache;
 import org.aion.log.AionLoggerFactory;
@@ -57,6 +59,7 @@ import org.aion.zero.types.AionTxReceipt;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -68,6 +71,13 @@ import org.slf4j.Logger;
 public class OldTxExecutorTest {
     private static final Logger LOGGER_VM = AionLoggerFactory.getLogger(LogEnum.VM.toString());
     private StandaloneBlockchain blockchain;
+
+    @BeforeClass
+    public static void beforeClass() {
+        Map<String, String> cfg = new HashMap<>();
+        cfg.put("ROOT", "ERROR");
+        AionLoggerFactory.init(cfg);
+    }
 
     @Before
     public void setup() {


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- This is an attempt to avoid Jenkins running out of heap memory when trying to parse the XML output of our unit tests
- I noticed that some of the XML files are really large.  This PR changes the logging levels of two of the large files (size in kB):

        1199180 ./modAionImpl/test/TEST-org.aion.zero.impl.BlockchainImplementationTest.xml
        24100   ./modAionImpl/test/TEST-org.aion.zero.impl.vm.OldTxExecutorTest.xml

- Example of failure: https://ci.aion.network:8443/job/aionnetwork/job/jenkins-no-gradle-daemon/5/console
- After this change, both files are <80 kB

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
