### PR TITLE
Fix transaction timestamp issue in the transaction pool

### DIFF
--- a/modAion/src/org/aion/zero/types/AionTransaction.java
+++ b/modAion/src/org/aion/zero/types/AionTransaction.java
@@ -2,6 +2,7 @@ package org.aion.zero.types;
 
 import static org.aion.util.bytes.ByteUtil.ZERO_BYTE_ARRAY;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.math.BigInteger;
 import java.util.Arrays;
 import org.aion.mcf.vm.types.DataWordImpl;
@@ -339,6 +340,14 @@ public class AionTransaction extends AbstractTransaction {
 
     public void sign(ECKey key) throws MissingPrivateKeyException {
         this.timeStamp = ByteUtil.longToBytes(TimeInstant.now().toEpochMicro());
+        this.signature = key.sign(this.getRawHash());
+        this.rlpEncoded = null;
+    }
+
+
+    @VisibleForTesting
+    public void signWithSecTimeStamp(ECKey key) throws MissingPrivateKeyException {
+        this.timeStamp = ByteUtil.longToBytes(TimeInstant.now().toEpochSec() * 1_000_000L);
         this.signature = key.sign(this.getRawHash());
         this.rlpEncoded = null;
     }

--- a/modTxPoolImpl/src/org/aion/txpool/zero/TxPoolA0.java
+++ b/modTxPoolImpl/src/org/aion/txpool/zero/TxPoolA0.java
@@ -464,7 +464,8 @@ public class TxPoolA0<TX extends Transaction> extends AbstractTxPool<TX> impleme
             for (Entry<ByteArrayWrapper, TxDependList<ByteArrayWrapper>> pair :
                     e.getValue().entrySet()) {
                 BigInteger ts = pair.getValue().getTimeStamp();
-                while (timeTxDep.get(ts.add(BigInteger.ONE)) != null) {
+                // If timestamp has collision, increase 1 for getting a new slot to put the transaction pair.
+                while (timeTxDep.get(ts) != null) {
                     ts = ts.add(BigInteger.ONE);
                 }
                 timeTxDep.put(ts, pair);


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the master branch directly, please submit your PR to the master-pre-merge branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Fixed txpool snapshot issue when the pool has the same timestamp transactions with the same sender.

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- Adding new test case and helper method in the AionTransaction class.

## Verification

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] I have self-reviewed my own code and conformed to the style guidelines of this project.
- [x] New and existing tests pass locally with my changes.
- [x] I have added tests for my fix or feature.
- [ ] I have made appropriate changes to the corresponding documentation.
- [x] My code generates no new warnings.
- [ ] Any dependent changes have been made.
