### PR TITLE
Optimizations and caching

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -1199,7 +1199,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
             }
             transactionStore.flushBatch();
 
-            repository.commitBlock(block.getHeader());
+            repository.commitBlock(block.getHashWrapper(), block.getNumber(), block.getStateRoot());
 
             if (LOG.isDebugEnabled())
                 LOG.debug(
@@ -1532,7 +1532,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
         }
         transactionStore.flushBatch();
 
-        repository.commitBlock(block.getHeader());
+        repository.commitBlock(block.getHashWrapper(), block.getNumber(), block.getStateRoot());
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(

--- a/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionBlockchainImpl.java
@@ -784,7 +784,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
         // Check block exists before processing more rules
         if (doExistCheck // skipped when redoing imports
                 && getBlockStore().getMaxNumber() >= block.getNumber()
-                && getBlockStore().isBlockExist(block.getHash())) {
+                && getBlockStore().isBlockStored(block.getHash(), block.getNumber())) {
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug(
@@ -853,7 +853,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
                 forkLevel = NO_FORK_LEVEL;
             }
         } else {
-            if (getBlockStore().isBlockExist(block.getParentHash())) {
+            if (getBlockStore().isBlockStored(block.getParentHash(), block.getNumber()-1)) {
                 BigInteger oldTotalDiff = getInternalTD();
 
                 // determine if the block parent is main chain or side chain
@@ -1665,8 +1665,9 @@ public class AionBlockchainImpl implements IAionBlockchain {
         return minerCoinbase;
     }
 
-    public boolean isBlockExist(byte[] hash) {
-        return getBlockStore().isBlockExist(hash);
+    @Override
+    public boolean isBlockStored(byte[] hash, long number) {
+        return getBlockStore().isBlockStored(hash, number);
     }
 
     /**

--- a/modAionImpl/src/org/aion/zero/impl/AionHubUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHubUtils.java
@@ -36,7 +36,7 @@ public class AionHubUtils {
         }
         track.flush();
 
-        repository.commitBlock(genesis.getHeader());
+        repository.commitBlock(genesis.getHashWrapper(), genesis.getNumber(), genesis.getStateRoot());
         repository.getBlockStore().saveBlock(genesis, genesis.getDifficultyBI(), true);
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/StandaloneBlockchain.java
@@ -403,7 +403,7 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
             }
             track.flush();
 
-            bc.getRepository().commitBlock(genesis.getHeader());
+            bc.getRepository().commitBlock(genesis.getHashWrapper(), genesis.getNumber(), genesis.getStateRoot());
             bc.getRepository().getBlockStore().saveBlock(genesis, genesis.getDifficultyBI(), true);
             bc.setBestBlock(genesis);
             bc.setTotalDifficulty(genesis.getDifficultyBI());

--- a/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
@@ -435,8 +435,18 @@ public class AionBlockStore extends AbstractPowBlockstore {
     }
 
     @Override
-    public boolean isBlockExist(byte[] hash) {
-        return getBlockByHash(hash) != null;
+    public boolean isBlockStored(byte[] hash, long number) {
+        lock.readLock().lock();
+        try {
+            // the index size is cached, making this check faster than reading from the db
+            if (number >= index.size()) {
+                return false;
+            } else {
+                return blocks.get(hash) != null;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -59,6 +59,9 @@ public class AionRepositoryImpl
     // inferred contract information not used for consensus
     private ObjectDataSource<ContractInformation> contractInfoSource;
 
+    // TODO: include in the repository config after the FVM is decoupled or remove RepositoryConfig and pass individual parameters
+    private int blockCacheSize;
+
     /**
      * used by getSnapShotTo
      *
@@ -67,7 +70,8 @@ public class AionRepositoryImpl
      */
     protected AionRepositoryImpl() {}
 
-    protected AionRepositoryImpl(RepositoryConfig repoConfig) {
+    protected AionRepositoryImpl(RepositoryConfig repoConfig, int blockCacheSize) {
+        this.blockCacheSize = blockCacheSize;
         this.cfg = repoConfig;
         init();
     }
@@ -77,7 +81,7 @@ public class AionRepositoryImpl
     }
 
     public static AionRepositoryImpl createForTesting(RepositoryConfig repoConfig) {
-        return new AionRepositoryImpl(repoConfig);
+        return new AionRepositoryImpl(repoConfig, 0);
     }
 
     private void init() {
@@ -90,7 +94,7 @@ public class AionRepositoryImpl
                             transactionDatabase, AionTransactionStoreSerializer.serializer);
 
             // Setup block store.
-            this.blockStore = new AionBlockStore(indexDatabase, blockDatabase, checkIntegrity);
+            this.blockStore = new AionBlockStore(indexDatabase, blockDatabase, checkIntegrity, blockCacheSize);
 
             this.pendingStore = new PendingBlockStore(pendingStoreProperties);
             this.contractInfoSource =
@@ -1208,6 +1212,7 @@ public class AionRepositoryImpl
                         new RepositoryConfigImpl(
                                 config.getDatabasePath(),
                                 ContractDetailsAion.getInstance(),
-                                config.getDb()));
+                                config.getDb()),
+                        10);
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionRepositoryImpl.java
@@ -740,10 +740,10 @@ public class AionRepositoryImpl
             }
 
             try {
-                if (contractIndexDatabase != null) {
-                    contractIndexDatabase.close();
-                    LOGGEN.info("contractIndexDatabase store closed.");
-                    contractIndexDatabase = null;
+                if (contractInfoSource != null) {
+                    contractInfoSource.close();
+                    LOGGEN.info("contractInfoSource closed.");
+                    contractInfoSource = null;
                 }
             } catch (Exception e) {
                 LOGGEN.error(
@@ -771,10 +771,10 @@ public class AionRepositoryImpl
             }
 
             try {
-                if (transactionDatabase != null) {
-                    transactionDatabase.close();
-                    LOGGEN.info("Transaction database closed.");
-                    transactionDatabase = null;
+                if (transactionStore != null) {
+                    transactionStore.close();
+                    LOGGEN.info("Transaction store closed.");
+                    transactionStore = null;
                 }
             } catch (Exception e) {
                 LOGGEN.error("Exception occurred while closing the transaction database.", e);

--- a/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/TaskImportBlocks.java
@@ -32,7 +32,6 @@ import org.aion.zero.impl.SystemExitCodes;
 import org.aion.zero.impl.db.AionBlockStore;
 import org.aion.zero.impl.sync.PeerState.Mode;
 import org.aion.zero.impl.sync.statistics.BlockType;
-import org.aion.zero.impl.types.AionBlock;
 import org.slf4j.Logger;
 
 /**
@@ -536,7 +535,7 @@ final class TaskImportBlocks implements Runnable {
      *     old blocks, for example when blocks are imported in {@link PeerState.Mode#FORWARD} mode.
      */
     static boolean isAlreadyStored(AionBlockStore store, Block block) {
-        return store.getMaxNumber() >= block.getNumber() && store.isBlockExist(block.getHash());
+        return store.getMaxNumber() >= block.getNumber() && store.isBlockStored(block.getHash(), block.getNumber());
     }
 
     private ImportResult importBlock(Block b, String displayId, PeerState state) {

--- a/modAionImpl/test/org/aion/zero/impl/BlockchainConcurrentImportTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/BlockchainConcurrentImportTest.java
@@ -280,7 +280,7 @@ public class BlockchainConcurrentImportTest {
                 () -> {
 
                     // creating block only if parent already imported
-                    if (_chain.isBlockExist(_parent.getHash())) {
+                    if (_chain.isBlockStored(_parent.getHash(), _parent.getNumber())) {
 
                         testChain.assertEqualTotalDifficulty();
 
@@ -295,7 +295,7 @@ public class BlockchainConcurrentImportTest {
                         testChain.assertEqualTotalDifficulty();
 
                         // checking if the new block was already imported
-                        if (!_chain.isBlockExist(block.getHash())) {
+                        if (!_chain.isBlockStored(block.getHash(), block.getNumber())) {
                             // still adding this block
                             _queue.add(block);
 

--- a/modAionImpl/test/org/aion/zero/impl/BlockchainTestUtils.java
+++ b/modAionImpl/test/org/aion/zero/impl/BlockchainTestUtils.java
@@ -226,7 +226,7 @@ public class BlockchainTestUtils {
      */
     public static Block generateNewBlock(
             StandaloneBlockchain chain, Block parent, List<ECKey> accounts, int txCount) {
-        if (!chain.getBlockStore().isBlockExist(parent.getHash())) return null;
+        if (!chain.getBlockStore().isBlockStored(parent.getHash(), parent.getNumber())) return null;
 
         Block block;
         AionRepositoryImpl repo = chain.getRepository();

--- a/modApiServer/build.gradle
+++ b/modApiServer/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.5.0'
     compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
-    compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
+    compile 'com.github.ben-manes.caffeine:caffeine:2.8.0'
     compile group: 'org.nanohttpd', name: 'nanohttpd', version: '2.3.1'
     compile group: 'org.jboss.logging', name: 'jboss-logging', version: '3.3.0.Final'
     compile group: 'org.jboss.xnio', name: 'xnio-nio', version: '3.3.8.Final'

--- a/modLogger/src/main/java/org/aion/log/LogEnum.java
+++ b/modLogger/src/main/java/org/aion/log/LogEnum.java
@@ -4,6 +4,7 @@ package org.aion.log;
 public enum LogEnum {
     GEN,
     CONS,
+    CACHE,
     SYNC,
     API,
     VM,

--- a/modMcf/build.gradle
+++ b/modMcf/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile 'org.json:json:20180813'
+    compile 'com.github.ben-manes.caffeine:caffeine:2.8.0'
 
     testCompile project(':modAionImpl')
     testCompile 'junit:junit:4.12'

--- a/modMcf/src/module-info.java
+++ b/modMcf/src/module-info.java
@@ -15,6 +15,7 @@ module aion.mcf {
     requires aion.fastvm;
     requires commons.lang3;
     requires org.json;
+    requires com.github.benmanes.caffeine;
 
     exports org.aion.mcf.account;
     exports org.aion.mcf.blockchain;

--- a/modMcf/src/org/aion/mcf/config/CfgLog.java
+++ b/modMcf/src/org/aion/mcf/config/CfgLog.java
@@ -26,6 +26,7 @@ public class CfgLog {
         modules = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         modules.put(LogEnum.ROOT.name(), LogLevel.WARN.name());
         modules.put(LogEnum.CONS.name(), LogLevel.INFO.name());
+        modules.put(LogEnum.CACHE.name(), LogLevel.ERROR.name());
         modules.put(LogEnum.GEN.name(), LogLevel.INFO.name());
         modules.put(LogEnum.VM.name(), LogLevel.ERROR.name());
         modules.put(LogEnum.DB.name(), LogLevel.ERROR.name());

--- a/modMcf/src/org/aion/mcf/core/IBlockchain.java
+++ b/modMcf/src/org/aion/mcf/core/IBlockchain.java
@@ -93,7 +93,7 @@ public interface IBlockchain extends IPowChain {
 
     AionAddress getMinerCoinbase();
 
-    boolean isBlockExist(byte[] hash);
+    boolean isBlockStored(byte[] hash, long number);
 
     List<BlockHeader> getListOfHeadersStartFrom(long number, int limit);
 

--- a/modMcf/src/org/aion/mcf/db/IBlockStoreBase.java
+++ b/modMcf/src/org/aion/mcf/db/IBlockStoreBase.java
@@ -18,7 +18,7 @@ public interface IBlockStoreBase {
 
     Block getBlockByHash(byte[] hash);
 
-    boolean isBlockExist(byte[] hash);
+    boolean isBlockStored(byte[] hash, long number);
 
     List<byte[]> getListHashesEndWith(byte[] hash, long qty);
 

--- a/modMcf/src/org/aion/mcf/ds/CaffeineDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/CaffeineDataSource.java
@@ -1,0 +1,53 @@
+package org.aion.mcf.ds;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.util.concurrent.TimeUnit;
+import org.aion.db.impl.ByteArrayKeyValueDatabase;
+import org.aion.util.types.ByteArrayWrapper;
+
+/**
+ * Adds a Window-TinyLfu cache of predefined size to the {@link ObjectDataSource} using {@link
+ * Caffeine} (<a href=https://github.com/ben-manes/caffeine/wiki/Efficiency>efficiency details</a>).
+ *
+ * @author Alexandra Roatis
+ */
+public final class CaffeineDataSource<V> extends ObjectDataSource<V> {
+
+    private final LoadingCache<ByteArrayWrapper, V> cache;
+
+    // Only DataSource should know about this implementation
+    CaffeineDataSource(ByteArrayKeyValueDatabase src, Serializer<V, byte[]> serializer, int cacheSize) {
+        super(src, serializer);
+        this.cache =
+                Caffeine.newBuilder()
+                        .maximumSize(cacheSize)
+                        .expireAfterWrite(6, TimeUnit.MINUTES)
+                        .build(key -> getFromDatabase(key.getData()));
+    }
+
+    public void put(byte[] key, V value) {
+        super.put(key, value);
+        cache.put(ByteArrayWrapper.wrap(key), value);
+    }
+
+    public void putToBatch(byte[] key, V value) {
+        super.putToBatch(key, value);
+        cache.put(ByteArrayWrapper.wrap(key), value);
+    }
+
+    public void deleteInBatch(byte[] key) {
+        super.deleteInBatch(key);
+        cache.invalidate(ByteArrayWrapper.wrap(key));
+    }
+
+    public void delete(byte[] key) {
+        super.delete(key);
+        cache.invalidate(ByteArrayWrapper.wrap(key));
+    }
+
+    public V get(byte[] key) {
+        // the cache automatically loads the entries it is missing as defined in the constructor
+        return cache.get(ByteArrayWrapper.wrap(key));
+    }
+}

--- a/modMcf/src/org/aion/mcf/ds/DataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/DataSource.java
@@ -1,0 +1,100 @@
+package org.aion.mcf.ds;
+
+import org.aion.db.impl.ByteArrayKeyValueDatabase;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.slf4j.Logger;
+
+/**
+ * Builder for different data source implementations.
+ *
+ * @author Alexandra Roatis
+ */
+public final class DataSource<V> {
+
+    // Required parameters
+    private final ByteArrayKeyValueDatabase src;
+    private final Serializer<V, byte[]> serializer;
+
+    // Optional parameters
+    private int cacheSize;
+    private Type cacheType;
+    private boolean isDebug;
+    private static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.CACHE.name());
+
+    public enum Type {
+        LRU,
+        Window_TinyLfu
+    }
+
+    /**
+     * Required data for {@link ObjectDataSource} and {@link DataSourceArray}.
+     *
+     * @param src the source database
+     * @param serializer the serializer used to convert data to byte arrays and vice versa
+     */
+    public DataSource(ByteArrayKeyValueDatabase src, Serializer<V, byte[]> serializer) {
+        this.src = src;
+        this.serializer = serializer;
+        this.cacheSize = 0;
+    }
+
+    /**
+     * Adds caching to the used data source.
+     *
+     * @param cacheSize the size of the added cache
+     * @param cacheType the type of cache to be used
+     * @return a builder that will return a data source with cache when the given size is greater
+     *     than zero
+     */
+    public DataSource<V> withCache(int cacheSize, Type cacheType) {
+        // allows the case where cacheSize == 0 to facilitate enabling/disabling cache usage
+        if (cacheSize < 0) {
+            throw new IllegalArgumentException("Please provide a positive number as cache size.");
+        }
+        this.cacheSize = cacheSize;
+        this.cacheType = cacheType;
+        this.isDebug = false;
+        return this;
+    }
+
+    /**
+     * Recommended for debugging in correlation with the {@link LogEnum#CACHE} selected logging
+     * level. The returned implementation prints information on missed caching opportunities when
+     * {@link Logger#isTraceEnabled()} and usage statistics at data source close when {@link
+     * Logger#isInfoEnabled()}.
+     *
+     * @return a builder that will return a data source with statistics on cache usage
+     */
+    public DataSource<V> withStatistics() {
+        this.isDebug = true;
+        return this;
+    }
+
+    public ObjectDataSource<V> buildObjectSource() {
+        if (cacheSize != 0) {
+            if (isDebug) {
+                switch (cacheType) {
+                    case LRU:
+                        return new DebugLruDataSource<>(src, serializer, cacheSize, LOG);
+                    case Window_TinyLfu:
+                        return new DebugCaffeineDataSource<>(src, serializer, cacheSize, LOG);
+                }
+            } else {
+                switch (cacheType) {
+                    case LRU:
+                        return new LruDataSource<>(src, serializer, cacheSize);
+                    case Window_TinyLfu:
+                        return new CaffeineDataSource<>(src, serializer, cacheSize);
+                }
+            }
+        }
+
+        // in case the given cache size is equal to zero
+        return new ObjectDataSource<>(src, serializer);
+    }
+
+    public DataSourceArray<V> buildArraySource() {
+        return new DataSourceArray<>(this.buildObjectSource());
+    }
+}

--- a/modMcf/src/org/aion/mcf/ds/DebugCaffeineDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/DebugCaffeineDataSource.java
@@ -1,0 +1,93 @@
+package org.aion.mcf.ds;
+
+import com.github.benmanes.caffeine.cache.CacheWriter;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.util.concurrent.TimeUnit;
+import org.aion.db.impl.ByteArrayKeyValueDatabase;
+import org.aion.util.types.ByteArrayWrapper;
+import org.slf4j.Logger;
+
+/**
+ * Adds a Window-TinyLfu cache of predefined size to the {@link ObjectDataSource} using {@link
+ * Caffeine} (<a href=https://github.com/ben-manes/caffeine/wiki/Efficiency>efficiency
+ * details</a>).
+ *
+ * <p>This implementation prints information on missed caching opportunities when {@link
+ * Logger#isTraceEnabled()} and usage statistics at {@link DebugCaffeineDataSource#close()} when
+ * {@link Logger#isInfoEnabled()}.
+ *
+ * @author Alexandra Roatis
+ */
+public class DebugCaffeineDataSource<V> extends ObjectDataSource<V> {
+
+    protected final LoadingCache<ByteArrayWrapper, V> cache;
+
+    // for printing debug information
+    private Logger log;
+
+    // only DataSource should know about this implementation
+    DebugCaffeineDataSource(ByteArrayKeyValueDatabase src, Serializer<V, byte[]> serializer, int cacheSize, Logger log) {
+        super(src, serializer);
+        this.log = log;
+
+        // build with recordStats
+        if (this.log.isTraceEnabled()) {
+            this.cache =
+                    Caffeine.newBuilder()
+                            .expireAfterWrite(6, TimeUnit.MINUTES)
+                            .maximumSize(cacheSize)
+                            .recordStats()
+                            .build(
+                                    key -> {
+                                        // logging information on missed caching opportunities
+                                        this.log.trace("[Database:" + getName() + "] Stack trace for missed cache retrieval: ", new Exception());
+                                        return getFromDatabase(key.getData());
+                                    });
+        } else {
+            this.cache =
+                    Caffeine.newBuilder()
+                            .expireAfterWrite(6, TimeUnit.MINUTES)
+                            .maximumSize(cacheSize)
+                            .recordStats()
+                            .build(key -> getFromDatabase(key.getData()));
+        }
+    }
+
+    public void put(byte[] key, V value) {
+        super.put(key, value);
+        cache.put(ByteArrayWrapper.wrap(key), value);
+    }
+
+    public void putToBatch(byte[] key, V value) {
+        super.putToBatch(key, value);
+        cache.put(ByteArrayWrapper.wrap(key), value);
+    }
+
+    public void deleteInBatch(byte[] key) {
+        super.deleteInBatch(key);
+        cache.invalidate(ByteArrayWrapper.wrap(key));
+    }
+
+    public void delete(byte[] key) {
+        super.delete(key);
+        cache.invalidate(ByteArrayWrapper.wrap(key));
+    }
+
+    public V get(byte[] key) {
+        // the cache automatically loads the entries it is missing as defined in the constructor
+        return cache.get(ByteArrayWrapper.wrap(key));
+    }
+
+    @Override
+    public void close() {
+        super.close();
+
+        // log statistics at shutdown
+        log.info("[Database:" + getName() + "] Cache utilization: " + cache.stats());
+    }
+
+    private String getName() {
+        return getSrc().getName().orElse("UNKNOWN");
+    }
+}

--- a/modMcf/src/org/aion/mcf/ds/DebugLruDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/DebugLruDataSource.java
@@ -1,0 +1,68 @@
+package org.aion.mcf.ds;
+
+import org.aion.db.impl.ByteArrayKeyValueDatabase;
+import org.aion.util.types.ByteArrayWrapper;
+import org.slf4j.Logger;
+
+/**
+ * Adds debug messages and cache utilization information to {@link LruDataSource}. *
+ *
+ * <p>This implementation prints information on missed caching opportunities when {@link
+ * Logger#isTraceEnabled()} and usage statistics at {@link DebugLruDataSource#close()} when {@link
+ * Logger#isInfoEnabled()}.
+ *
+ * @author Alexandra Roatis
+ */
+public final class DebugLruDataSource<V> extends LruDataSource<V> {
+
+    // used to gather information regarding the cache use
+    private long hits;
+    private long missed;
+
+    // for printing debug information
+    private Logger log;
+
+    // only DataSource should know about this implementation
+    DebugLruDataSource(ByteArrayKeyValueDatabase src, Serializer<V, byte[]> serializer, int cacheSize, Logger log) {
+        super(src, serializer, cacheSize);
+
+        this.hits = 0L;
+        this.missed = 0L;
+        this.log = log;
+    }
+
+    public V get(byte[] key) {
+        ByteArrayWrapper wrappedKey = ByteArrayWrapper.wrap(key);
+        if (cache.containsKey(wrappedKey)) {
+            // gather usage data
+            hits++;
+
+            return cache.get(wrappedKey);
+        } else {
+            // gather usage data
+            missed++;
+
+            V val = super.get(key);
+            cache.put(wrappedKey, val);
+
+            // logging information on missed caching opportunities
+            if (log.isTraceEnabled()) {
+                log.trace("[Database:" + getName() + "] Stack trace for missed cache retrieval: ", new Exception());
+            }
+
+            return val;
+        }
+    }
+
+    @Override
+    public void close() {
+        super.close();
+
+        // log statistics at shutdown
+        log.info("[Database:" + getName() + "] Cache utilization: hits = " + hits + " misses = " + missed);
+    }
+
+    private String getName() {
+        return getSrc().getName().orElse("UNKNOWN");
+    }
+}

--- a/modMcf/src/org/aion/mcf/ds/LruDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/LruDataSource.java
@@ -1,0 +1,52 @@
+package org.aion.mcf.ds;
+
+import org.aion.db.impl.ByteArrayKeyValueDatabase;
+import org.aion.util.types.ByteArrayWrapper;
+import org.apache.commons.collections4.map.LRUMap;
+
+/**
+ * Adds an LRU cache of predefined size to the {@link ObjectDataSource}.
+ *
+ * @author Alexandra Roatis
+ */
+public class LruDataSource<V> extends ObjectDataSource<V> {
+
+    protected final LRUMap<ByteArrayWrapper, V> cache;
+
+    // only DataSource should know about this implementation
+    LruDataSource(ByteArrayKeyValueDatabase src, Serializer<V, byte[]> serializer, int cacheSize) {
+        super(src, serializer);
+        this.cache = new LRUMap<>(cacheSize);
+    }
+
+    public void put(byte[] key, V value) {
+        super.put(key, value);
+        cache.put(ByteArrayWrapper.wrap(key), value);
+    }
+
+    public void putToBatch(byte[] key, V value) {
+        super.putToBatch(key, value);
+        cache.put(ByteArrayWrapper.wrap(key), value);
+    }
+
+    public void deleteInBatch(byte[] key) {
+        super.deleteInBatch(key);
+        cache.remove(ByteArrayWrapper.wrap(key));
+    }
+
+    public void delete(byte[] key) {
+        super.delete(key);
+        cache.remove(ByteArrayWrapper.wrap(key));
+    }
+
+    public V get(byte[] key) {
+        ByteArrayWrapper wrappedKey = ByteArrayWrapper.wrap(key);
+        if (cache.containsKey(wrappedKey)) {
+            return cache.get(wrappedKey);
+        } else {
+            V val = super.get(key);
+            cache.put(wrappedKey, val);
+            return val;
+        }
+    }
+}

--- a/modMcf/src/org/aion/mcf/ds/ObjectDataSource.java
+++ b/modMcf/src/org/aion/mcf/ds/ObjectDataSource.java
@@ -29,12 +29,6 @@ public class ObjectDataSource<V> implements Flushable, Closeable {
 
     public void put(byte[] key, V value) {
         byte[] bytes = serializer.serialize(value);
-        /*
-         * src.put(key, bytes); if (cacheOnWrite) { cache.put(new
-         * ByteArrayWrapper(key), value); }
-         */
-        // TODO @yao - Don't know if just writing to cache is correct logic
-        // or what this was intended to be. Why do a flush then?
         src.put(key, bytes);
     }
 
@@ -56,6 +50,11 @@ public class ObjectDataSource<V> implements Flushable, Closeable {
     }
 
     public V get(byte[] key) {
+        return getFromDatabase(key);
+    }
+
+    // used by inheriting classes when automatically loading entries from the database
+    protected V getFromDatabase(byte[] key) {
         // Fetch the results from cache or database. Return null if doesn't exist.
         Optional<byte[]> val = src.get(key);
         return val.map(serializer::deserialize).orElse(null);

--- a/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
+++ b/modMcf/src/org/aion/mcf/trie/JournalPruneDataSource.java
@@ -208,7 +208,7 @@ public class JournalPruneDataSource implements ByteArrayKeyValueStore {
         return cnt;
     }
 
-    public void storeBlockChanges(byte[] blockHash, long blockNumber) {
+    public void storeBlockChanges(ByteArrayWrapper blockHash, long blockNumber) {
         if (!enabled.get()) {
             return;
         }
@@ -216,17 +216,16 @@ public class JournalPruneDataSource implements ByteArrayKeyValueStore {
         lock.writeLock().lock();
 
         try {
-            ByteArrayWrapper hash = ByteArrayWrapper.wrap(blockHash);
-            currentUpdates.blockHeader = hash;
+            currentUpdates.blockHeader = blockHash;
             currentUpdates.blockNumber = blockNumber;
-            blockUpdates.put(hash, currentUpdates);
+            blockUpdates.put(blockHash, currentUpdates);
             currentUpdates = new Updates();
         } finally {
             lock.writeLock().unlock();
         }
     }
 
-    public void prune(byte[] blockHash, long blockNumber) {
+    public void prune(ByteArrayWrapper blockHash, long blockNumber) {
         if (!enabled.get()) {
             return;
         }
@@ -234,8 +233,7 @@ public class JournalPruneDataSource implements ByteArrayKeyValueStore {
         lock.writeLock().lock();
 
         try {
-            ByteArrayWrapper blockHashW = ByteArrayWrapper.wrap(blockHash);
-            Updates updates = blockUpdates.remove(blockHashW);
+            Updates updates = blockUpdates.remove(blockHash);
             if (updates != null) {
                 for (ByteArrayWrapper insertedKey : updates.insertedKeys) {
                     decRef(insertedKey).dbRef = true;

--- a/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
+++ b/modMcf/test/org/aion/mcf/trie/JournalPruneDataSourceTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import org.aion.db.impl.ByteArrayKeyValueDatabase;
 import org.aion.db.impl.DatabaseFactory;
 import org.aion.log.AionLoggerFactory;
+import org.aion.util.types.ByteArrayWrapper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -312,7 +313,7 @@ public class JournalPruneDataSourceTest {
 
     // Pruning enabled tests ----------------------------------------------------
 
-    private static final byte[] b0 = "block0".getBytes();
+    private static final ByteArrayWrapper b0 = ByteArrayWrapper.wrap("block0".getBytes());
 
     @Test
     public void testPut_wPrune() {
@@ -913,7 +914,7 @@ public class JournalPruneDataSourceTest {
             List<Runnable> threads, JournalPruneDataSource db, String hash, long number) {
         threads.add(
                 () -> {
-                    db.storeBlockChanges(hash.getBytes(), number);
+                    db.storeBlockChanges(ByteArrayWrapper.wrap(hash.getBytes()), number);
                     if (DISPLAY_MESSAGES) {
                         System.out.println(
                                 Thread.currentThread().getName()
@@ -930,7 +931,7 @@ public class JournalPruneDataSourceTest {
             List<Runnable> threads, JournalPruneDataSource db, String hash, long number) {
         threads.add(
                 () -> {
-                    db.prune(hash.getBytes(), number);
+                    db.prune(ByteArrayWrapper.wrap(hash.getBytes()), number);
                     if (DISPLAY_MESSAGES) {
                         System.out.println(
                                 Thread.currentThread().getName()
@@ -1147,9 +1148,9 @@ public class JournalPruneDataSourceTest {
 
     // Pruning tests ----------------------------------------------------
 
-    private static final byte[] b1 = "block1".getBytes();
-    private static final byte[] b2 = "block2".getBytes();
-    private static final byte[] b3 = "block3".getBytes();
+    private static final ByteArrayWrapper b1 = ByteArrayWrapper.wrap("block1".getBytes());
+    private static final ByteArrayWrapper b2 = ByteArrayWrapper.wrap("block2".getBytes());
+    private static final ByteArrayWrapper b3 = ByteArrayWrapper.wrap("block3".getBytes());
 
     private static final byte[] k4 = "key4".getBytes();
     private static final byte[] v4 = "value4".getBytes();


### PR DESCRIPTION
## Description

- Optimized check for stored blocks by using the cached index size;
- Bugfix and optimized state pruning:  
    - using a cache to retrieve the block numbers and hashes for pruning;
    - updated method signatures to take only needed data and avoid unnecessary byte array conversions;
    - bugfix: all blocks at each level will be pruned;
- Correctly closing the store instead of directly closing the database;
- ObjectDataSource alternatives with caching and debugging features: 
    - cached versions using LRU and Caffeine implementations;
    - new builder class for creating different instances;
    - new `CACHE` logging level for getting cache statistics;
- AKI-263: Cache imported blocks to increase performance;
- AKI-275: Cache contract index data + skip database access on empty code;

Fixes Issue AKI-263 and AKI-275.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [x] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.
