### PR TITLE
Jenkinsfile: when invoking node_test_harness, run tests against Java kernel only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
 
                     dir('FunctionalTests') { 
                         sh('tar -C Tests -xjf Tests/aion.tar.bz2')
-                        sh('./gradlew :Tests:ciTest -i')
+                        sh('./gradlew :Tests:ciTest -i -PtestNodes=java')
                     }
             }
         }


### PR DESCRIPTION


## Notice

It is not allowed to submit your PR to the 'master' branch directly, please submit your PR to the 'master-pre-merge' branch and rebase your PR to 'master-pre-merge' branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Jenkinsfile: when invoking node_test_harness, run tests against Java kernel only (i.e. don't run tests against Rust kernel)

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

