### PR TITLE
fix p2p taskStatus disappear issue

### DIFF
--- a/modP2pImpl/src/org/aion/p2p/impl/TaskRequestActiveNodes.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/TaskRequestActiveNodes.java
@@ -23,6 +23,7 @@ public final class TaskRequestActiveNodes implements Runnable {
     public void run() {
         INode node = mgr.getRandom();
         if (node != null) {
+            Thread.currentThread().setName("p2p-reqNodes");
             if (p2pLOG.isTraceEnabled()) {
                 p2pLOG.trace("TaskRequestActiveNodes: {}", node.toString());
             }

--- a/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
@@ -226,8 +226,9 @@ public final class P2pMgr implements IP2pMgr {
             }
 
             if (p2pLOG.isInfoEnabled()) {
-                scheduledWorkers.scheduleWithFixedDelay(
-                        getStatusInstance(), 2, PERIOD_SHOW_STATUS, TimeUnit.MILLISECONDS);
+                Thread threadStatus = new Thread(getStatusInstance(), "p2p-ts");
+                threadStatus.setPriority(Thread.NORM_PRIORITY);
+                threadStatus.start();
             }
 
             if (!syncSeedsOnly) {
@@ -469,7 +470,8 @@ public final class P2pMgr implements IP2pMgr {
     }
 
     private TaskStatus getStatusInstance() {
-        return new TaskStatus(this.nodeMgr, this.selfShortId, this.sendMsgQue, this.receiveMsgQue);
+        return new TaskStatus(
+                this.start, this.nodeMgr, this.selfShortId, this.sendMsgQue, this.receiveMsgQue);
     }
 
     private TaskClear getClearInstance() {

--- a/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
@@ -462,20 +462,19 @@ public final class P2pMgr implements IP2pMgr {
     }
 
     private TaskSend getSendInstance(int i) {
-        return new TaskSend(this, i, this.sendMsgQue, this.start, this.nodeMgr, this.selector);
+        return new TaskSend(this, i, sendMsgQue, start, nodeMgr, selector);
     }
 
     private TaskReceive getReceiveInstance() {
-        return new TaskReceive(this.start, this.receiveMsgQue, this.handlers);
+        return new TaskReceive(start, receiveMsgQue, handlers);
     }
 
     private TaskStatus getStatusInstance() {
-        return new TaskStatus(
-                this.start, this.nodeMgr, this.selfShortId, this.sendMsgQue, this.receiveMsgQue);
+        return new TaskStatus(start, nodeMgr, selfShortId, sendMsgQue, receiveMsgQue);
     }
 
     private TaskClear getClearInstance() {
-        return new TaskClear(this.nodeMgr, this.start);
+        return new TaskClear(nodeMgr, start);
     }
 
     private TaskConnectPeers getConnectPeersInstance() {

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskStatus.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskStatus.java
@@ -31,23 +31,27 @@ public class TaskStatus implements Runnable {
 
     @Override
     public void run() {
+        p2pLOG.debug("P2p taskStatus start running.");
         while (start.get()) {
             try {
                 Thread.sleep(PERIOD_STATUS);
-                String status = this.nodeMgr.dumpNodeInfo(this.selfShortId, p2pLOG.isDebugEnabled());
+                String status = nodeMgr.dumpNodeInfo(selfShortId, p2pLOG.isDebugEnabled());
 
                 if (p2pLOG.isDebugEnabled()) {
                     p2pLOG.debug(status);
                     p2pLOG.debug(
-                        "recv queue[{}] send queue[{}]",
-                        this.receiveMsgQue.size(),
-                        this.sendMsgQue.size());
+                            "recv queue[{}] send queue[{}]",
+                            receiveMsgQue.size(),
+                            sendMsgQue.size());
                 } else if (p2pLOG.isInfoEnabled()) {
                     p2pLOG.info(status);
                 }
+            } catch (InterruptedException e) {
+                p2pLOG.warn("P2p taskStatus InterruptedException! ", e);
             } catch (Exception e) {
                 p2pLOG.warn("P2p taskStatus exception! ", e);
             }
         }
+        p2pLOG.info("P2p taskStatus has been shut down.");
     }
 }

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskStatus.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskStatus.java
@@ -3,6 +3,7 @@ package org.aion.p2p.impl1.tasks;
 import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.aion.p2p.INodeMgr;
 
 public class TaskStatus implements Runnable {
@@ -12,7 +13,11 @@ public class TaskStatus implements Runnable {
     private final BlockingQueue<MsgOut> sendMsgQue;
     private final BlockingQueue<MsgIn> receiveMsgQue;
 
+    private static final int PERIOD_STATUS = 10000;
+    private final AtomicBoolean start;
+
     public TaskStatus(
+            final AtomicBoolean _start,
             final INodeMgr _nodeMgr,
             final String _selfShortId,
             final BlockingQueue<MsgOut> _sendMsgQue,
@@ -21,21 +26,28 @@ public class TaskStatus implements Runnable {
         this.selfShortId = _selfShortId;
         this.sendMsgQue = _sendMsgQue;
         this.receiveMsgQue = _receiveMsgQue;
+        this.start = _start;
     }
 
     @Override
     public void run() {
-        Thread.currentThread().setName("p2p-ts");
-        String status = this.nodeMgr.dumpNodeInfo(this.selfShortId, p2pLOG.isDebugEnabled());
+        while (start.get()) {
+            try {
+                Thread.sleep(PERIOD_STATUS);
+                String status = this.nodeMgr.dumpNodeInfo(this.selfShortId, p2pLOG.isDebugEnabled());
 
-        if (p2pLOG.isDebugEnabled()) {
-            p2pLOG.debug(status);
-            p2pLOG.debug(
-                    "recv queue[{}] send queue[{}]",
-                    this.receiveMsgQue.size(),
-                    this.sendMsgQue.size());
-        } else if (p2pLOG.isInfoEnabled()) {
-            p2pLOG.info(status);
+                if (p2pLOG.isDebugEnabled()) {
+                    p2pLOG.debug(status);
+                    p2pLOG.debug(
+                        "recv queue[{}] send queue[{}]",
+                        this.receiveMsgQue.size(),
+                        this.sendMsgQue.size());
+                } else if (p2pLOG.isInfoEnabled()) {
+                    p2pLOG.info(status);
+                }
+            } catch (Exception e) {
+                p2pLOG.warn("P2p taskStatus exception! ", e);
+            }
         }
     }
 }

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskStatusTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskStatusTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.aion.log.LogLevel;
@@ -38,7 +39,9 @@ public class TaskStatusTest {
     @Test(timeout = 10_000)
     public void testRun() throws InterruptedException {
 
-        TaskStatus ts = new TaskStatus(nodeMgr, "1", msgOutQue, msgInQue);
+        final AtomicBoolean ab = new AtomicBoolean(true);
+
+        TaskStatus ts = new TaskStatus(ab, nodeMgr, "1", msgOutQue, msgInQue);
         assertNotNull(ts);
         when(nodeMgr.dumpNodeInfo(anyString(), anyBoolean())).thenReturn("get Status");
 
@@ -46,6 +49,7 @@ public class TaskStatusTest {
         t.start();
         assertTrue(t.isAlive());
 
+        ab.set(false);
         while (!t.getState().toString().contains("TERMINATED")) {
             Thread.sleep(10);
         }


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- This PR is trying to solve the thread p2p-ts stuck issue. Currently, the p2p-ts is using scheduled threads pool with the other thread task. I suspect the p2p-ts stuck due to the `reqnodestasks` thread blocking the pool. Therefore, I use dedicated thread instead of using the sharing thread pool to avoid the blocking.

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Modified the existing test case with new implementation

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [ ] My code generates no new warnings.
- [ ] Any dependent changes have been made.
