### PR TITLE
Fix AionPendingStateImpl Init exception when seednode mode turns-on

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionPendingStateImpl.java
@@ -333,9 +333,11 @@ public class AionPendingStateImpl implements IPendingStateInternal<AionBlock, Ai
     }
 
     public void init(final AionBlockchainImpl blockchain, boolean test) {
+
+        this.blockchain = blockchain;
+        this.best = new AtomicReference<>();
+
         if (!this.isSeed) {
-            this.blockchain = blockchain;
-            this.best = new AtomicReference<>();
             this.transactionStore = blockchain.getTransactionStore();
 
             this.evtMgr = blockchain.getEventMgr();

--- a/modAionImpl/src/org/aion/zero/impl/config/CfgConsensusPow.java
+++ b/modAionImpl/src/org/aion/zero/impl/config/CfgConsensusPow.java
@@ -1,5 +1,6 @@
 package org.aion.zero.impl.config;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -156,5 +157,10 @@ public final class CfgConsensusPow extends CfgConsensus {
 
     public boolean isSeed() {
         return seed;
+    }
+
+    @VisibleForTesting
+    public void setSeed(final boolean value) {
+        seed = value;
     }
 }

--- a/modAionImpl/test/org/aion/zero/impl/PendingStateTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/PendingStateTest.java
@@ -216,4 +216,22 @@ public class PendingStateTest {
 
         assertEquals(hub.getPendingState().addPendingTransaction(transaction), TxResponse.SUCCESS);
     }
+
+    @Test
+    public void testAionPendingStateInit() {
+        StandaloneBlockchain.Bundle bundle =
+            new StandaloneBlockchain.Builder()
+                .withDefaultAccounts()
+                .withValidatorConfiguration("simple")
+                .withAvmEnabled()
+                .build();
+        StandaloneBlockchain blockchain = bundle.bc;
+        CfgAion.inst().setGenesis(blockchain.getGenesis());
+        CfgAion.inst().getConsensus().setSeed(true);
+
+        // NullPointerException should not happens
+        AionHub.createForTesting(CfgAion.inst(), blockchain, blockchain.getRepository());
+
+        CfgAion.inst().getConsensus().setSeed(false);
+    }
 }


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the 'master' branch directly, please submit your PR to the 'master-pre-merge' branch and rebase your PR to 'master-pre-merge' branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- the pendingStateImpl init exception due 

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- added a test case in the pendingstat test

