### PR TITLE
Added CLI tooling for querying block/transaction/account details

### DIFF
--- a/modAion/src/org/aion/zero/types/AionTxExecSummary.java
+++ b/modAion/src/org/aion/zero/types/AionTxExecSummary.java
@@ -457,4 +457,22 @@ public class AionTxExecSummary implements TxExecSummary {
             return null;
         }
     }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+
+        s.append(receipt.toString()).append("\n");
+        s.append("value= ").append(value).append("\n");
+        s.append("deletedAccounts [");
+        if (!deletedAccounts.isEmpty()) {
+            s.append("\n");
+            for (AionAddress a : deletedAccounts) {
+                s.append("  ").append(a).append("\n");
+            }
+        }
+        s.append("]\n");
+
+        return s.toString();
+    }
 }

--- a/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Arguments.java
@@ -167,6 +167,28 @@ public class Arguments {
                     "drops all databases except for block and index when not given a parameter or starting from 0 and redoes import of all known main chain blocks")
     private String redoImport = null;
 
+    // data query
+    @Option(
+            names = {"qb", "--query-block"},
+            arity = "1",
+            paramLabel = "<block_number>",
+            description = "retrieve block information")
+    private String blockDetails = null;
+
+    @Option(
+            names = {"qt", "--query-tx"},
+            arity = "1",
+            paramLabel = "<transaction_hash>",
+            description = "retrieve transaction information")
+    private String transactionDetails = null;
+
+    @Option(
+            names = {"qa", "--query-account"},
+            arity = "1",
+            paramLabel = "<account_address>",
+            description = "retrieve account information")
+    private String accountDetails = null;
+
     /** Compacts the account options into specific commands. */
     public static String[] preProcess(String[] arguments) {
         List<String> list = new ArrayList<>();
@@ -281,5 +303,17 @@ public class Arguments {
 
     public String isRedoImport() {
         return redoImport;
+    }
+
+    public String getBlockDetails() {
+        return blockDetails;
+    }
+
+    public String getTransactionDetails() {
+        return transactionDetails;
+    }
+
+    public String getAccountDetails() {
+        return accountDetails;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
@@ -247,6 +247,43 @@ public class AionBlockStore extends AbstractPowBlockstore<AionBlock, A0BlockHead
     }
 
     /**
+     * @implNote method use for the CLI tooling
+     * @param number block number
+     * @return list of blocks in the given block level.
+     */
+    List<AionBlock> getAllChainBlockByNumber(long number) {
+        lock.readLock().lock();
+
+        try {
+            long size = index.size();
+            if (number < 0L || number >= size) {
+                return null;
+            }
+
+            List<BlockInfo> blockInfos = index.get(number);
+
+            if (blockInfos == null) {
+                return null;
+            }
+
+            List<AionBlock> blockList = new ArrayList<>();
+            for (BlockInfo blockInfo : blockInfos) {
+                AionBlock b = blocks.get(blockInfo.getHash());
+                if (blockInfo.isMainChain()) {
+                    b.setMainChain();
+                }
+
+                b.setCumulativeDifficulty(blockInfo.cummDifficulty);
+                blockList.add(b);
+            }
+
+            return blockList;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
      * Returns a range of main chain blocks.
      *
      * @param first the height of the first block in the requested range; this block must exist in

--- a/modAionImpl/src/org/aion/zero/impl/db/AionContractDetailsImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionContractDetailsImpl.java
@@ -24,6 +24,7 @@ import org.aion.rlp.RLPElement;
 import org.aion.rlp.RLPItem;
 import org.aion.rlp.RLPList;
 import org.aion.types.AionAddress;
+import org.aion.util.conversions.Hex;
 import org.aion.util.types.ByteArrayWrapper;
 
 public class AionContractDetailsImpl extends AbstractContractDetails {
@@ -693,5 +694,42 @@ public class AionContractDetailsImpl extends AbstractContractDetails {
             copyOfCodes.put(keyWrapper, copyOfValue);
         }
         return copyOfCodes;
+    }
+
+    public byte[] getConcatenatedStorageHash() {
+        return concatenatedStorageHash;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        ret.append("  VM: ").append(vmType.toString()).append("\n");
+        ret.append("  dirty: ").append(isDirty()).append("\n");
+
+        byte[] code = getCode();
+        if (code != null) {
+            ret.append("  Code: ")
+                    .append(
+                            (code.length < 2
+                                    ? Hex.toHexString(getCode())
+                                    : code.length + " versions"))
+                    .append("\n");
+        } else {
+            ret.append("  Code: null\n");
+        }
+
+        byte[] storage = getStorageHash();
+        if (storage != null) {
+            ret.append("  Storage: ").append(Hex.toHexString(storage)).append("\n");
+        } else {
+            ret.append("  Storage: null\n");
+        }
+
+        ret.append("  objectGraphHash: ").append(Hex.toHexString(objectGraphHash)).append("\n");
+        ret.append("  concatenatedStorageHash: ")
+                .append(Hex.toHexString(concatenatedStorageHash))
+                .append("\n");
+
+        return ret.toString();
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryCache.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryCache.java
@@ -720,4 +720,32 @@ public class AionRepositoryCache implements RepositoryCache<AccountState, IBlock
             fullyWriteUnlock();
         }
     }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+
+        s.append("cachedAccounts [");
+
+        if (cachedAccounts != null && !cachedAccounts.isEmpty()) {
+            s.append("\n");
+            for (Map.Entry<AionAddress, AccountState> ca : cachedAccounts.entrySet()) {
+                s.append(ca.getKey()).append("\n").append(ca.getValue()).append("\n");
+            }
+        } else {
+            s.append("]\n");
+        }
+
+        s.append("cachedDetails [");
+        if (cachedDetails != null && !cachedDetails.isEmpty()) {
+            s.append("\n");
+            for (Map.Entry<AionAddress, ContractDetails> ca : cachedDetails.entrySet()) {
+                s.append(ca.getKey()).append("\n").append(ca.getValue()).append("\n");
+            }
+        } else {
+            s.append("]\n");
+        }
+
+        return s.toString();
+    }
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/ContractDetailsCacheImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/ContractDetailsCacheImpl.java
@@ -1,5 +1,7 @@
 package org.aion.zero.impl.db;
 
+import static org.aion.crypto.HashUtil.h256;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,6 +11,7 @@ import org.aion.db.impl.ByteArrayKeyValueStore;
 import org.aion.mcf.db.ContractDetails;
 import org.aion.mcf.db.InternalVmType;
 import org.aion.types.AionAddress;
+import org.aion.util.conversions.Hex;
 import org.aion.util.types.ByteArrayWrapper;
 
 /** Contract details cache implementation. */
@@ -352,5 +355,44 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
             storageCopy.put(keyWrapper, valueWrapper);
         }
         return storageCopy;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        ret.append("  VM: ").append(vmType.toString()).append("\n");
+        ret.append("  dirty: ").append(isDirty()).append("\n");
+
+        byte[] code = getCode();
+        if (code != null) {
+            ret.append("  Code: ")
+                    .append(
+                            (code.length < 2
+                                    ? Hex.toHexString(getCode())
+                                    : code.length + " versions"))
+                    .append("\n");
+        } else {
+            ret.append("  Code: null\n");
+        }
+
+        byte[] storage = getStorageHash();
+        if (storage != null) {
+            ret.append("  Storage: ").append(Hex.toHexString(storage)).append("\n");
+        } else {
+            ret.append("  Storage: null\n");
+        }
+
+        ret.append("  objectGraphHash: ")
+                .append(objectGraph == null ? "null" : Hex.toHexString(h256(objectGraph)))
+                .append("\n");
+        if (origContract != null && origContract instanceof AionContractDetailsImpl) {
+            byte[] hash = ((AionContractDetailsImpl) origContract).getConcatenatedStorageHash();
+            if (hash != null) {
+                ret.append("  concatenatedStorageHash: ")
+                        .append(Hex.toHexString(hash))
+                        .append("\n");
+            }
+        }
+        return ret.toString();
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/types/AionBlock.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionBlock.java
@@ -350,41 +350,41 @@ public class AionBlock extends AbstractBlock<A0BlockHeader> implements IAionBloc
         parseRLP();
 
         toStringBuff.setLength(0);
-        toStringBuff.append(Hex.toHexString(this.getEncoded())).append("\n");
         toStringBuff.append("BlockData [ ");
         toStringBuff.append("hash=").append(ByteUtil.toHexString(this.getHash())).append("\n");
         toStringBuff.append(header.toString());
 
+        if (td != null) {
+            toStringBuff.append("  cumulative difficulty=").append(td).append("\n");
+        }
+
+        if (mainChain != null) {
+            toStringBuff.append("  mainChain=").append(mainChain ? "yes" : "no").append("\n");
+        }
+
         if (!getTransactionsList().isEmpty()) {
-            toStringBuff.append("Txs [\n");
+            toStringBuff
+                    .append("  transactions=")
+                    .append(getTransactionsList().size())
+                    .append("\n\n");
+            toStringBuff.append("  Txs [\n");
+            int index = 0;
             for (AionTransaction tx : getTransactionsList()) {
-                toStringBuff.append(tx);
-                toStringBuff.append("\n");
+                toStringBuff
+                        .append("  ")
+                        .append("index=")
+                        .append(index++)
+                        .append("\n")
+                        .append(tx)
+                        .append("\n");
             }
-            toStringBuff.append("]\n");
+            toStringBuff.append("  ]\n");
         } else {
-            toStringBuff.append("Txs []\n");
+            toStringBuff.append("  Txs []\n");
         }
-        toStringBuff.append("]");
+        toStringBuff.append("]\n");
+        toStringBuff.append(Hex.toHexString(this.getEncoded())).append("\n");
 
-        return toStringBuff.toString();
-    }
-
-    public String toFlatString() {
-        StringBuilder toStringBuff = new StringBuilder();
-        parseRLP();
-
-        toStringBuff.setLength(0);
-        toStringBuff.append("BlockData [");
-        toStringBuff.append("hash=").append(ByteUtil.toHexString(this.getHash()));
-        toStringBuff.append(header.toFlatString());
-
-        for (AionTransaction tx : getTransactionsList()) {
-            toStringBuff.append("\n");
-            toStringBuff.append(tx.toString());
-        }
-
-        toStringBuff.append("]");
         return toStringBuff.toString();
     }
 
@@ -543,5 +543,12 @@ public class AionBlock extends AbstractBlock<A0BlockHeader> implements IAionBloc
 
     public void setCumulativeDifficulty(BigInteger _td) {
         td = _td;
+    }
+
+    /** use for cli tooling */
+    private Boolean mainChain;
+
+    public void setMainChain() {
+        mainChain = true;
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/types/AionBlockSummary.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionBlockSummary.java
@@ -3,6 +3,7 @@ package org.aion.zero.impl.types;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.aion.mcf.types.AbstractBlockSummary;
 import org.aion.types.AionAddress;
 import org.aion.zero.impl.blockchain.BlockSummary;
@@ -28,5 +29,29 @@ public class AionBlockSummary
         this.rewards = rewards;
         this.receipts = receipts;
         this.summaries = summaries;
+    }
+
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+        s.append("rewards [\n");
+        for (Entry e : rewards.entrySet()) {
+            s.append("  ")
+                    .append(e.getKey().toString())
+                    .append(" ")
+                    .append(e.getValue().toString())
+                    .append("\n");
+        }
+        s.append("]\n\n");
+
+        // Ignore print receipt cause the summary already has.
+
+        int index = 0;
+        s.append("summaries [\n");
+        for (AionTxExecSummary sum : summaries) {
+            s.append("tx index ").append(index++).append("\n").append(sum.toString()).append("\n");
+        }
+        s.append("]\n");
+
+        return s.toString();
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/types/AionTxInfo.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionTxInfo.java
@@ -6,6 +6,7 @@ import org.aion.mcf.core.AbstractTxInfo;
 import org.aion.rlp.RLP;
 import org.aion.rlp.RLPItem;
 import org.aion.rlp.RLPList;
+import org.aion.util.conversions.Hex;
 import org.aion.zero.types.AionTxReceipt;
 
 public class AionTxInfo extends AbstractTxInfo<AionTxReceipt> {
@@ -75,5 +76,16 @@ public class AionTxInfo extends AbstractTxInfo<AionTxReceipt> {
 
     public boolean isPending() {
         return blockHash == null;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder toStringBuff = new StringBuilder();
+        toStringBuff.setLength(0);
+        toStringBuff.append("  ").append("index=").append(index).append("\n");
+        toStringBuff.append("  ").append(receipt.toString()).append("\n");
+        toStringBuff.append("  ").append(Hex.toHexString(this.getEncoded()));
+
+        return toStringBuff.toString();
     }
 }

--- a/modAionImpl/test/org/aion/zero/impl/cli/CliTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/cli/CliTest.java
@@ -2037,6 +2037,15 @@ public class CliTest {
         skippedTasks.add("--db-compact");
         parameters.add(new Object[] {input, TaskPriority.DUMP_BLOCKS, skippedTasks});
 
+        input =
+                new String[] {
+                    "--query-block", "100", "--query-tx", "0xa0", "--query-account", "0xa0"
+                };
+        skippedTasks = new HashSet<>();
+        skippedTasks.add("--query-tx");
+        skippedTasks.add("--query-account");
+        parameters.add(new Object[] {input, TaskPriority.QUERY_BLOCK, skippedTasks});
+
         return parameters.toArray();
     }
 
@@ -2052,6 +2061,37 @@ public class CliTest {
         assertEquals(expectedPriority, breakingTaskPriority);
         Set<String> skippedTasks = cli.getSkippedTasks(options, breakingTaskPriority);
         assertEquals(expectedTasks, skippedTasks);
+    }
+
+    /**
+     * Ensures that the { <i>qt</i>, <i>--query-tx</i>} arguments fail when invalid transaction hash
+     * is supplied. Separate 2 tests cause the db has load issue during the multiple parameters
+     * input.
+     */
+    @Test
+    @Parameters({"qt", "--query-tx"})
+    public void testQueryTransaction(String option) {
+        assertThat(mockCli.call(new String[] {option, "0xa0"}, cfg)).isEqualTo(ERROR);
+    }
+
+    /**
+     * Ensures that the { <i>qb</i>, <i>--query-block</i>} arguments fail when no blocknumber is
+     * supplied.
+     */
+    @Test
+    @Parameters({"qb", "--query-block"})
+    public void testQueryBlock(String option) {
+        assertThat(mockCli.call(new String[] {option, ""}, cfg)).isEqualTo(ERROR);
+    }
+
+    /**
+     * Ensures that the { <i>qa</i>, <i>--query-account</i>} arguments fail when invalid account
+     * address is supplied.
+     */
+    @Test
+    @Parameters({"qa", "--query-account"})
+    public void testQueryAccount(String option) {
+        assertThat(mockCli.call(new String[] {option, ""}, cfg)).isEqualTo(ERROR);
     }
 
     // Methods below taken from FileUtils class


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the 'master' branch directly, please submit your PR to the 'master-pre-merge' branch and rebase your PR to 'master-pre-merge' branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- Added new CLI tooling for query block/transaction/account details.
- To query the account details currently only has the API, does not have the implement details because it relates with the database account retrieve model revise.

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- A test case for the CLI task priorities.

