### PR TITLE
Fix: Incorrect prune config after cli edit

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
+++ b/modAionImpl/src/org/aion/zero/impl/cli/EditCli.java
@@ -114,7 +114,7 @@ public class EditCli {
 
     private boolean updatePrune(CfgDb cfgDb) {
         if (pruneOption != null && !pruneOption.equals(cfgDb.getPrune_option())) {
-            cfgDb.setPrune_option(pruneOption);
+            cfgDb.setPrune(pruneOption.toString());
             System.out.println("Updated state storage to: " + pruneOption.toString().toLowerCase());
             return true;
         } else return false;

--- a/modAionImpl/test/org/aion/zero/impl/cli/EditCliTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/cli/EditCliTest.java
@@ -6,6 +6,8 @@ import org.aion.db.impl.DBVendor;
 import org.aion.log.LogEnum;
 import org.aion.log.LogLevel;
 import org.aion.mcf.config.CfgDb;
+import org.aion.mcf.config.CfgDb.PruneOption;
+import org.aion.mcf.config.CfgPrune;
 import org.aion.zero.impl.config.CfgAion;
 import org.junit.After;
 import org.junit.Test;
@@ -18,6 +20,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.aion.mcf.config.CfgDb.SPREAD_PRUNE_ARCHIVE_RATE;
+import static org.aion.mcf.config.CfgDb.SPREAD_PRUNE_BLOCK_COUNT;
+import static org.aion.mcf.config.CfgDb.TOP_PRUNE_BLOCK_COUNT;
 import static org.aion.util.TestResources.TEST_RESOURCE_DIR;
 
 @RunWith(JUnitParamsRunner.class)
@@ -87,6 +92,7 @@ public class EditCliTest {
         assertThat(cfg.getDb().getVendor()).ignoringCase().isEqualTo(vendor.name());
         assertThat(cfg.getDb().getPrune_option()).isEqualTo(prune);
         assertThat(cfg.getDb().isInternalTxStorageEnabled()).isEqualTo(internalTxStorage);
+        assertThat(cfg.getDb().getPrune()).isEqualTo(pruneFromEnum(prune));
         assertThat(cfg.getNet().getP2p().getPort()).isEqualTo(port);
         assertThat(cfg.getSync().getShowStatus()).isEqualTo(showStatus);
 
@@ -95,6 +101,17 @@ public class EditCliTest {
         }
     }
 
+    private CfgPrune pruneFromEnum(PruneOption pruneOption){
+        switch (pruneOption){
+            case TOP:
+                return new CfgPrune(TOP_PRUNE_BLOCK_COUNT);
+            case SPREAD:
+                return new CfgPrune(SPREAD_PRUNE_BLOCK_COUNT, SPREAD_PRUNE_ARCHIVE_RATE);
+            case FULL:
+            default:
+                return new CfgPrune(false);
+        }
+    }
 
     public Object[] updateCommandParams(){
         return new Object[] {

--- a/modMcf/src/org/aion/mcf/config/CfgDb.java
+++ b/modMcf/src/org/aion/mcf/config/CfgDb.java
@@ -275,10 +275,6 @@ public class CfgDb {
         return prune_option;
     }
 
-    public void setPrune_option(PruneOption prune_option) {
-        this.prune_option = prune_option;
-    }
-
     public void setCompression(boolean compression) {
         this.compression = compression;
     }


### PR DESCRIPTION
## Description
Fixes bug in which changes to the Database prune config is only applied after restarting the kernel. This was due to a failure to update the the prune config.

## Type of change

- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Updated EditCliTest#testUpdateCommand to check that the correct Prune config is set.


