### PR TITLE
Expanded kernel CLI

### DIFF
--- a/modAionImpl/build.gradle
+++ b/modAionImpl/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile project(':modTxPool')
     compile files("${rootProject.projectDir}/lib/fastvm-658171d.jar")
     compile 'org.json:json:20180813'
-    compile 'info.picocli:picocli:3.6.1'
+    compile 'info.picocli:picocli:4.0.0'
     compile files("${rootProject.projectDir}/lib/aion-types-d6eb8f7.jar")
 
     testCompile project(path: ':modTxPoolImpl')

--- a/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/Cli.java
@@ -51,7 +51,14 @@ public class Cli {
             new File(System.getProperty("user.dir") + File.separator + CfgSsl.SSL_KEYSTORE_DIR);
 
     private final Arguments options = new Arguments();
-    private final CommandLine parser = new CommandLine(options);
+    private final CommandLine parser;
+    private final EditCli editCli;
+
+    public Cli() {
+        editCli = new EditCli();
+        parser = new CommandLine(options)
+                .addSubcommand("edit",editCli);
+    }
 
     public enum ReturnType {
         RUN(2),
@@ -95,10 +102,11 @@ public class Cli {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public ReturnType call(final String[] args, Cfg cfg) {
+        final CommandLine.ParseResult parseResult;
         try {
             // the pre-process method handles arguments that are separated by space
             // parsing populates the options object
-            parser.parse(Arguments.preProcess(args));
+            parseResult = parser.parseArgs(Arguments.preProcess(args));
         } catch (Exception e) {
             System.out.println("Unable to parse the input arguments due to: ");
             if (e.getMessage() != null) {
@@ -181,6 +189,13 @@ public class Cli {
             boolean overwrite = cfg.fromXML(configFile);
 
             // determine the port configuration, can be combined with the -n, -d, -c, -i arguments
+
+
+            if (parseResult.subcommand() != null &&
+                    parseResult.subcommand().commandSpec().userObject().getClass() == EditCli.class &&
+                    editCli.runCommand(cfg)){
+                overwrite = true;
+            }
 
             if (options.getPort() != null) {
 

--- a/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
@@ -97,6 +97,7 @@ public class EditCli {
     private boolean updatePort(CfgNetP2p net) {
         if (port != null && net.getPort() != port) {
             net.setPort(port);
+            System.out.println("Updated p2p port to: " + port);
             return true;
         } else {
             return false;
@@ -106,6 +107,7 @@ public class EditCli {
     private boolean updatePrune(CfgDb cfgDb) {
         if (pruneOption != null && !pruneOption.equals(cfgDb.getPrune_option())) {
             cfgDb.setPrune_option(pruneOption);
+            System.out.println("Updated state storage to: " + pruneOption.toString().toLowerCase());
             return true;
         } else return false;
     }
@@ -113,15 +115,20 @@ public class EditCli {
     private boolean updateVendor(CfgDb cfgDb) {
         if (vendor != null && !vendor.equals(DBVendor.fromString(cfgDb.getVendor()))) {
             cfgDb.setVendor(vendor.name());
+            System.out.println("Updated database vendor to: " + vendor.toString().toLowerCase());
             return true;
         } else {
             return false;
         }
     }
+    private static String boolToMessage(boolean bool){
+        return bool? "Enabled":"Disabled";
+    }
 
     private boolean updateJavaApi(CfgApiZmq cfgApiZmq) {
         if (javaApi !=null && javaApi != cfgApiZmq.getActive()) {
             cfgApiZmq.setActive(javaApi);
+            System.out.println(boolToMessage(javaApi) + " java api.");
             return true;
         } else {
             return false;
@@ -131,6 +138,7 @@ public class EditCli {
     private boolean updateJsonRPC(CfgApiRpc cfgApiRpc) {
         if (jsonRPC != null && jsonRPC != cfgApiRpc.isActive()) {
             cfgApiRpc.setActive(jsonRPC);
+            System.out.println(boolToMessage(jsonRPC) + " jsonRPC.");
             return true;
         } else {
             return false;
@@ -140,6 +148,7 @@ public class EditCli {
     private boolean updateMining(CfgConsensus cfgConsensus) {
         if (cfgConsensus instanceof CfgConsensusPow) {
             if (mining != null && mining != ((CfgConsensusPow) cfgConsensus).getMining()) {
+                System.out.println(boolToMessage(mining) + " mining.");
 
                 ((CfgConsensusPow) cfgConsensus).setMining(mining);
                 return true;
@@ -151,6 +160,7 @@ public class EditCli {
 
     private boolean updateStatus(CfgSync cfgSync) {
         if (showStatus != null && cfgSync.getShowStatus() != showStatus) {
+            System.out.println((showStatus ? "Showing" : "Hiding") + " sync status.");
             cfgSync.setShowStatus(showStatus);
             return true;
         } else {
@@ -161,6 +171,7 @@ public class EditCli {
     private boolean updateCompression(CfgDb cfgDb) {
         if (compression != null && cfgDb.isCompression() != compression) {
             cfgDb.setCompression(compression);
+            System.out.println(boolToMessage(compression) + " database compression.");
             return true;
         } else {
             return false;
@@ -173,6 +184,7 @@ public class EditCli {
             for (Object[] objects : log) {
 
                 if (cfgLog.updateModule(((LogEnum) objects[0]).name().toLowerCase(), ((LogLevel) objects[1]).name())) {
+                    System.out.println("Changed loglevel of "+objects[0].toString().toLowerCase() +" logger to " + objects[1].toString()  );
                     res = true;
                 }
             }

--- a/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
@@ -1,0 +1,329 @@
+package org.aion.zero.impl.cli;
+
+import org.aion.db.impl.DBVendor;
+import org.aion.log.LogEnum;
+import org.aion.log.LogLevel;
+import org.aion.mcf.config.*;
+import org.aion.zero.impl.config.CfgConsensusPow;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static picocli.CommandLine.*;
+
+@Command(name = "edit",
+        aliases = {"e"},
+        description = "Changes the kernel configuration at runtime. This subcommand needs to be issued after " +
+                "all options to \"aion.sh\" has been added." +
+                "\nOptions\n" +
+                "port=<setting> Executes the kernel with the specified port number.\n" +
+                "state-storage=<setting> Changes the state pruning strategy. Settings: full, spread, and top.\n" +
+                "vendor=<setting> Changes the database implementation. Settings: h2, rocksdb, and leveldb.\n" +
+                "java=setting Enables/disables the java api. Settings on and off.\n" +
+                "rpc=<setting> Enables/disables the json rpc. Settings on and off.\n" +
+                "mining=<setting> Enables/disables the cpu miner. Settings on and off.\n" +
+                "compression=<setting> Changes the database compression setting. Settings: on and off\n" +
+                "log <logger>=<loglevel> Set the log level of the specified logger. Loggers: GEN, CONS, SYNC, API," +
+                " VM, NET, DB, and P2P. Loglevels: INFO, DEBUG, ERROR, WARN, and TRACE."
+)
+public class EditCli {
+
+
+    @Option(names = {"port"},
+            description = "Executes the kernel with the specified port number.",
+            paramLabel = "<setting>",
+            arity = "1",
+            converter = PortNumberConverter.class
+    )
+    private Integer port = null;
+    @Option(names = {"state-storage"},
+            paramLabel = "<setting>",
+            description = "Changes the state pruning strategy. Settings: full, spread, and top.",
+            converter = DBPruneOptionConverter.class,
+            arity = "1"
+    )
+    private CfgDb.PruneOption pruneOption = null;
+    @Option(names = {"vendor"},
+            paramLabel = "<setting>",
+            description = "Changes the database implementation. Settings: h2, rocksdb, leveldb.",
+            converter = DBVendorConverter.class,
+            arity = "1"
+    )
+    private DBVendor vendor = null;
+    @Option(names = {"java"},
+            paramLabel = "<setting>",
+            description = "Enables/disables the java api. Settings on and off.",
+            converter = EnabledConverter.class,
+            arity = "1"
+    )
+    private Boolean javaApi = null;
+    @Option(names = {"rpc"},
+            paramLabel = "<setting>",
+            description = "Enables/disables the json rpc. Settings on and off.",
+            converter = EnabledConverter.class,
+            arity = "1"
+    )
+    private Boolean jsonRPC = null;
+    @Option(names = {"mining"},
+            paramLabel = "<setting>",
+            description = "Enables/disables the cpu miner. Settings on and off.",
+            converter = EnabledConverter.class,
+            arity = "1"
+    )
+    private Boolean mining = null;
+    @Option(names = "show-status",
+            paramLabel = "<setting>",
+            description = "Changes show/hides the sync status. Settings on and off.",
+            converter = EnabledConverter.class,
+            arity = "1"
+    )
+    private Boolean showStatus = null;
+    @Option(names = {"compression"},
+            paramLabel = "<setting>",
+            description = "Changes the database compression setting. Settings: on and off",
+            converter = EnabledConverter.class,
+            arity = "1"
+    )
+    private Boolean compression = null;
+    @Option(names = {"log"},
+            paramLabel = "<logger>=<loglevel>",
+            description = "Set the log level of the specified logger. Loggers: GEN, CONS, SYNC, API, VM, NET, DB, and P2P",
+            converter = LogConverter.class,
+            arity = "1..*"
+    )
+    private List<Object[]> log = null;
+
+    private boolean updatePort(CfgNetP2p net) {
+        if (port != null && net.getPort() != port) {
+            net.setPort(port);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean updatePrune(CfgDb cfgDb) {
+        if (pruneOption != null && !pruneOption.equals(cfgDb.getPrune_option())) {
+            cfgDb.setPrune_option(pruneOption);
+            return true;
+        } else return false;
+    }
+
+    private boolean updateVendor(CfgDb cfgDb) {
+        if (vendor != null && !vendor.equals(DBVendor.fromString(cfgDb.getVendor()))) {
+            cfgDb.setVendor(vendor.name());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean updateJavaApi(CfgApiZmq cfgApiZmq) {
+        if (javaApi != cfgApiZmq.getActive() && javaApi != null) {
+            cfgApiZmq.setActive(javaApi);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean updateJsonRPC(CfgApiRpc cfgApiRpc) {
+        if (jsonRPC != null && jsonRPC != cfgApiRpc.isActive()) {
+            cfgApiRpc.setActive(jsonRPC);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean updateMining(CfgConsensus cfgConsensus) {
+        if (cfgConsensus instanceof CfgConsensusPow) {
+            if (mining != null && mining != ((CfgConsensusPow) cfgConsensus).getMining()) {
+
+                ((CfgConsensusPow) cfgConsensus).setMining(mining);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean updateStatus(CfgSync cfgSync) {
+        if (showStatus != null && cfgSync.getShowStatus() != showStatus) {
+            cfgSync.setShowStatus(showStatus);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean updateCompression(CfgDb cfgDb) {
+        if (compression != null && cfgDb.isCompression() != compression) {
+            cfgDb.setCompression(compression);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean updateLog(CfgLog cfgLog) {
+        boolean res = false;
+        for (Object[] objects : log) {
+
+            if (cfgLog.updateModule(((LogEnum) objects[0]).name().toLowerCase(), ((LogLevel) objects[1]).name())) {
+                res = true;
+            }
+        }
+        return res;
+    }
+
+    private void checkOptions() {
+        if (port == null &&
+                pruneOption == null &&
+                vendor == null &&
+                javaApi == null &&
+                jsonRPC == null &&
+                mining == null &&
+                showStatus == null &&
+                compression == null &&
+                log == null
+        ) {
+            throw new IllegalArgumentException("Expected an argument to the edit command");
+        }
+    }
+
+
+    /**
+     * @param cfg the config associated with the current runtime instance.
+     * @return indicates whether any configs were changed
+     */
+    public boolean runCommand(Cfg cfg) {
+        checkOptions();
+        //update all the configurations
+        final boolean updateCompression = updateCompression(cfg.getDb());
+        final boolean updateJavaApi = updateJavaApi(cfg.getApi().getZmq());
+        final boolean updateJsonRPC = updateJsonRPC(cfg.getApi().getRpc());
+        final boolean updateLog = updateLog(cfg.getLog());
+        final boolean updateMining = updateMining(cfg.getConsensus());
+        final boolean updatePort = updatePort(cfg.getNet().getP2p());
+        final boolean updatePrune = updatePrune(cfg.getDb());
+        final boolean updateStatus = updateStatus(cfg.getSync());
+        final boolean updateVendor = updateVendor(cfg.getDb());
+
+        //Indicate whether any of the configs were updated
+        return updateCompression || updateJavaApi || updateJsonRPC || updateLog || updateMining || updatePort || updatePrune || updateStatus || updateVendor;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public void setPruneOption(CfgDb.PruneOption pruneOption) {
+        this.pruneOption = pruneOption;
+    }
+
+    public void setVendor(DBVendor vendor) {
+        this.vendor = vendor;
+    }
+
+    public void setJavaApi(Boolean javaApi) {
+        this.javaApi = javaApi;
+    }
+
+    public void setJsonRPC(Boolean jsonRPC) {
+        this.jsonRPC = jsonRPC;
+    }
+
+    public void setMining(Boolean mining) {
+        this.mining = mining;
+    }
+
+    public void setShowStatus(Boolean showStatus) {
+        this.showStatus = showStatus;
+    }
+
+    public void setCompression(Boolean compression) {
+        this.compression = compression;
+    }
+
+    public void setLog(List<Object[]> log) {
+        this.log = log;
+    }
+
+    public static class EnabledConverter implements ITypeConverter<Boolean> {
+        @Override
+        public Boolean convert(String value) {
+            if (value.equals("on") || value.equals("off")) {
+                return value.equals("on");
+            } else {
+                throw new IllegalArgumentException("Expected: on or off.");
+            }
+        }
+    }
+
+    public static class DBVendorConverter implements ITypeConverter<DBVendor> {
+
+        @Override
+        public DBVendor convert(String value) {
+            try {
+                DBVendor vendor = DBVendor.fromString(value.toLowerCase());
+
+                if (vendor.equals(DBVendor.UNKNOWN)) {
+                    throw new IllegalArgumentException();
+                }
+                return vendor;
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Expected: h2, leveldb or rocksdb.");
+
+            }
+        }
+    }
+
+    public static class DBPruneOptionConverter implements ITypeConverter<CfgDb.PruneOption> {
+
+        @Override
+        public CfgDb.PruneOption convert(String value) {
+            try {
+                return CfgDb.PruneOption.valueOf(value.toUpperCase());
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Expected: " + Arrays.stream(CfgDb.PruneOption.values())
+                        .map(CfgDb.PruneOption::toString)
+                        .collect(Collectors.joining(", ")));
+            }
+        }
+    }
+
+    public static class LogConverter implements ITypeConverter<Object[]> {
+
+        @Override
+        public Object[] convert(String value) {
+            try {
+                String[] splitStrs = value.split("(\\s|=)");
+                if (splitStrs.length == 2) {
+                    return new Object[]{LogEnum.valueOf(splitStrs[0].toUpperCase()), LogLevel.valueOf(splitStrs[1].toUpperCase())};
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            } catch (Exception e) {
+                throw new IllegalArgumentException(String.format("Expected: <logger>=<loglevel>. Loggers=[%s]LogLevels=[%s].",
+                        Arrays.stream(LogEnum.values()).map(LogEnum::toString).collect(Collectors.joining(", ")),
+                        Arrays.stream(LogLevel.values()).map(LogLevel::toString).collect(Collectors.joining(","))
+                ));
+            }
+        }
+    }
+
+    public static class PortNumberConverter implements ITypeConverter<Integer> {
+
+        @Override
+        public Integer convert(String value) {
+            Integer val = Integer.parseInt(value);
+
+            if (val > 0 && val <= 0xFFFF) {
+                return val;
+            } else throw new IllegalArgumentException("Invalid port number.");
+
+        }
+    }
+}

--- a/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
@@ -120,7 +120,7 @@ public class EditCli {
     }
 
     private boolean updateJavaApi(CfgApiZmq cfgApiZmq) {
-        if (javaApi != cfgApiZmq.getActive() && javaApi != null) {
+        if (javaApi !=null && javaApi != cfgApiZmq.getActive()) {
             cfgApiZmq.setActive(javaApi);
             return true;
         } else {
@@ -169,16 +169,18 @@ public class EditCli {
 
     private boolean updateLog(CfgLog cfgLog) {
         boolean res = false;
-        for (Object[] objects : log) {
+        if (log != null) {
+            for (Object[] objects : log) {
 
-            if (cfgLog.updateModule(((LogEnum) objects[0]).name().toLowerCase(), ((LogLevel) objects[1]).name())) {
-                res = true;
+                if (cfgLog.updateModule(((LogEnum) objects[0]).name().toLowerCase(), ((LogLevel) objects[1]).name())) {
+                    res = true;
+                }
             }
         }
         return res;
     }
 
-    private void checkOptions() {
+    void checkOptions() {
         if (port == null &&
                 pruneOption == null &&
                 vendor == null &&

--- a/modAionImpl/test/org/aion/zero/impl/cli/EditCliTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/cli/EditCliTest.java
@@ -1,0 +1,219 @@
+package org.aion.zero.impl.cli;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.aion.db.impl.DBVendor;
+import org.aion.log.LogEnum;
+import org.aion.log.LogLevel;
+import org.aion.mcf.config.CfgDb;
+import org.aion.zero.impl.config.CfgAion;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.aion.util.TestResources.TEST_RESOURCE_DIR;
+
+@RunWith(JUnitParamsRunner.class)
+public class EditCliTest {
+
+    private final CfgAion cfg = CfgAion.inst();
+    private static final String configFileName = "config.xml";
+    private static final File config = new File(TEST_RESOURCE_DIR, configFileName);
+
+
+    @After
+    public void tearDown(){
+        cfg.resetInternal();
+        cfg.fromXML(config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyCLI(){
+        new EditCli().runCommand(cfg);
+    }
+
+
+    @Parameters(method = "updateCommandParams")
+    @Test
+    public void testUpdateCommand(Integer port,
+                                  CfgDb.PruneOption prune,
+                                  DBVendor vendor,
+                                  Boolean javaAPI,
+                                  Boolean jsonRPC,
+                                  Boolean mining,
+                                  Boolean showStatus,
+                                  Boolean compression,
+                                  Object[] objects){
+
+        EditCli cli = new EditCli();
+        List<Object[]> logs;
+        //convert the object array to a list
+        if (objects.length ==2){
+            logs = Collections.singletonList(objects);
+        }
+        else {
+
+            logs = new ArrayList<>();
+            for (int i = 0; i < objects.length; i+=2){
+                logs.add(new Object[]{objects[i], objects[i+1]});
+            }
+        }
+        cli.setCompression(compression);
+        cli.setJavaApi(javaAPI);
+        cli.setJsonRPC(jsonRPC);
+        cli.setLog(logs);
+        cli.setMining(mining);
+        cli.setPruneOption(prune);
+        cli.setShowStatus(showStatus);
+        cli.setVendor(vendor);
+        cli.setPort(port);
+        assertThat(cli.runCommand(cfg)).isTrue();
+
+
+        //check that the changes were applied
+        assertThat(cfg.getDb().isCompression()).isEqualTo(compression);
+        assertThat(cfg.getConsensus().getMining()).isEqualTo(mining);
+        assertThat(cfg.getApi().getRpc().isActive()).isEqualTo(jsonRPC);
+        assertThat(cfg.getApi().getZmq().getActive()).isEqualTo(javaAPI);
+        assertThat(cfg.getDb().getVendor()).ignoringCase().isEqualTo(vendor.name());
+        assertThat(cfg.getDb().getPrune_option()).isEqualTo(prune);
+        assertThat(cfg.getNet().getP2p().getPort()).isEqualTo(port);
+        assertThat(cfg.getSync().getShowStatus()).isEqualTo(showStatus);
+
+        for (Object[] arr: logs){
+            assertThat(cfg.getLog().getModules()).containsEntry(arr[0].toString(),arr[1].toString());
+        }
+    }
+
+
+    public Object[] updateCommandParams(){
+        return new Object[] {
+                new Object[]{30300, CfgDb.PruneOption.TOP, DBVendor.H2, false, false, false, false, false, new Object[]{LogEnum.API, LogLevel.DEBUG}},
+                new Object[]{30301, CfgDb.PruneOption.SPREAD, DBVendor.LEVELDB, true, true, true, true, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.SPREAD, DBVendor.LEVELDB, true, true, true, true, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.LEVELDB, true, true, true, true, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, true, true, true, true, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, true, true, true, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, true, true, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, true, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, false, true, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, false, false, new Object[]{LogEnum.API, LogLevel.INFO}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, false, false, new Object[]{LogEnum.API, LogLevel.DEBUG}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, false, false, new Object[]{LogEnum.GEN, LogLevel.DEBUG,LogEnum.SYNC, LogLevel.DEBUG}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, false, false, new Object[]{LogEnum.GEN, LogLevel.DEBUG,LogEnum.SYNC, LogLevel.DEBUG,LogEnum.DB, LogLevel.DEBUG,LogEnum.CONS, LogLevel.DEBUG}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, false, false, new Object[]{LogEnum.GEN, LogLevel.DEBUG,LogEnum.SYNC, LogLevel.DEBUG,LogEnum.DB, LogLevel.DEBUG,LogEnum.CONS, LogLevel.DEBUG,LogEnum.P2P, LogLevel.DEBUG,LogEnum.VM, LogLevel.DEBUG}},
+                new Object[]{30302, CfgDb.PruneOption.TOP, DBVendor.ROCKSDB, false, false, false, false, false, new Object[]{LogEnum.GEN, LogLevel.INFO,LogEnum.SYNC, LogLevel.INFO,LogEnum.DB, LogLevel.INFO,LogEnum.CONS, LogLevel.INFO,LogEnum.P2P, LogLevel.INFO,LogEnum.VM, LogLevel.INFO}}
+        };
+    }
+
+    @Parameters(method = "paramsForTestConverter")
+    @Test
+    public void testConverter(String option, CommandLine.ITypeConverter typeConverter, Object expected) throws Exception {
+
+        assertThat(typeConverter.convert(option)).isEqualTo(expected);
+    }
+
+
+    @Parameters(method = "paramsForTestConverterValidation")
+    @Test(expected = RuntimeException.class)
+    public void testConverterValidation(String option, CommandLine.ITypeConverter typeConverter) throws Exception {
+
+        typeConverter.convert(option);
+    }
+
+
+    public Object paramsForTestConverter(){
+        List<Object> params = new ArrayList<>();
+        EditCli.EnabledConverter enabledConverter = new EditCli.EnabledConverter();
+        EditCli.DBVendorConverter dbVendorConverter = new EditCli.DBVendorConverter();
+        EditCli.DBPruneOptionConverter dbPruneOptionConverter = new EditCli.DBPruneOptionConverter();
+        EditCli.PortNumberConverter portNumberConverter = new EditCli.PortNumberConverter();
+        EditCli.LogConverter logConverter = new EditCli.LogConverter();
+        params.add(new Object[]{"on", enabledConverter, true});
+        params.add(new Object[]{"off", enabledConverter, false});
+
+        for (DBVendor vendor: DBVendor.values()){
+            if (!vendor.equals(DBVendor.UNKNOWN)) {
+                params.add(new Object[]{vendor.toString().toUpperCase(), dbVendorConverter, vendor});
+                params.add(new Object[]{vendor.toString().toLowerCase(), dbVendorConverter, vendor});
+            }
+        }
+
+        for (CfgDb.PruneOption pruneOption: CfgDb.PruneOption.values()){
+            params.add(new Object[]{pruneOption.toString().toUpperCase(), dbPruneOptionConverter, pruneOption });
+            params.add(new Object[]{pruneOption.toString().toLowerCase(), dbPruneOptionConverter, pruneOption });
+        }
+
+        for (LogEnum logEnum: LogEnum.values()){
+            for (LogLevel logLevel: LogLevel.values()){
+                params.add(new Object[]{logEnum.toString()+"=" + logLevel.toString(), logConverter, new Object[]{logEnum, logLevel}});
+            }
+        }
+
+        int[] ports = {0x1, 0xF, 0xFF, 0xFFF, 0xFFFF};
+
+        for (Integer port: ports){
+            params.add(new Object[]{port.toString(), portNumberConverter, port});
+        }
+
+        return params;
+    }
+
+
+    public Object paramsForTestConverterValidation(){
+        List<Object[]> params = new ArrayList<>();
+        EditCli.EnabledConverter enabledConverter = new EditCli.EnabledConverter();
+        EditCli.DBVendorConverter dbVendorConverter = new EditCli.DBVendorConverter();
+        EditCli.DBPruneOptionConverter dbPruneOptionConverter = new EditCli.DBPruneOptionConverter();
+        EditCli.PortNumberConverter portNumberConverter = new EditCli.PortNumberConverter();
+        EditCli.LogConverter logConverter = new EditCli.LogConverter();
+        params.add(new Object[]{"onn", enabledConverter});
+        params.add(new Object[]{"offf", enabledConverter});
+        params.add(new Object[]{"on".toUpperCase(), enabledConverter});
+        params.add(new Object[]{"off".toUpperCase(), enabledConverter});
+        params.add(new Object[]{"".toUpperCase(), enabledConverter});
+
+        for (DBVendor vendor: DBVendor.values()) {
+
+            params.add(new Object[]{vendor +"1", dbVendorConverter});
+        }
+
+        params.add(new Object[]{"", dbVendorConverter});
+
+        for (CfgDb.PruneOption pruneOption: CfgDb.PruneOption.values()){
+            params.add(new Object[]{pruneOption.toString().toUpperCase()+"1", dbPruneOptionConverter });
+            params.add(new Object[]{pruneOption.toString().toLowerCase()+"1", dbPruneOptionConverter });
+        }
+        params.add(new Object[]{"", dbPruneOptionConverter});
+
+        for (LogEnum logEnum: LogEnum.values()){
+            for (LogLevel logLevel: LogLevel.values()){
+                params.add(new Object[]{logEnum.toString()+"-" + logLevel.toString(), logConverter});
+                params.add(new Object[]{logEnum.toString()+"=" + logLevel.toString()+"1", logConverter});
+                params.add(new Object[]{logEnum.toString()+"1"+"=" + logLevel.toString()+"1", logConverter});
+                params.add(new Object[]{logEnum.toString()+"1"+"=" + logLevel.toString(), logConverter});
+            }
+        }
+        params.add(new Object[]{"", logConverter});
+
+
+
+
+        int[] ports = {0x0, 0xFFFF+1};
+
+        for (Integer port: ports){
+            params.add(new Object[]{port.toString(), portNumberConverter});
+        }
+        params.add(new Object[]{"", portNumberConverter});
+        return params;
+    }
+
+
+}

--- a/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiRpc.java
@@ -277,6 +277,10 @@ public final class CfgApiRpc {
         }
     }
 
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
     public boolean isActive() {
         return this.active;
     }

--- a/modMcf/src/org/aion/mcf/config/CfgApiZmq.java
+++ b/modMcf/src/org/aion/mcf/config/CfgApiZmq.java
@@ -126,6 +126,10 @@ public class CfgApiZmq {
         }
     }
 
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
     public boolean getActive() {
         return this.active;
     }

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -260,6 +260,22 @@ public class CfgDb {
         }
     }
 
+    public PruneOption getPrune_option(){
+        return prune_option;
+    }
+
+    public void setPrune_option(PruneOption prune_option) {
+        this.prune_option = prune_option;
+    }
+
+    public void setCompression(boolean compression) {
+        this.compression = compression;
+    }
+
+    public boolean isCompression() {
+        return compression;
+    }
+
     public boolean isFileBased() {
         DBVendor vendor = DBVendor.fromString(this.vendor);
         return vendor.isFileBased();
@@ -277,6 +293,9 @@ public class CfgDb {
         this.vendor = vendor;
     }
 
+    public String getVendor(){
+        return vendor;
+    }
     public CfgPrune getPrune() {
         return this.prune;
     }

--- a/modMcf/src/org/aion/mcf/config/CfgLog.java
+++ b/modMcf/src/org/aion/mcf/config/CfgLog.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -22,7 +23,7 @@ public class CfgLog {
     String logPath;
 
     public CfgLog() {
-        modules = new HashMap<>();
+        modules = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         modules.put(LogEnum.ROOT.name(), LogLevel.WARN.name());
         modules.put(LogEnum.CONS.name(), LogLevel.INFO.name());
         modules.put(LogEnum.GEN.name(), LogLevel.INFO.name());
@@ -39,7 +40,7 @@ public class CfgLog {
     }
 
     public void fromXML(final XMLStreamReader sr) throws XMLStreamException {
-        this.modules = new HashMap<>();
+        this.modules = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         loop:
         while (sr.hasNext()) {
             int eventType = sr.next();
@@ -129,6 +130,16 @@ public class CfgLog {
 
     public Map<String, String> getModules() {
         return this.modules;
+    }
+
+    public boolean updateModule(String logEnum, String logLevel){
+        if (modules.containsKey(logEnum) && !modules.get(logEnum).equalsIgnoreCase(logLevel)){
+            modules.replace(logEnum, logLevel);
+            return true;
+        }
+        else {
+            return false;
+        }
     }
 
     public void setLogPath(String value) {

--- a/modMcf/src/org/aion/mcf/config/CfgSync.java
+++ b/modMcf/src/org/aion/mcf/config/CfgSync.java
@@ -225,6 +225,10 @@ public final class CfgSync {
         return this.blocksQueueMax;
     }
 
+    public void setShowStatus(boolean showStatus) {
+        this.showStatus = showStatus;
+    }
+
     public boolean getShowStatus() {
         return this.showStatus;
     }


### PR DESCRIPTION
## Description

This change adds support for command line configuration of the kernel.
 Supported configuration changes: 
- enable/disable rpc api
- enable/disable java api
- enable/disable mining
- enable/disable sync statistics 
- set state storage type
- set database vendor
- enable/disable database compression
- set levels for logging information

This change required five additonal CLI options to be implemented: 
1. --edit consensus / -e consensus
2. --edit log/ -e log
3. --edit sync /-e sync
4. --edit api / -e api
5. --edit db/ -e db





## Type of change

- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Relevant unit tests for the CLI parser and preprocessor were added to the CliTest.java and ArgumentsTest.java files.

-

