### PR TITLE
CLI option for retrieving data for consensus tests

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
@@ -147,6 +147,14 @@ public class Arguments {
     private String dumpStateCount = null;
 
     @Option(
+            names = {"--dump-for-test"},
+            arity = "1..*",
+            paramLabel = "<block_to_import> [skip-state] [<contr_1>]  [<contr_2>] ",
+            description =
+                    "retrieves block and multiple contract data from the blockchain to be used for consensus unit tests; the skip-state option can be used to retrieve the data only for contracts")
+    private String[] dumpForTest = null;
+
+    @Option(
             names = {"--db-compact"},
             description = "if using leveldb, it triggers its database compaction processes")
     private boolean dbCompact;
@@ -261,6 +269,10 @@ public class Arguments {
 
     public String getDumpStateCount() {
         return dumpStateCount;
+    }
+
+    public String[] getDumpForTest() {
+        return dumpForTest;
     }
 
     public boolean isDbCompact() {

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -79,6 +79,7 @@ public class Cli {
         PRUNE_STATE,
         DUMP_STATE_SIZE,
         DUMP_STATE,
+        DUMP_STATE_TEST,
         DUMP_BLOCKS,
         DB_COMPACT,
         REDO_IMPORT
@@ -479,6 +480,34 @@ public class Cli {
                                 "Retrieving state for main chain block at level " + level + "...");
                     }
                     RecoveryUtils.printStateTrieDump(level);
+                    return EXIT;
+                }
+            }
+
+            if (options.getDumpForTest() != null) {
+                long level;
+                String[] parameters = options.getDumpForTest();
+
+                try {
+                    level = Long.parseLong(parameters[0]);
+                } catch (NumberFormatException e) {
+                    System.out.println(
+                            "The given argument «"
+                                    + parameters[0]
+                                    + "» cannot be converted to a number.");
+                    return ERROR;
+                }
+                if (level < 2) { // requires a parent and grandparent
+                    System.out.println(
+                            "Negative block values are not legal input values for this functionality.");
+                    return ERROR;
+                } else {
+                    System.out.println(
+                            "Retrieving consensus data for unit tests for the main chain block at level "
+                                    + level
+                                    + "...");
+
+                    RecoveryUtils.dumpTestData(level, parameters);
                     return EXIT;
                 }
             }
@@ -935,6 +964,9 @@ public class Cli {
         if (options.getDumpStateCount() != null) {
             return TaskPriority.DUMP_STATE;
         }
+        if (options.getDumpForTest() != null) {
+            return TaskPriority.DUMP_STATE_TEST;
+        }
         if (options.getDumpBlocksCount() != null) {
             return TaskPriority.DUMP_BLOCKS;
         }
@@ -1015,6 +1047,10 @@ public class Cli {
         if (breakingTaskPriority.compareTo(TaskPriority.DUMP_STATE) < 0
                 && options.getDumpStateCount() != null) {
             skippedTasks.add("--dump-state");
+        }
+        if (breakingTaskPriority.compareTo(TaskPriority.DUMP_STATE_TEST) < 0
+                && options.getDumpForTest() != null) {
+            skippedTasks.add("--dump-for-test");
         }
         if (breakingTaskPriority.compareTo(TaskPriority.DUMP_BLOCKS) < 0
                 && options.getDumpBlocksCount() != null) {

--- a/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
@@ -961,6 +961,11 @@ public class AionBlockStore extends AbstractPowBlockstore<AionBlock, A0BlockHead
             if (firstBlock < 0) {
                 return null;
             }
+
+            // the 1st block will be imported by the test
+            // its total difficulty, state root and receipt hash can be used for validation
+            // the 2nd block will be used to setup the blockchain world state before import
+            // the 3rd block is also part of the setup as it is required for header validation
             long lastBlock = firstBlock - 3;
 
             File file =

--- a/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
@@ -953,6 +953,58 @@ public class AionBlockStore extends AbstractPowBlockstore<AionBlock, A0BlockHead
         }
     }
 
+    public String dumpPastBlocksForConsensusTest(long firstBlock, String reportsFolder)
+            throws IOException {
+        lock.readLock().lock();
+
+        try {
+            if (firstBlock < 0) {
+                return null;
+            }
+            long lastBlock = firstBlock - 3;
+
+            File file =
+                    new File(
+                            reportsFolder,
+                            System.currentTimeMillis() + "-blocks-for-consensus-test.out");
+
+            BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+
+            while (firstBlock > lastBlock && firstBlock >= 0) {
+                List<BlockInfo> levelBlocks = getBlockInfoForLevel(firstBlock);
+
+                for (BlockInfo bi : levelBlocks) {
+                    if (bi.mainChain) {
+                        writer.append(
+                                "\nBlock hash from index database: "
+                                        + Hex.toHexString(bi.getHash())
+                                        + "\nTotal Difficulty: "
+                                        + bi.getCummDifficulty()
+                                        + "\nBlock on main chain: "
+                                        + String.valueOf(bi.isMainChain()).toUpperCase());
+                        writer.newLine();
+                        AionBlock blk = getBlockByHash(bi.getHash());
+                        if (blk != null) {
+                            writer.append("\nFull block data:\n");
+                            writer.append(blk.toString());
+                            writer.newLine();
+                        } else {
+                            writer.append("Retrieved block data is null.");
+                        }
+                    }
+                }
+                writer.newLine();
+
+                firstBlock--;
+            }
+
+            writer.close();
+            return file.getName();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     public List<byte[]> getListHashesStartWith(long number, long maxBlocks) {
         lock.readLock().lock();
 

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -995,7 +995,6 @@ public class AionRepositoryImpl
         byte[][] elements = new byte[refs.size()][];
         int i = 0;
         for (byte[] ref : refs) {
-            System.out.println("dump-key:" + Hex.toHexString(ref));
             elements[i] =
                     RLP.encodeList(
                             RLP.encodeElement(ref),


### PR DESCRIPTION
## Description

Calling `--dump-for-test` will retrieve block, state and contract data from any network (with a database that is not pruned) that can be used to build unit tests similar to `MasteryConsensusTest.java`

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [x] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- existing test suite
- used the new functionality in practice to build tests for `MasteryConsensusTest.java`

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests for my fix or feature.
- [x] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
