### PR TITLE
Post-fork transaction validation

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -37,8 +37,8 @@ import org.aion.interfaces.db.Repository;
 import org.aion.interfaces.db.RepositoryCache;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
-import org.aion.mcf.core.FastImportResult;
 import org.aion.mcf.core.AccountState;
+import org.aion.mcf.core.FastImportResult;
 import org.aion.mcf.core.ImportResult;
 import org.aion.mcf.db.IBlockStorePow;
 import org.aion.mcf.db.TransactionStore;
@@ -1170,8 +1170,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
                         .anyMatch(
                                 tx ->
                                         !TXValidator.isValid(tx)
-                                                || !TransactionTypeValidator.isValid(
-                                                        tx.getTargetVM()))) {
+                                                || !TransactionTypeValidator.isValid(tx))) {
                     LOG.error("Some transactions in the block are invalid");
                     if (TX_LOG.isDebugEnabled()) {
                         for (AionTransaction tx : txs) {
@@ -1179,7 +1178,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
                                     "Tx valid ["
                                             + TXValidator.isValid(tx)
                                             + "]. Type valid ["
-                                            + TransactionTypeValidator.isValid(tx.getTargetVM())
+                                            + TransactionTypeValidator.isValid(tx)
                                             + "]\n"
                                             + tx.toString());
                         }

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -21,9 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.aion.interfaces.block.Constant;
-import org.aion.interfaces.db.Repository;
-import org.aion.interfaces.db.RepositoryCache;
 import org.aion.evtmgr.IEvent;
 import org.aion.evtmgr.IEventMgr;
 import org.aion.evtmgr.IHandler;
@@ -31,6 +28,9 @@ import org.aion.evtmgr.impl.callback.EventCallback;
 import org.aion.evtmgr.impl.es.EventExecuteService;
 import org.aion.evtmgr.impl.evt.EventBlock;
 import org.aion.evtmgr.impl.evt.EventTx;
+import org.aion.interfaces.block.Constant;
+import org.aion.interfaces.db.Repository;
+import org.aion.interfaces.db.RepositoryCache;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.aion.mcf.blockchain.IPendingStateInternal;
@@ -441,7 +441,7 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
     }
 
     public boolean isValid(AionTransaction tx) {
-        return TXValidator.isValid(tx) && TransactionTypeValidator.isValid(tx.getTargetVM());
+        return TXValidator.isValid(tx) && TransactionTypeValidator.isValid(tx);
     }
 
     /**

--- a/modAionImpl/src/org/aion/zero/impl/valid/TransactionTypeValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/TransactionTypeValidator.java
@@ -2,18 +2,41 @@ package org.aion.zero.impl.valid;
 
 import static org.aion.mcf.valid.TransactionTypeRule.isValidTransactionType;
 
+import org.aion.interfaces.tx.Transaction;
+import org.aion.zero.types.AionTransaction;
+
 /**
  * Validator for the type field of transactions allowed by the network. The transaction types
- * currently correlate with which virtual machines are enabled. This field mainly impacts contract
- * creation. Contracts created using the default transaction type should be deployed on the FastVM.
- * AVM contracts creations/transactions are declared valid only if the AVM is enabled from the
- * configuration and the transaction has the correct type associated with the AVM.
+ * currently correlate with which virtual machines are enabled.
  *
  * @author Alexandra Roatis
  */
 public class TransactionTypeValidator {
 
-    public static boolean isValid(byte type) {
-        return isValidTransactionType(type);
+    /**
+     * Validates the transaction type as follows:
+     *
+     * <ol>
+     *   <li>Any transaction type is allowed before the 0.4.0 fork which enables the use of the AVM.
+     *   <li>Only the transaction types listed in {@link org.aion.mcf.tx.TransactionTypes#ALL} are
+     *       valid after the fork.
+     *   <li>Contract deployments must have the transaction types from the set {@link
+     *       org.aion.mcf.tx.TransactionTypes#CREATE}.
+     *   <li>Transactions that are not contract deployments must have the transaction type {@link
+     *       org.aion.mcf.tx.TransactionTypes#DEFAULT}
+     * </ol>
+     *
+     * @implNote Delegates the check to {@link
+     *     org.aion.mcf.valid.TransactionTypeRule#isValidTransactionType(Transaction)}.
+     * @param transaction the transaction to be validated
+     * @return {@code true} is the transaction satisfies the rule described above; {@code false}
+     *     otherwise
+     */
+    public static boolean isValid(AionTransaction transaction) {
+        /*
+        TODO: this class could be replaced by org.aion.mcf.valid.TransactionTypeRule
+        when the specification of modMcf and modAionImpl are properly defined and refactored
+        */
+        return isValidTransactionType(transaction);
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/valid/TransactionTypeValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/TransactionTypeValidator.java
@@ -13,17 +13,7 @@ import static org.aion.mcf.valid.TransactionTypeRule.isValidTransactionType;
  */
 public class TransactionTypeValidator {
 
-    private static boolean avmEnabled;
-
-    public static void enableAvmCheck(boolean enableAVM) {
-        avmEnabled = enableAVM;
-    }
-
     public static boolean isValid(byte type) {
-        return true;
-    }
-
-    public static boolean isValidAfterFork(byte type) {
         return isValidTransactionType(type);
     }
 }

--- a/modAionImpl/test/org/aion/zero/impl/consensus/BalanceTransferConsensusTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/consensus/BalanceTransferConsensusTest.java
@@ -1,5 +1,6 @@
 package org.aion.zero.impl.consensus;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -8,15 +9,18 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.aion.crypto.ECKey;
 import org.aion.mcf.core.ImportResult;
+import org.aion.mcf.valid.TransactionTypeRule;
 import org.aion.types.Address;
+import org.aion.util.conversions.Hex;
 import org.aion.vm.VirtualMachineProvider;
 import org.aion.zero.impl.StandaloneBlockchain;
 import org.aion.zero.impl.StandaloneBlockchain.Builder;
 import org.aion.zero.impl.StandaloneBlockchain.Bundle;
-import org.aion.util.conversions.Hex;
 import org.aion.zero.impl.types.AionBlock;
 import org.aion.zero.impl.types.AionBlockSummary;
+import org.aion.zero.impl.valid.TransactionTypeValidator;
 import org.aion.zero.types.AionTransaction;
 import org.aion.zero.types.AionTxReceipt;
 import org.apache.commons.lang3.tuple.Pair;
@@ -63,6 +67,90 @@ public class BalanceTransferConsensusTest {
         if (VirtualMachineProvider.isMachinesAreLive()) {
             VirtualMachineProvider.shutdownAllVirtualMachines();
         }
+    }
+
+    @Test
+    public void testTransactionTypeBeforeTheFork() {
+        // ensure that the fork was not triggered
+        TransactionTypeRule.disallowAVMContractTransaction();
+
+        BigInteger amount = BigInteger.TEN.pow(12).add(BigInteger.valueOf(293_865));
+        BigInteger initialBalance = getBalance(Address.wrap(SENDER_ADDR));
+        assertThat(initialBalance).isEqualTo(SENDER_BALANCE);
+        assertThat(this.blockchain.getMinerCoinbase().toBytes()).isEqualTo(MINER);
+
+        // get contract address from precompiled factory
+        Address to =
+                Address.wrap("a0123456a89a6ffbfdc45782771fba3f5e9da36baa69444f8f95e325430463e7");
+
+        // Make balance transfer transaction to precompiled contract.
+        ECKey key = org.aion.crypto.ECKeyFac.inst().fromPrivate(SENDER_KEY);
+        AionTransaction transaction =
+                new AionTransaction(
+                        BigInteger.ZERO.toByteArray(),
+                        to,
+                        amount.toByteArray(),
+                        new byte[0],
+                        2_000_000,
+                        ENERGY_PRICE,
+                        (byte) 11); // legal type before the fork
+        transaction.sign(key);
+
+        // check that the transaction is valid
+        assertThat(TransactionTypeValidator.isValid(transaction.getTargetVM())).isTrue();
+
+        // Process the transaction.
+        Pair<ImportResult, AionBlockSummary> results = processTransactions(transaction, 1);
+
+        // ensure transaction and block were valid
+        AionBlockSummary blockSummary = results.getRight();
+        AionTxReceipt receipt = blockSummary.getSummaries().get(0).getReceipt();
+        assertThat(receipt.isSuccessful()).isTrue();
+        assertThat(receipt.getEnergyUsed()).isEqualTo(21000);
+    }
+
+    @Test
+    public void testTransactionTypeAfterTheFork() {
+        // triggering fork changes
+        TransactionTypeRule.allowAVMContractTransaction();
+
+        BigInteger amount = BigInteger.TEN.pow(12).add(BigInteger.valueOf(293_865));
+        BigInteger initialBalance = getBalance(Address.wrap(SENDER_ADDR));
+        assertThat(initialBalance).isEqualTo(SENDER_BALANCE);
+        assertThat(this.blockchain.getMinerCoinbase().toBytes()).isEqualTo(MINER);
+
+        // get contract address from precompiled factory
+        Address to =
+                Address.wrap("a0123456a89a6ffbfdc45782771fba3f5e9da36baa69444f8f95e325430463e7");
+
+        // Make balance transfer transaction to precompiled contract.
+        ECKey key = org.aion.crypto.ECKeyFac.inst().fromPrivate(SENDER_KEY);
+        AionTransaction transaction =
+                new AionTransaction(
+                        BigInteger.ZERO.toByteArray(),
+                        to,
+                        amount.toByteArray(),
+                        new byte[0],
+                        2_000_000,
+                        ENERGY_PRICE,
+                        (byte) 11); // illegal type after the fork
+        transaction.sign(key);
+
+        // check that the transaction is not valid
+        assertThat(TransactionTypeValidator.isValid(transaction.getTargetVM())).isFalse();
+
+        // Process the transaction.
+        AionBlock parentBlock = this.blockchain.getRepository().blockStore.getBestBlock();
+        AionBlock block =
+                this.blockchain.createNewBlock(
+                        parentBlock, Collections.singletonList(transaction), false);
+        Pair<ImportResult, AionBlockSummary> results =
+                this.blockchain.tryToConnectAndFetchSummary(block);
+
+        assertThat(results.getLeft()).isEqualTo(ImportResult.INVALID_BLOCK);
+
+        // cleaning up for future tests
+        TransactionTypeRule.disallowAVMContractTransaction();
     }
 
     private static final String RECIPIENT1 =

--- a/modAionImpl/test/org/aion/zero/impl/consensus/BalanceTransferConsensusTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/consensus/BalanceTransferConsensusTest.java
@@ -97,7 +97,7 @@ public class BalanceTransferConsensusTest {
         transaction.sign(key);
 
         // check that the transaction is valid
-        assertThat(TransactionTypeValidator.isValid(transaction.getTargetVM())).isTrue();
+        assertThat(TransactionTypeValidator.isValid(transaction)).isTrue();
 
         // Process the transaction.
         Pair<ImportResult, AionBlockSummary> results = processTransactions(transaction, 1);
@@ -137,7 +137,7 @@ public class BalanceTransferConsensusTest {
         transaction.sign(key);
 
         // check that the transaction is not valid
-        assertThat(TransactionTypeValidator.isValid(transaction.getTargetVM())).isFalse();
+        assertThat(TransactionTypeValidator.isValid(transaction)).isFalse();
 
         // Process the transaction.
         AionBlock parentBlock = this.blockchain.getRepository().blockStore.getBestBlock();

--- a/modAionImpl/test/org/aion/zero/impl/vm/AvmBulkTransactionTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/AvmBulkTransactionTest.java
@@ -256,7 +256,7 @@ public class AvmBulkTransactionTest {
                         new byte[0],
                         2_000_000,
                         this.energyPrice,
-                        (byte) 0x1);
+                        TransactionTypes.DEFAULT);
         transaction.sign(sender);
         return transaction;
     }

--- a/modAionImpl/test/org/aion/zero/impl/vm/FvmBulkTransactionTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/FvmBulkTransactionTest.java
@@ -8,12 +8,12 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.aion.types.Address;
 import org.aion.crypto.ECKey;
 import org.aion.mcf.core.ImportResult;
+import org.aion.mcf.tx.TransactionTypes;
 import org.aion.mcf.vm.types.DataWordImpl;
+import org.aion.types.Address;
 import org.aion.util.conversions.Hex;
-
 import org.aion.zero.impl.StandaloneBlockchain;
 import org.aion.zero.impl.types.AionBlock;
 import org.aion.zero.impl.types.AionBlockSummary;
@@ -158,7 +158,7 @@ public class FvmBulkTransactionTest {
                         contractBytes,
                         5_000_000,
                         this.energyPrice,
-                        (byte) 0x01);
+                        TransactionTypes.FVM_CREATE_CODE);
         transaction.sign(this.deployerKey);
         return transaction;
     }
@@ -178,7 +178,7 @@ public class FvmBulkTransactionTest {
                         callBytes,
                         2_000_000,
                         this.energyPrice,
-                        (byte) 0x01);
+                        TransactionTypes.DEFAULT);
         transaction.sign(this.deployerKey);
         return transaction;
     }
@@ -197,7 +197,7 @@ public class FvmBulkTransactionTest {
                         callBytes,
                         2_000_000,
                         this.energyPrice,
-                        (byte) 0x01);
+                        TransactionTypes.DEFAULT);
         transaction.sign(this.deployerKey);
 
         AionBlockSummary summary =

--- a/modAionImpl/test/org/aion/zero/impl/vm/InvalidBlockTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/InvalidBlockTest.java
@@ -4,12 +4,11 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import com.mongodb.client.model.Collation;
 import org.aion.avm.core.dappreading.JarBuilder;
 import org.aion.avm.core.util.CodeAndArguments;
 import org.aion.crypto.ECKey;
 import org.aion.mcf.core.ImportResult;
+import org.aion.mcf.tx.TransactionTypes;
 import org.aion.types.Address;
 import org.aion.vm.VirtualMachineProvider;
 import org.aion.zero.impl.StandaloneBlockchain;
@@ -64,14 +63,18 @@ public class InvalidBlockTest {
 
     @Test
     public void test() {
-        BigInteger nonce = this.blockchain.getRepository().getNonce(Address.wrap(this.deployerKey.getAddress()));
+        BigInteger nonce =
+                this.blockchain
+                        .getRepository()
+                        .getNonce(Address.wrap(this.deployerKey.getAddress()));
         List<AionTransaction> transactions = makeTransactions(10, nonce);
         Collections.shuffle(transactions);
 
         AionBlock parent = this.blockchain.getBestBlock();
         AionBlock block = this.blockchain.createNewBlock(parent, transactions, false);
 
-        Pair<ImportResult, AionBlockSummary> res = this.blockchain.tryToConnectAndFetchSummary(block);
+        Pair<ImportResult, AionBlockSummary> res =
+                this.blockchain.tryToConnectAndFetchSummary(block);
         System.out.println(res.getLeft());
         System.out.println(res.getRight().getReceipts());
     }
@@ -79,20 +82,25 @@ public class InvalidBlockTest {
     private List<AionTransaction> makeTransactions(int num, BigInteger initialNonce) {
         List<AionTransaction> transactions = new ArrayList<>();
 
-        byte[] jar = new CodeAndArguments(JarBuilder.buildJarForMainAndClassesAndUserlib(Contract.class), new byte[0]).encodeToBytes();
+        byte[] jar =
+                new CodeAndArguments(
+                                JarBuilder.buildJarForMainAndClassesAndUserlib(Contract.class),
+                                new byte[0])
+                        .encodeToBytes();
         BigInteger nonce = initialNonce;
 
         for (int i = 0; i < num; i++) {
 
-            AionTransaction transaction = new AionTransaction(
-                    nonce.toByteArray(),
-                    Address.wrap(this.deployerKey.getAddress()),
-                    null,
-                    BigInteger.ZERO.toByteArray(),
-                    jar,
-                    5_000_000L,
-                    10_000_000_000L,
-                    (byte) 0x0f);
+            AionTransaction transaction =
+                    new AionTransaction(
+                            nonce.toByteArray(),
+                            Address.wrap(this.deployerKey.getAddress()),
+                            null,
+                            BigInteger.ZERO.toByteArray(),
+                            jar,
+                            5_000_000L,
+                            10_000_000_000L,
+                            TransactionTypes.AVM_CREATE_CODE);
             transaction.sign(this.deployerKey);
 
             transactions.add(transaction);
@@ -101,5 +109,4 @@ public class InvalidBlockTest {
 
         return transactions;
     }
-
 }

--- a/modAionImpl/test/org/aion/zero/impl/vm/StatefulnessTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/StatefulnessTest.java
@@ -8,17 +8,16 @@ import java.util.Arrays;
 import org.aion.avm.core.dappreading.JarBuilder;
 import org.aion.avm.core.util.ABIUtil;
 import org.aion.avm.core.util.CodeAndArguments;
-import org.aion.avm.userlib.abi.ABIEncoder;
 import org.aion.crypto.AddressSpecs;
 import org.aion.crypto.ECKey;
 import org.aion.mcf.core.ImportResult;
+import org.aion.mcf.tx.TransactionTypes;
 import org.aion.mcf.valid.TransactionTypeRule;
 import org.aion.types.Address;
 import org.aion.vm.VirtualMachineProvider;
 import org.aion.zero.impl.StandaloneBlockchain;
 import org.aion.zero.impl.types.AionBlock;
 import org.aion.zero.impl.types.AionBlockSummary;
-import org.aion.mcf.tx.TransactionTypes;
 import org.aion.zero.impl.vm.contracts.Statefulness;
 import org.aion.zero.types.AionTransaction;
 import org.aion.zero.types.AionTxReceipt;
@@ -220,7 +219,7 @@ public class StatefulnessTest {
                         new byte[0],
                         2_000_000,
                         this.energyPrice,
-                        (byte) 0x1);
+                        TransactionTypes.DEFAULT);
         transaction.sign(this.deployerKey);
 
         return sendTransactions(transaction);
@@ -242,7 +241,8 @@ public class StatefulnessTest {
 
     private byte[] getJarBytes() {
         return new CodeAndArguments(
-                        JarBuilder.buildJarForMainAndClassesAndUserlib(Statefulness.class), new byte[0])
+                        JarBuilder.buildJarForMainAndClassesAndUserlib(Statefulness.class),
+                        new byte[0])
                 .encodeToBytes();
     }
 

--- a/modMcf/src/org/aion/mcf/tx/TransactionTypes.java
+++ b/modMcf/src/org/aion/mcf/tx/TransactionTypes.java
@@ -6,7 +6,7 @@ import java.util.Set;
 public class TransactionTypes {
     public static final byte DEFAULT = 0x00;
     public static final byte FVM_CREATE_CODE = 0x01;
-    public static final byte AVM_CREATE_CODE = 0x0f;
+    public static final byte AVM_CREATE_CODE = 0x02;
 
     /** Set of transaction types allowed by any of the Virtual Machine implementations. */
     public static final Set<Byte> ALL = Set.of(DEFAULT, FVM_CREATE_CODE, AVM_CREATE_CODE);

--- a/modMcf/src/org/aion/mcf/tx/TransactionTypes.java
+++ b/modMcf/src/org/aion/mcf/tx/TransactionTypes.java
@@ -16,4 +16,7 @@ public class TransactionTypes {
 
     /** Set of transaction types allowed by the Aion Virtual Machine implementation. */
     public static final Set<Byte> AVM = Set.of(DEFAULT, AVM_CREATE_CODE);
+
+    /** Set of transaction types allowed when deploying a contract. */
+    public static final Set<Byte> CREATE = Set.of(FVM_CREATE_CODE, AVM_CREATE_CODE);
 }

--- a/modMcf/src/org/aion/mcf/types/AbstractTransaction.java
+++ b/modMcf/src/org/aion/mcf/types/AbstractTransaction.java
@@ -54,8 +54,12 @@ public abstract class AbstractTransaction implements Transaction {
         this.to = receiveAddress;
         this.value = value;
         this.data = data;
-        // default type 0x01; reserve date for multi-type transaction
-        this.type = TransactionTypes.DEFAULT;
+        // setting the default type depending on use case
+        if (to == null) {
+            this.type = TransactionTypes.FVM_CREATE_CODE;
+        } else {
+            this.type = TransactionTypes.DEFAULT;
+        }
     }
 
     public AbstractTransaction(
@@ -80,11 +84,6 @@ public abstract class AbstractTransaction implements Transaction {
             byte type)
             throws Exception {
         this(nonce, receiveAddress, value, data, nrg, nrgPrice);
-
-        if (type == 0x00) {
-            throw new Exception("Incorrect tx type!");
-        }
-
         this.type = type;
     }
 

--- a/modMcf/src/org/aion/mcf/valid/TransactionTypeRule.java
+++ b/modMcf/src/org/aion/mcf/valid/TransactionTypeRule.java
@@ -1,9 +1,12 @@
 package org.aion.mcf.valid;
 
-import static org.aion.mcf.tx.TransactionTypes.ALL;
 import static org.aion.mcf.tx.TransactionTypes.AVM;
 import static org.aion.mcf.tx.TransactionTypes.AVM_CREATE_CODE;
+import static org.aion.mcf.tx.TransactionTypes.CREATE;
 import static org.aion.mcf.tx.TransactionTypes.FVM;
+
+import org.aion.interfaces.tx.Transaction;
+import org.aion.mcf.tx.TransactionTypes;
 
 /**
  * Rules for validating transactions based on allowed types.
@@ -16,15 +19,33 @@ public class TransactionTypeRule {
     private static boolean AVM_CONTRACT_TRANSACTION_ALLOWED = false;
 
     /**
-     * Compares the given transaction type with all the transaction types allowed.
+     * Validates the transaction type as follows:
      *
-     * @param type the type of a transaction applicable on any of the allowed VMs
-     * @return {@code true} is this is a valid transaction type, {@code false} otherwise
+     * <ol>
+     *   <li>Any transaction type is allowed before the 0.4 hard fork which enables the use of the
+     *       AVM.
+     *   <li>Only the transaction types listed in {@link org.aion.mcf.tx.TransactionTypes#ALL} are
+     *       valid after the fork.
+     *   <li>Contract deployments must have the transaction types from the set {@link
+     *       org.aion.mcf.tx.TransactionTypes#CREATE}.
+     *   <li>Transactions that are not contract deployments must have the transaction type {@link
+     *       org.aion.mcf.tx.TransactionTypes#DEFAULT}
+     * </ol>
+     *
+     * @param transaction the transaction to be validated
+     * @return {@code true} is the transaction satisfies the rule described above; {@code false}
+     *     otherwise
      */
-    public static boolean isValidTransactionType(byte type) {
+    public static boolean isValidTransactionType(Transaction transaction) {
         if (AVM_CONTRACT_TRANSACTION_ALLOWED) {
             // transaction types are validated after the fork
-            return ALL.contains(type);
+            if (transaction.getDestinationAddress() == null) {
+                // checks for valid contract deployments
+                return CREATE.contains(transaction.getTargetVM());
+            } else {
+                // other transactions must have default type
+                return transaction.getTargetVM() == TransactionTypes.DEFAULT;
+            }
         } else {
             // transaction types are not checked before the fork
             return true;
@@ -61,12 +82,12 @@ public class TransactionTypeRule {
         return type == AVM_CREATE_CODE && AVM_CONTRACT_TRANSACTION_ALLOWED;
     }
 
-    /** It should be triggered by 0.4 hardfork or testing purpose */
+    /** It should be triggered by 0.4 hard fork or testing purpose */
     public static void allowAVMContractTransaction() {
         AVM_CONTRACT_TRANSACTION_ALLOWED = true;
     }
 
-    /** It should be triggered by 0.4 hardfork or testing purpose */
+    /** It should be triggered by 0.4 hard fork or testing purpose */
     public static void disallowAVMContractTransaction() {
         AVM_CONTRACT_TRANSACTION_ALLOWED = false;
     }

--- a/modMcf/src/org/aion/mcf/valid/TransactionTypeRule.java
+++ b/modMcf/src/org/aion/mcf/valid/TransactionTypeRule.java
@@ -4,7 +4,6 @@ import static org.aion.mcf.tx.TransactionTypes.ALL;
 import static org.aion.mcf.tx.TransactionTypes.AVM;
 import static org.aion.mcf.tx.TransactionTypes.AVM_CREATE_CODE;
 import static org.aion.mcf.tx.TransactionTypes.FVM;
-import static org.aion.mcf.tx.TransactionTypes.FVM_CREATE_CODE;
 
 /**
  * Rules for validating transactions based on allowed types.
@@ -23,7 +22,13 @@ public class TransactionTypeRule {
      * @return {@code true} is this is a valid transaction type, {@code false} otherwise
      */
     public static boolean isValidTransactionType(byte type) {
-        return ALL.contains(type);
+        if (AVM_CONTRACT_TRANSACTION_ALLOWED) {
+            // transaction types are validated after the fork
+            return ALL.contains(type);
+        } else {
+            // transaction types are not checked before the fork
+            return true;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

- Set the `AVM_CREATE_CODE = 0x02`;
- Allowing only transactions with types 0, 1, 2 after the fork;
- Unit tests for transaction validation before and after the fork.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing tests
- two new tests to verify correct transaction validation after the fork

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
