### PR TITLE
Jenkins: if heapdump log present, print it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                 archiveArtifacts artifacts: 'pack/aion-v*.tar.bz2'
             }
         }
-        
+       
         stage('Unit test') {
             steps {
                 timeout(60) {
@@ -61,6 +61,7 @@ pipeline {
         always {
             sh('([ -d FunctionalTests ] && cp -r FunctionalTests/report/FunctionalTests report/) || true')
             junit "report/**/*.xml"
+            sh 'bash script/jenkins-dump-heapfiles.sh'
             cleanWs()
     }
 

--- a/script/jenkins-dump-heapfiles.sh
+++ b/script/jenkins-dump-heapfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# A simple script that Jenkins CI can call to print out the hs_err_pid 
+# Java heap dump files.  Intention is so that if kernel crashes during
+# node_test_harness, we can see the heap dump from the Jenkins UI.
+
+if compgen -G "FunctionalTests/Tests/aion/hs_err_pid*.log" > /dev/null; then
+    echo "Found Java heap dump file(s) after FunctionalTests execution."
+
+    for file in FunctionalTests/Tests/aion/hs_err_pid*.log; do
+        echo "=== $file ==="
+        cat $file
+    done
+fi
+


### PR DESCRIPTION
## Notice

It is not allowed to submit your PR to the 'master' branch directly, please submit your PR to the 'master-pre-merge' branch and rebase your PR to 'master-pre-merge' branch.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- temporary hack to make Jenkins print out Java heap dump files
- not a permanent fix, need to add the proper crash detection and reporting into node_test_harness

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

-

