### PR TITLE
eth_call sender return fix

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionImpl.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
 import org.aion.equihash.EquihashMiner;
 import org.aion.interfaces.db.Repository;
@@ -37,6 +38,7 @@ public class AionImpl implements IAionChain {
     private static final Logger LOG_GEN = AionLoggerFactory.getLogger(LogEnum.GEN.toString());
     private static final Logger LOG_TX = AionLoggerFactory.getLogger(LogEnum.TX.toString());
     private static final Logger LOG_VM = AionLoggerFactory.getLogger(LogEnum.VM.toString());
+    private static final ECKey keyForCallandEstimate = ECKeyFac.inst().fromPrivate(new byte[64]);
 
     public AionHub aionHub;
 
@@ -131,7 +133,7 @@ public class AionImpl implements IAionChain {
     public long estimateTxNrg(AionTransaction tx, IAionBlock block) {
 
         if (tx.getSignature() == null) {
-            tx.sign(ECKeyFac.inst().fromPrivate(new byte[64]));
+            tx.sign(keyForCallandEstimate);
         }
 
         RepositoryCache repository =
@@ -158,11 +160,11 @@ public class AionImpl implements IAionChain {
         }
     }
 
-    /** TODO: pretty sure we can just use a static key, verify and implement */
     @Override
     public AionTxReceipt callConstant(AionTransaction tx, IAionBlock block) {
+
         if (tx.getSignature() == null) {
-            tx.sign(ECKeyFac.inst().fromPrivate(new byte[64]));
+            tx.sign(keyForCallandEstimate);
         }
 
         RepositoryCache repository =

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -442,6 +442,7 @@ public abstract class ApiAion extends Api {
         AionTransaction tx =
                 new AionTransaction(
                         _params.getNonce().toByteArray(),
+                        _params.getFrom() == null ? Address.ZERO_ADDRESS() : _params.getFrom(),
                         _params.getTo(),
                         _params.getValue().toByteArray(),
                         _params.getData(),

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -808,9 +808,15 @@ public class ApiWeb3Aion extends ApiAion {
 
         AionBlock b = getBlockByBN(bn);
 
+        Address sender = txParams.getFrom();
+        if (sender == null) {
+            sender = Address.ZERO_ADDRESS();
+        }
+
         AionTransaction tx =
                 new AionTransaction(
                         txParams.getNonce().toByteArray(),
+                        sender,
                         txParams.getTo(),
                         txParams.getValue().toByteArray(),
                         txParams.getData(),

--- a/modApiServer/test/org/aion/api/server/rpc/ApiWeb3AionTest.java
+++ b/modApiServer/test/org/aion/api/server/rpc/ApiWeb3AionTest.java
@@ -9,10 +9,12 @@ import org.aion.types.Address;
 import org.aion.mcf.account.AccountManager;
 import org.aion.mcf.account.Keystore;
 
+import org.aion.vm.VirtualMachineProvider;
 import org.aion.zero.impl.blockchain.AionImpl;
 import org.aion.zero.impl.blockchain.AionPendingStateImpl;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,6 +27,12 @@ public class ApiWeb3AionTest {
     public void setup() {
         impl = AionImpl.inst();
         web3Api = new ApiWeb3Aion(impl);
+        VirtualMachineProvider.initializeAllVirtualMachines();
+    }
+
+    @After
+    public void tearDown() {
+        VirtualMachineProvider.shutdownAllVirtualMachines();
     }
 
     @Test
@@ -205,5 +213,22 @@ public class ApiWeb3AionTest {
 
         RpcMsg rsp = web3Api.eth_getTransactionByBlockNumberAndIndex(req);
         assertEquals(JSONObject.NULL, rsp.getResult());
+    }
+
+    @Test
+    public void testEth_call() {
+        Address from = new Address("a000000000000000000000000000000000000000000000000000000000000001");
+        Address to = new Address("a000000000000000000000000000000000000000000000000000000000000002");
+
+        JSONObject tx = new JSONObject();
+        tx.put("from", from.toString());
+        tx.put("to", to.toString());
+
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.put(tx);
+
+        RpcMsg rsp = web3Api.eth_call(jsonArray);
+
+        assertEquals(JSONObject.wrap("0x"), rsp.getResult());
     }
 }


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the 'master' branch directly, please submit your PR to the 'master-pre-merge' branch and rebase your PR to 'master-pre-merge' branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- fixed eth_call fixed sender issue, the from address becoming to an optional argument. If the caller doesn't assign the from address in the call. the kernel will return an all 0 address

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- This fix has been verified by Aion_Jennifer. However, for verifying the sender address of the returns, it will implement it in the hardness test (AKI-162).

