### PR TITLE
AKI-32 fix the energy limit for the eth_call

### DIFF
--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -789,7 +789,7 @@ public class ApiWeb3Aion extends ApiAion {
             return new RpcMsg(null, RpcError.INVALID_PARAMS, "Invalid parameters");
         }
 
-        ArgTxCall txParams = ArgTxCall.fromJSON(_tx, getRecommendedNrgPrice());
+        ArgTxCall txParams = ArgTxCall.fromJSONforCall(_tx, getRecommendedNrgPrice());
 
         if (txParams == null) {
             return new RpcMsg(
@@ -832,7 +832,7 @@ public class ApiWeb3Aion extends ApiAion {
             return new RpcMsg(null, RpcError.INVALID_PARAMS, "Invalid parameters");
         }
 
-        ArgTxCall txParams = ArgTxCall.fromJSON(_tx, getRecommendedNrgPrice());
+        ArgTxCall txParams = ArgTxCall.fromJSONforCall(_tx, getRecommendedNrgPrice());
 
         NumericalValue estimate = new NumericalValue(estimateNrg(txParams));
 

--- a/modApiServer/src/org/aion/api/server/types/ArgTxCall.java
+++ b/modApiServer/src/org/aion/api/server/types/ArgTxCall.java
@@ -62,10 +62,20 @@ public final class ArgTxCall {
     }
 
     public static ArgTxCall fromJSON(final JSONObject _jsonObj, long defaultNrgPrice) {
+        return fromJSON(_jsonObj, defaultNrgPrice, false);
+    }
+
+    public static ArgTxCall fromJSONforCall(final JSONObject _jsonObj, long defaultNrgPrice) {
+        return fromJSON(_jsonObj, defaultNrgPrice, true);
+    }
+
+    private static ArgTxCall fromJSON(
+        final JSONObject _jsonObj, long defaultNrgPrice, boolean forCall) {
         try {
 
             String fromStr = _jsonObj.optString("from", "");
-            Address from = fromStr.equals("") ? null : Address.wrap(ByteUtil.hexStringToBytes(fromStr));
+            Address from =
+                    fromStr.equals("") ? null : Address.wrap(ByteUtil.hexStringToBytes(fromStr));
 
             String toStr = _jsonObj.optString("to", "");
             Address to = toStr.equals("") ? null : Address.wrap(ByteUtil.hexStringToBytes(toStr));
@@ -87,12 +97,19 @@ public final class ArgTxCall {
             String nrgStr = _jsonObj.optString("gas", null);
             String nrgPriceStr = _jsonObj.optString("gasPrice", null);
 
-            long nrg = to == null ? NRG_CREATE_CONTRACT_DEFAULT : NRG_TRANSACTION_DEFAULT;
-            if (nrgStr != null)
+            long nrg;
+            if (nrgStr != null) {
                 nrg =
                         nrgStr.contains("0x")
                                 ? StringUtils.StringHexToBigInteger(nrgStr).longValue()
                                 : StringUtils.StringNumberAsBigInt(nrgStr).longValue();
+            } else {
+                if (forCall) {
+                    nrg = Long.MAX_VALUE;
+                } else {
+                    nrg = to == null ? NRG_CREATE_CONTRACT_DEFAULT : NRG_TRANSACTION_DEFAULT;
+                }
+            }
 
             long nrgPrice = defaultNrgPrice;
             if (nrgPriceStr != null)

--- a/modApiServer/test/org/aion/api/server/types/ArgTxCallTest.java
+++ b/modApiServer/test/org/aion/api/server/types/ArgTxCallTest.java
@@ -2,8 +2,10 @@ package org.aion.api.server.types;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
+import static org.aion.mcf.vm.Constants.NRG_CREATE_CONTRACT_MAX;
 import static org.aion.mcf.vm.Constants.NRG_TRANSACTION_DEFAULT;
 import static org.aion.mcf.vm.Constants.NRG_CREATE_CONTRACT_DEFAULT;
+import static org.aion.mcf.vm.Constants.NRG_TRANSACTION_MAX;
 
 import java.math.BigInteger;
 import org.aion.types.Address;
@@ -45,6 +47,41 @@ public class ArgTxCallTest {
         assertEquals(BigInteger.ZERO, txCall.getNonce());
         assertEquals(BigInteger.ZERO, txCall.getValue());
         assertEquals(NRG_TRANSACTION_DEFAULT, txCall.getNrg());
+        assertEquals(nrgPrice, txCall.getNrgPrice());
+    }
+
+    @Test
+    public void testTxCallfromJSONforCall() {
+        long nrgPrice = 10L;
+
+        String toAddr = "0xa076407088416d71467529d8312c24d7596f5d7db75a5c4129d2763df112b8a1";
+        JSONObject tx = new JSONObject();
+
+        tx.put("to", toAddr);
+        ArgTxCall txCall = ArgTxCall.fromJSONforCall(tx, nrgPrice);
+
+        assertNull(txCall.getFrom());
+        assertEquals(new Address(toAddr), txCall.getTo());
+        assertEquals(0, txCall.getData().length);
+        assertEquals(BigInteger.ZERO, txCall.getNonce());
+        assertEquals(BigInteger.ZERO, txCall.getValue());
+        assertEquals(Long.MAX_VALUE, txCall.getNrg());
+        assertEquals(nrgPrice, txCall.getNrgPrice());
+    }
+
+    @Test
+    public void testTxCallContractCreatefromJSONforCall() {
+        long nrgPrice = 10L;
+
+        JSONObject tx = new JSONObject();
+        ArgTxCall txCall = ArgTxCall.fromJSONforCall(tx, nrgPrice);
+
+        assertNull(txCall.getFrom());
+        assertNull(txCall.getTo());
+        assertEquals(0, txCall.getData().length);
+        assertEquals(BigInteger.ZERO, txCall.getNonce());
+        assertEquals(BigInteger.ZERO, txCall.getValue());
+        assertEquals(Long.MAX_VALUE, txCall.getNrg());
         assertEquals(nrgPrice, txCall.getNrgPrice());
     }
 }


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the 'master' branch directly, please submit your PR to the 'master-pre-merge' branch and rebase your PR to 'master-pre-merge' branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Currently, the kernel has the issue for the user using eth_call but does not give the energy or give a small amount of the energy which cannot perform the transaction in the real blockchain. This fix grant the user perform the eth_call without the energy limit (or say the kernel will assign an extremely amount energy value in the call)

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- the test case relates with AKI-161 but there are 2 unit tests for checking the energy limit the kernel assigned.

