### PR TITLE
Memory usage tune-up

### DIFF
--- a/aion.sh
+++ b/aion.sh
@@ -4,6 +4,8 @@ cd "$(dirname $(realpath $0))"
 
 KERVER=$(uname -r | grep -o "^4\.")
 
+export MALLOC_ARENA_MAX=4
+
 if [ "$KERVER" != "4." ]; then
   echo "Warning! The linux kernel must be greater than or equal to version 4."
 fi
@@ -41,11 +43,11 @@ chmod +x ./rt/bin/*
 # default to minimum 4gb heap if Xms not set.
 JAVA_OPTS="$JAVA_OPTS"
 if [[ ! ${JAVA_OPTS} = *"-Xms"* ]]; then
-  JAVA_OPTS+=" -Xms4g"
+  JAVA_OPTS+=" -Xms512m"
 fi
 
 if [[ ! ${JAVA_OPTS} = *"-Xmx"* ]]; then
-  JAVA_OPTS+=" -Xmx8g"
+  JAVA_OPTS+=" -Xmx2g"
 fi
 
 

--- a/modAionImpl/src/org/aion/zero/impl/valid/TXValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/TXValidator.java
@@ -21,7 +21,7 @@ public class TXValidator {
     private static final Logger LOG = LoggerFactory.getLogger(LogEnum.TX.name());
 
     private static final Map<ByteArrayWrapper, Boolean> cache =
-            Collections.synchronizedMap(new LRUMap<>(128 * 1024));
+            Collections.synchronizedMap(new LRUMap<>(16 * 1024));
 
     public static boolean isValid(AionTransaction tx) {
         Boolean valid = cache.get(ByteArrayWrapper.wrap(tx.getTransactionHash()));


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the 'master' branch directly, please submit your PR to the 'master-pre-merge' branch and rebase your PR to 'master-pre-merge' branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Kernel memory usage tune-up. The aionblock cached the unnecessary trie instance after calculated the transaction state root. Therefore, when the syncMgr queuing the downloaded blocks with tons of transactions from the network. It will consume a lot of memory.  It should be released right away.
- Changed the Linux kernel env setup relate with glibc for solving the memory occupy issue.

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- syncing test with the network. The kernel stays around 4GB after tune-up even import the heavy transaction blocks (before is 7~8GB). 

