### PR TITLE
AKI 321

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/db/AbstractContractDetails.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AbstractContractDetails.java
@@ -24,7 +24,7 @@ public abstract class AbstractContractDetails implements ContractDetails {
     protected int detailsInMemoryStorageLimit;
 
     private Map<ByteArrayWrapper, byte[]> codes = new HashMap<>();
-    protected byte[] performCode;
+    protected byte[] transformedCode;
     // classes extending this rely on this value starting off as null
     protected byte[] objectGraph = null;
 
@@ -56,14 +56,14 @@ public abstract class AbstractContractDetails implements ContractDetails {
 
     @Override
     public byte[] getTransformedCode() {
-        return performCode;
+        return transformedCode;
     }
 
     @Override
     public void setTransformedCode(byte[] transformedCode) {
         // ensures that the object is not set to dirty when copied
-        if (!Arrays.equals(performCode, transformedCode)) {
-            performCode = transformedCode;
+        if (!Arrays.equals(this.transformedCode, transformedCode)) {
+            this.transformedCode = transformedCode;
             setDirty(true);
         }
     }

--- a/modAionImpl/src/org/aion/zero/impl/db/ContractDetailsCacheImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/ContractDetailsCacheImpl.java
@@ -144,10 +144,10 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
 
     @Override
     public byte[] getTransformedCode() {
-        if (performCode == null && this.origContract != null) {
-            performCode = origContract.getTransformedCode();
+        if (transformedCode == null && this.origContract != null) {
+            transformedCode = origContract.getTransformedCode();
         }
-        return performCode;
+        return transformedCode;
     }
 
     /**

--- a/modVM/src/org/aion/vm/ExternalStateForAvm.java
+++ b/modVM/src/org/aion/vm/ExternalStateForAvm.java
@@ -95,13 +95,18 @@ public class ExternalStateForAvm implements IExternalState {
 
     @Override
     public void putCode(AionAddress address, byte[] code) {
+        if (code.length == 0) {
+            throw new IllegalArgumentException("The AVM does not allow the concept of empty code.");
+        }
         this.repositoryCache.saveCode(address, code);
         setVmType(address);
     }
 
     @Override
     public byte[] getCode(AionAddress address) {
-        return this.repositoryCache.getCode(address);
+        byte[] code = this.repositoryCache.getCode(address);
+        // the notion of empty code is not a valid concept for the AVM
+        return code.length == 0 ? null : code;
     }
 
     @Override
@@ -231,7 +236,7 @@ public class ExternalStateForAvm implements IExternalState {
         }
 
         // If address has no code then it is always safe.
-        if (getCode(address).length == 0) {
+        if (getCode(address) == null) {
             return true;
         }
 


### PR DESCRIPTION
## Description

- Renamed performCode into transformedCode to avoid terminology confusions
- getCode() in ExternalStateForAvm returns null instead of byte[0]

Fixes Issue AKI-321.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

