### PR TITLE
AKI-326: Remove external module dependencies from p2p

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -153,6 +153,7 @@ public class AionHub {
         // there are two p2p implementation , now just point to impl1.
         this.p2pMgr =
                 new P2pMgr(
+                        AionLoggerFactory.getLogger(LogEnum.P2P.name()),
                         this.cfg.getNet().getId(),
                         Version.KERNEL_VERSION,
                         this.cfg.getId(),

--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -55,6 +55,7 @@ public class AionHub {
     private static final Logger syncLOG = AionLoggerFactory.getLogger(LogEnum.SYNC.name());
 
     private IP2pMgr p2pMgr;
+    private int chainId; // TODO: can be made final upon constructor refactoring
 
     private CfgAion cfg;
 
@@ -153,12 +154,13 @@ public class AionHub {
          * method
          */
         CfgNetP2p cfgNetP2p = this.cfg.getNet().getP2p();
+        this.chainId = this.cfg.getNet().getId();
 
         // there are two p2p implementation , now just point to impl1.
         this.p2pMgr =
                 new P2pMgr(
                         AionLoggerFactory.getLogger(LogEnum.P2P.name()),
-                        this.cfg.getNet().getId(),
+                        this.chainId,
                         Version.KERNEL_VERSION,
                         this.cfg.getId(),
                         cfgNetP2p.getIp(),
@@ -545,7 +547,7 @@ public class AionHub {
     }
 
     public int getChainId() {
-        return this.p2pMgr.chainId();
+        return this.chainId;
     }
 
     public Map<Integer, NodeWrapper> getActiveNodes() {

--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -5,7 +5,9 @@ import static org.aion.crypto.HashUtil.EMPTY_TRIE_HASH;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -22,6 +24,7 @@ import org.aion.mcf.config.CfgNetP2p;
 import org.aion.mcf.db.IBlockStorePow;
 import org.aion.mcf.db.Repository;
 import org.aion.p2p.Handler;
+import org.aion.p2p.INode;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.impl1.P2pMgr;
 import org.aion.util.bytes.ByteUtil;
@@ -32,6 +35,7 @@ import org.aion.zero.impl.core.IAionBlockchain;
 import org.aion.zero.impl.db.AionRepositoryImpl;
 import org.aion.zero.impl.db.DBUtils;
 import org.aion.zero.impl.pow.AionPoW;
+import org.aion.zero.impl.sync.NodeWrapper;
 import org.aion.zero.impl.sync.SyncMgr;
 import org.aion.zero.impl.sync.handler.BlockPropagationHandler;
 import org.aion.zero.impl.sync.handler.BroadcastNewBlockHandler;
@@ -527,8 +531,29 @@ public class AionHub {
         return this.syncMgr;
     }
 
+    /** Note: method used only by AionImpl and tests. Please avoid further use. */
     public IP2pMgr getP2pMgr() {
         return this.p2pMgr;
+    }
+
+    public int getActiveNodesCount() {
+        return this.p2pMgr.getActiveNodes().size();
+    }
+
+    public List<Short> getP2pVersions() {
+        return this.p2pMgr.versions();
+    }
+
+    public int getChainId() {
+        return this.p2pMgr.chainId();
+    }
+
+    public Map<Integer, NodeWrapper> getActiveNodes() {
+        Map<Integer, NodeWrapper> active = new HashMap<>();
+        for (Map.Entry<Integer, INode> entry : this.p2pMgr.getActiveNodes().entrySet()) {
+            active.put(entry.getKey(), new NodeWrapper(entry.getValue()));
+        }
+        return active;
     }
 
     public static String getRepoVersion() {

--- a/modAionImpl/src/org/aion/zero/impl/sync/NodeWrapper.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/NodeWrapper.java
@@ -1,0 +1,53 @@
+package org.aion.zero.impl.sync;
+
+import java.math.BigInteger;
+import org.aion.p2p.INode;
+
+/** Facilitates passing peer information to the API without relying on the p2p module interfaces. */
+public class NodeWrapper {
+    INode peer;
+
+    public NodeWrapper(INode peer) {
+        this.peer = peer;
+    }
+
+    public String getIdShort() {
+        return peer.getIdShort();
+    }
+
+    public byte[] getId() {
+        return peer.getId();
+    }
+
+    public int getIdHash() {
+        return peer.getIdHash();
+    }
+
+    public String getBinaryVersion() {
+        return peer.getBinaryVersion();
+    }
+
+    public long getBestBlockNumber() {
+        return peer.getBestBlockNumber();
+    }
+
+    public BigInteger getTotalDifficulty() {
+        return peer.getTotalDifficulty();
+    }
+
+    public byte[] getIp() {
+        return peer.getIp();
+    }
+
+    public String getIpStr() {
+        return peer.getIpStr();
+    }
+
+    public int getPort() {
+        return peer.getPort();
+    }
+
+    public long getTimestamp() {
+        return peer.getTimestamp();
+    }
+}

--- a/modAionImpl/test/org/aion/zero/impl/sync/BlockPropagationTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/BlockPropagationTest.java
@@ -236,11 +236,6 @@ public class BlockPropagationTest {
         public void closeSocket(SocketChannel _sc, String _reason, Exception e) {}
 
         @Override
-        public int getSelfIdHash() {
-            return 0;
-        }
-
-        @Override
         public void dropActive(int _nodeIdHash, String _reason) {
             throw new IllegalStateException("not implemented.");
         }
@@ -273,6 +268,11 @@ public class BlockPropagationTest {
         @Override
         public boolean isCorrectNetwork(int netId){
             return netId == 0;
+        }
+
+        @Override
+        public boolean isSelf(INode node) {
+            return false;
         }
 
         @Override

--- a/modAionImpl/test/org/aion/zero/impl/sync/BlockPropagationTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/sync/BlockPropagationTest.java
@@ -216,11 +216,6 @@ public class BlockPropagationTest {
         }
 
         @Override
-        public int chainId() {
-            return 0;
-        }
-
-        @Override
         public void errCheck(int nodeIdHashcode, String _displayId) {}
 
         @Override
@@ -276,8 +271,8 @@ public class BlockPropagationTest {
         }
 
         @Override
-        public int getSelfNetId() {
-            throw new IllegalStateException("not implemented.");
+        public boolean isCorrectNetwork(int netId){
+            return netId == 0;
         }
 
         @Override

--- a/modApiServer/build.gradle
+++ b/modApiServer/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     compile project(':modAionImpl')
     compile files("${rootProject.projectDir}/lib/fastvm-f2a39b8.jar")
     compile project(':modMcf')
-    compile project(':modP2p')
     compile project(':modEvtMgr')
     compile project(':modEvtMgrImpl')
     compile project(':3rdParty.libnzmq')

--- a/modApiServer/src/module-info.java
+++ b/modApiServer/src/module-info.java
@@ -1,7 +1,6 @@
 module aion.apiserver {
     requires aion.zero.impl;
     requires aion.log;
-    requires aion.p2p;
     requires aion.mcf;
     requires aion.crypto;
     requires slf4j.api;

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -692,7 +692,7 @@ public abstract class ApiAion extends Api {
     }
 
     protected int peerCount() {
-        return this.ac.getAionHub().getP2pMgr().getActiveNodes().size();
+        return this.ac.getAionHub().getActiveNodesCount();
     }
 
     // follows the ethereum standard for web3 compliance. DO NOT DEPEND ON IT.
@@ -717,7 +717,7 @@ public abstract class ApiAion extends Api {
     // mainly to keep compatibility with eth_protocolVersion which returns a String
     protected String p2pProtocolVersion() {
         try {
-            List<Short> p2pVersions = this.ac.getAionHub().getP2pMgr().versions();
+            List<Short> p2pVersions = this.ac.getAionHub().getP2pVersions();
             int i = 0;
             StringBuilder b = new StringBuilder();
             for (Short v : p2pVersions) {
@@ -735,7 +735,7 @@ public abstract class ApiAion extends Api {
     }
 
     protected String chainId() {
-        return (this.ac.getAionHub().getP2pMgr().chainId() + "");
+        return (this.ac.getAionHub().getChainId() + "");
     }
 
     public String getHashrate() {

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -51,7 +51,6 @@ import org.aion.evtmgr.impl.evt.EventTx;
 import org.aion.mcf.account.Keystore;
 import org.aion.mcf.blockchain.Block;
 import org.aion.mcf.tx.TxReceipt;
-import org.aion.p2p.INode;
 import org.aion.types.AionAddress;
 import org.aion.types.Log;
 import org.aion.util.bytes.ByteUtil;
@@ -65,6 +64,7 @@ import org.aion.zero.impl.AionHub;
 import org.aion.zero.impl.Version;
 import org.aion.zero.impl.blockchain.IAionChain;
 import org.aion.zero.impl.config.CfgAion;
+import org.aion.zero.impl.sync.NodeWrapper;
 import org.aion.zero.impl.types.AionBlock;
 import org.aion.zero.impl.types.AionBlockSummary;
 import org.aion.zero.impl.types.AionTxInfo;
@@ -1304,12 +1304,12 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                 getApiVersion(), Retcode.r_fail_service_call_VALUE);
                     }
 
-                    List<INode> nodes =
+                    List<NodeWrapper> nodes =
                             new ArrayList<>(
-                                    this.ac.getAionHub().getP2pMgr().getActiveNodes().values());
+                                    this.ac.getAionHub().getActiveNodes().values());
                     List<Message.t_Node> pl = new ArrayList<>();
                     try {
-                        for (INode n : nodes) {
+                        for (NodeWrapper n : nodes) {
                             Message.t_Node node =
                                     Message.t_Node
                                             .newBuilder()

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -66,7 +66,6 @@ import org.aion.mcf.core.ImportResult;
 import org.aion.mcf.db.Repository;
 import org.aion.mcf.tx.TxReceipt;
 import org.aion.mcf.vm.types.DataWordImpl;
-import org.aion.p2p.INode;
 import org.aion.types.AionAddress;
 import org.aion.types.Log;
 import org.aion.util.bytes.ByteUtil;
@@ -84,6 +83,7 @@ import org.aion.zero.impl.config.CfgConsensusPow;
 import org.aion.zero.impl.config.CfgEnergyStrategy;
 import org.aion.zero.impl.db.AionBlockStore;
 import org.aion.zero.impl.db.AionRepositoryImpl;
+import org.aion.zero.impl.sync.NodeWrapper;
 import org.aion.zero.impl.sync.PeerState;
 import org.aion.zero.impl.types.AionBlock;
 import org.aion.zero.impl.types.AionBlockSummary;
@@ -1453,11 +1453,11 @@ public class ApiWeb3Aion extends ApiAion {
      * we can freely change the responses without breaking compatibility
      */
     public RpcMsg priv_peers() {
-        Map<Integer, INode> activeNodes = this.ac.getAionHub().getP2pMgr().getActiveNodes();
+        Map<Integer, NodeWrapper> activeNodes = this.ac.getAionHub().getActiveNodes();
 
         JSONArray peerList = new JSONArray();
 
-        for (INode node : activeNodes.values()) {
+        for (NodeWrapper node : activeNodes.values()) {
             JSONObject n = new JSONObject();
             n.put("idShort", node.getIdShort());
             n.put("id", new String(node.getId()));
@@ -1613,11 +1613,11 @@ public class ApiWeb3Aion extends ApiAion {
     // TODO
     public RpcMsg priv_shortStats() {
         Block block = this.ac.getBlockchain().getBestBlock();
-        Map<Integer, INode> peer = this.ac.getAionHub().getP2pMgr().getActiveNodes();
+        Map<Integer, NodeWrapper> peer = this.ac.getAionHub().getActiveNodes();
 
         // this could be optimized (cached)
-        INode maxPeer = null;
-        for (INode p : peer.values()) {
+        NodeWrapper maxPeer = null;
+        for (NodeWrapper p : peer.values()) {
             if (maxPeer == null) {
                 maxPeer = p;
                 continue;
@@ -1687,13 +1687,13 @@ public class ApiWeb3Aion extends ApiAion {
         Map<Integer, PeerState> peerStates = this.ac.getAionHub().getSyncMgr().getPeerStates();
 
         // also retrieve nodes from p2p to see if we can piece together a full state
-        Map<Integer, INode> nodeState = this.ac.getAionHub().getP2pMgr().getActiveNodes();
+        Map<Integer, NodeWrapper> nodeState = this.ac.getAionHub().getActiveNodes();
 
         JSONArray array = new JSONArray();
         for (Map.Entry<Integer, PeerState> peerState : peerStates.entrySet()) {
             // begin []
             JSONObject peerObj = new JSONObject();
-            INode node;
+            NodeWrapper node;
             if ((node = nodeState.get(peerState.getKey())) != null) {
                 // base[].node
                 JSONObject nodeObj = new JSONObject();

--- a/modApiServer/test/org/aion/api/server/ApiAionTest.java
+++ b/modApiServer/test/org/aion/api/server/ApiAionTest.java
@@ -509,7 +509,7 @@ public class ApiAionTest {
         assertEquals(impl.getAionHub().getP2pMgr().getActiveNodes().size(), api.peerCount());
         assertNotNull(api.p2pProtocolVersion());
         assertNotEquals(0, api.getRecommendedNrgPrice());
-        assertEquals(impl.getAionHub().getP2pMgr().chainId(), Integer.parseInt(api.chainId()));
+        assertEquals(impl.getAionHub().getChainId(), Integer.parseInt(api.chainId()));
     }
 
     @Test

--- a/modP2p/src/org/aion/p2p/IP2pMgr.java
+++ b/modP2p/src/org/aion/p2p/IP2pMgr.java
@@ -31,8 +31,6 @@ public interface IP2pMgr {
 
     List<Short> versions();
 
-    int getSelfIdHash();
-
     void closeSocket(final SocketChannel _sc, String _reason);
 
     void closeSocket(final SocketChannel _sc, String _reason, Exception e);
@@ -61,4 +59,13 @@ public interface IP2pMgr {
      *     of correctness, {@code false} otherwise
      */
     boolean isCorrectNetwork(int netId);
+
+    /**
+     * Compares the given node to the one recorded as the running node.
+     *
+     * @param node a node for which a connection is attempted
+     * @return {@code true} if the given node is the same as the running node according to the p2p
+     *     manager's definition of node equality, {@code false} otherwise
+     */
+    boolean isSelf(INode node);
 }

--- a/modP2p/src/org/aion/p2p/IP2pMgr.java
+++ b/modP2p/src/org/aion/p2p/IP2pMgr.java
@@ -31,8 +31,6 @@ public interface IP2pMgr {
 
     List<Short> versions();
 
-    int chainId();
-
     int getSelfIdHash();
 
     void closeSocket(final SocketChannel _sc, String _reason);
@@ -53,7 +51,14 @@ public interface IP2pMgr {
 
     boolean validateNode(INode _node);
 
-    int getSelfNetId();
-
     int getAvgLatency();
+
+    /**
+     * Compares the given network identifier to the one recorded in the p2p manager.
+     *
+     * @param netId network identifier for attempted connection
+     * @return {@code true} if the network is compatible according to the p2p manager's definition
+     *     of correctness, {@code false} otherwise
+     */
+    boolean isCorrectNetwork(int netId);
 }

--- a/modP2pImpl/build.gradle
+++ b/modP2pImpl/build.gradle
@@ -9,10 +9,6 @@ sourceSets {
 }
 
 dependencies {
-    //compile 'network.aion:util4j:0.4.0'
-    //compile 'network.aion:log4j:0.4.0'
-    compile project(':modUtil')
-
     compile project(':modP2p')
     compile files('../lib/miniupnpc_linux.jar')
     compile 'org.apache.commons:commons-collections4:4.0'

--- a/modP2pImpl/build.gradle
+++ b/modP2pImpl/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     //compile 'network.aion:util4j:0.4.0'
     //compile 'network.aion:log4j:0.4.0'
     compile project(':modUtil')
-    compile project(':modLogger')
 
     compile project(':modP2p')
     compile files('../lib/miniupnpc_linux.jar')

--- a/modP2pImpl/src/module-info.java
+++ b/modP2pImpl/src/module-info.java
@@ -1,6 +1,5 @@
 module aion.p2p.impl {
     requires aion.p2p;
-    requires aion.util;
     requires miniupnpc.linux;
     requires slf4j.api;
     requires jsr305;

--- a/modP2pImpl/src/module-info.java
+++ b/modP2pImpl/src/module-info.java
@@ -1,7 +1,6 @@
 module aion.p2p.impl {
     requires aion.p2p;
     requires aion.util;
-    requires aion.log;
     requires miniupnpc.linux;
     requires slf4j.api;
     requires jsr305;

--- a/modP2pImpl/src/org/aion/p2p/impl/TaskUPnPManager.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/TaskUPnPManager.java
@@ -1,13 +1,12 @@
 package org.aion.p2p.impl;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import fr.free.miniupnp.IGDdatas;
 import fr.free.miniupnp.MiniupnpcLibrary;
 import fr.free.miniupnp.UPNPDev;
 import fr.free.miniupnp.UPNPUrls;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import org.slf4j.Logger;
 
 public class TaskUPnPManager implements Runnable {
 
@@ -16,10 +15,12 @@ public class TaskUPnPManager implements Runnable {
     private static final int DEFAULT_UPNP_PORT_MAPPING_LIFETIME_IN_SECONDS = 3600;
     private static final int UPNP_DELAY = 2000;
 
+    private final Logger p2pLOG;
     private int port;
     private MiniupnpcLibrary miniupnpc;
 
-    public TaskUPnPManager(int port) {
+    public TaskUPnPManager(final Logger p2pLOG, int port) {
+        this.p2pLOG = p2pLOG;
         this.port = port;
         miniupnpc = MiniupnpcLibrary.INSTANCE;
     }

--- a/modP2pImpl/src/org/aion/p2p/impl/comm/Node.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/comm/Node.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 import org.aion.p2p.INode;
 import org.aion.p2p.IPeerMetric;
-import org.aion.util.bytes.ByteUtil;
 
 /**
  * @author Chris p2p://{node-id}@{ip}:{port} node-id could be any non-empty string update to 36
@@ -352,10 +351,22 @@ public final class Node implements INode {
                 + totalDifficulty.toString()
                 + "\n"
                 + "bestBlockHash:"
-                + (bestBlockHash == null ? "null" : ByteUtil.toHexString(bestBlockHash))
+                + (bestBlockHash == null ? "null" : toHexString(bestBlockHash, 64))
                 + "\n"
                 + "binaryVersion:"
                 + binaryVersion
                 + "\n\n";
+    }
+
+    /** Simple implementation. Should be revised if used during performance critical operations. */
+    public static final String toHexString(byte[] bytes, int expectedLength) {
+        // this conversion to hex will remove leading zeros
+        String conversion = new BigInteger(1, bytes).toString(16);
+        if (conversion.length() < expectedLength) {
+            // using the size to pad with leading 0
+            return String.format("%" + expectedLength + "s", conversion).replace(' ', '0');
+        } else {
+            return conversion;
+        }
     }
 }

--- a/modP2pImpl/src/org/aion/p2p/impl/comm/NodeMgr.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/comm/NodeMgr.java
@@ -338,7 +338,7 @@ public class NodeMgr implements INodeMgr {
                     return;
                 }
 
-                if (node.getIdHash() == p2pMgr.getSelfIdHash()) {
+                if (p2pMgr.isSelf(node)) {
                     p2pMgr.closeSocket(node.getChannel(), _type + " -> active, self-connected");
                     return;
                 }

--- a/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ReqHandshake1.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ReqHandshake1.java
@@ -1,10 +1,9 @@
 package org.aion.p2p.impl.zero.msg;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
 
 /**
  * @author chris
@@ -50,7 +49,7 @@ public final class ReqHandshake1 extends ReqHandshake {
      * @param _bytes byte[]
      * @return ReqHandshake decode body
      */
-    public static ReqHandshake1 decode(final byte[] _bytes) {
+    public static ReqHandshake1 decode(final byte[] _bytes, final Logger p2pLOG) {
         if (_bytes == null || _bytes.length < MIN_LEN) return null;
         else {
             try {

--- a/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ResActiveNodes.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ResActiveNodes.java
@@ -1,7 +1,5 @@
 package org.aion.p2p.impl.zero.msg;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,10 +9,12 @@ import org.aion.p2p.Msg;
 import org.aion.p2p.Ver;
 import org.aion.p2p.impl.comm.Act;
 import org.aion.p2p.impl.comm.Node;
+import org.slf4j.Logger;
 
 /** @author chris */
 public final class ResActiveNodes extends Msg {
 
+    private final Logger p2pLOG;
     private final List<INode> nodes;
 
     private int count;
@@ -25,8 +25,9 @@ public final class ResActiveNodes extends Msg {
     private static final int MAX_NODES = 40;
 
     /** @param _nodes List */
-    public ResActiveNodes(final List<INode> _nodes) {
+    public ResActiveNodes(final Logger p2pLOG, final List<INode> _nodes) {
         super(Ver.V0, Ctrl.NET, Act.RES_ACTIVE_NODES);
+        this.p2pLOG = p2pLOG;
         this.count = Math.min(MAX_NODES, _nodes.size());
         if (this.count > 0) {
             this.nodes = _nodes.subList(0, this.count);
@@ -44,7 +45,7 @@ public final class ResActiveNodes extends Msg {
      * @param _bytes byte[]
      * @return ResActiveNodes
      */
-    public static ResActiveNodes decode(final byte[] _bytes) {
+    public static ResActiveNodes decode(final byte[] _bytes, final Logger p2pLOG) {
         if (_bytes == null || _bytes.length == 0 || (_bytes.length - 1) % NODE_BYTES_LENGTH != 0) {
             return null;
         } else {
@@ -69,7 +70,7 @@ public final class ResActiveNodes extends Msg {
                     INode n = new Node(false, nodeIdBytes, ipBytes, port);
                     activeNodes.add(n);
                 }
-                return new ResActiveNodes(activeNodes);
+                return new ResActiveNodes(p2pLOG, activeNodes);
 
             } catch (Exception e) {
                 if (p2pLOG.isDebugEnabled()) {

--- a/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ResHandshake1.java
+++ b/modP2pImpl/src/org/aion/p2p/impl/zero/msg/ResHandshake1.java
@@ -1,11 +1,10 @@
 package org.aion.p2p.impl.zero.msg;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
 
 /** @author chris */
 public final class ResHandshake1 extends ResHandshake {
@@ -13,10 +12,13 @@ public final class ResHandshake1 extends ResHandshake {
     // success(byte) + binary version len (byte)
     private static final int MIN_LEN = 2;
 
+    private final Logger p2pLOG;
     private String binaryVersion;
 
-    public ResHandshake1(boolean _success, @Nonnull final String _binaryVersion) {
+    public ResHandshake1(final Logger p2pLOG, boolean _success, @Nonnull final String _binaryVersion) {
         super(_success);
+
+        this.p2pLOG = p2pLOG;
 
         // truncate string when byte length large then 127
         if (_binaryVersion.getBytes().length > Byte.MAX_VALUE) {
@@ -30,7 +32,7 @@ public final class ResHandshake1 extends ResHandshake {
         }
     }
 
-    public static ResHandshake1 decode(final byte[] _bytes) {
+    public static ResHandshake1 decode(final byte[] _bytes, final Logger p2pLOG) {
         if (_bytes == null || _bytes.length < MIN_LEN) {
             return null;
         } else {
@@ -48,7 +50,7 @@ public final class ResHandshake1 extends ResHandshake {
                         }
                         return null;
                     }
-                    return new ResHandshake1(_bytes[0] == 0x01, binaryVersion);
+                    return new ResHandshake1(p2pLOG, _bytes[0] == 0x01, binaryVersion);
                 } else {
                     if (p2pLOG.isDebugEnabled()) {
                         p2pLOG.debug(

--- a/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/P2pMgr.java
@@ -64,11 +64,11 @@ public final class P2pMgr implements IP2pMgr {
     private final int SOCKET_RECV_BUFFER = 1024 * 128;
     private final int SOCKET_BACKLOG = 1024;
 
-    private int maxTempNodes, maxActiveNodes, selfNodeIdHash, selfPort;
+    private final int maxTempNodes, maxActiveNodes, selfNodeIdHash, selfPort;
     private final int selfChainId;
     private boolean syncSeedsOnly, upnpEnable;
     private String selfRevision, selfShortId;
-    private byte[] selfNodeId, selfIp;
+    private final byte[] selfNodeId, selfIp;
     private INodeMgr nodeMgr;
     private final Map<Integer, List<Handler>> handlers = new ConcurrentHashMap<>();
     private final Set<Short> versions = new HashSet<>();
@@ -405,11 +405,6 @@ public final class P2pMgr implements IP2pMgr {
         return this.nodeMgr.getActiveNodesMap();
     }
 
-    @Override
-    public int getSelfIdHash() {
-        return this.selfNodeIdHash;
-    }
-
     public int getTempNodesCount() {
         return this.nodeMgr.tempNodesSize();
     }
@@ -437,6 +432,18 @@ public final class P2pMgr implements IP2pMgr {
     @Override
     public boolean isCorrectNetwork(int netId){
         return netId == selfChainId;
+    }
+
+    /**
+     * @implNote Compares the port and id to the given node to allow connections to the same id and
+     *     different port. Does not compare IP values since the self IP is often recorded as 0.0.0.0
+     *     in the configuration file and cannot be inferred reliably by the node itself.
+     */
+    @Override
+    public boolean isSelf(INode node) {
+        return selfNodeIdHash == node.getIdHash()
+                && selfPort == node.getPort()
+                && Arrays.equals(selfNodeId, node.getId());
     }
 
     private TaskInbound getInboundInstance() {

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/ChannelBuffer.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/ChannelBuffer.java
@@ -1,7 +1,5 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.aion.p2p.Header;
+import org.slf4j.Logger;
 
 /** @author chris */
 class ChannelBuffer {
@@ -26,7 +25,11 @@ class ChannelBuffer {
 
     private Map<Integer, RouteStatus> routes = new HashMap<>();
 
-    ChannelBuffer() {}
+    private final Logger p2pLOG;
+
+    ChannelBuffer(final Logger p2pLOG) {
+        this.p2pLOG = p2pLOG;
+    }
 
     public String getDisplayId() {
         return displayId;

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskClear.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskClear.java
@@ -1,18 +1,19 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.aion.p2p.INodeMgr;
+import org.slf4j.Logger;
 
 public class TaskClear implements Runnable {
 
     private static final int PERIOD_CLEAR = 10000;
 
+    private final Logger p2pLOG;
     private final INodeMgr nodeMgr;
     private final AtomicBoolean start;
 
-    public TaskClear(final INodeMgr _nodeMgr, final AtomicBoolean _start) {
+    public TaskClear(final Logger p2pLOG, final INodeMgr _nodeMgr, final AtomicBoolean _start) {
+        this.p2pLOG = p2pLOG;
         this.nodeMgr = _nodeMgr;
         this.start = _start;
     }

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskConnectPeers.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskConnectPeers.java
@@ -1,7 +1,5 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
@@ -14,12 +12,14 @@ import org.aion.p2p.INodeMgr;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.impl.zero.msg.ReqHandshake1;
 import org.aion.p2p.impl1.P2pMgr.Dest;
+import org.slf4j.Logger;
 
 public class TaskConnectPeers implements Runnable {
 
     private static final int PERIOD_CONNECT_OUTBOUND = 1000;
     private static final int TIMEOUT_OUTBOUND_CONNECT = 10000;
 
+    private final Logger p2pLOG;
     private final INodeMgr nodeMgr;
     private final int maxActiveNodes;
     private final IP2pMgr mgr;
@@ -29,6 +29,7 @@ public class TaskConnectPeers implements Runnable {
     private final ReqHandshake1 cachedReqHS;
 
     public TaskConnectPeers(
+            final Logger p2pLOG,
             final IP2pMgr _mgr,
             final AtomicBoolean _start,
             final INodeMgr _nodeMgr,
@@ -37,6 +38,7 @@ public class TaskConnectPeers implements Runnable {
             final BlockingQueue<MsgOut> _sendMsgQue,
             final ReqHandshake1 _cachedReqHS) {
 
+        this.p2pLOG = p2pLOG;
         this.start = _start;
         this.nodeMgr = _nodeMgr;
         this.maxActiveNodes = _maxActiveNodes;
@@ -97,7 +99,7 @@ public class TaskConnectPeers implements Runnable {
 
                         channel.configureBlocking(false);
                         SelectionKey sk = channel.register(this.selector, SelectionKey.OP_READ);
-                        ChannelBuffer rb = new ChannelBuffer();
+                        ChannelBuffer rb = new ChannelBuffer(p2pLOG);
                         rb.setDisplayId(node.getIdShort());
                         rb.setNodeIdHash(nodeIdHash);
                         sk.attach(rb);

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskInbound.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskInbound.java
@@ -492,7 +492,7 @@ public class TaskInbound implements Runnable {
             if (p2pLOG.isTraceEnabled()) {
                 p2pLOG.trace("node {}", node.toString());
             }
-            if (handshakeRuleCheck(_netId)) {
+            if (mgr.isCorrectNetwork(_netId)) {
                 _buffer.setNodeIdHash(Arrays.hashCode(_nodeId));
                 _buffer.setDisplayId(new String(Arrays.copyOfRange(_nodeId, 0, 6)));
                 node.setId(_nodeId);
@@ -544,12 +544,6 @@ public class TaskInbound implements Runnable {
         } else {
             p2pLOG.debug("handleKernelMsg can't find hash{}", _nodeIdHash);
         }
-    }
-
-    /** @return boolean TODO: implementation */
-    private boolean handshakeRuleCheck(int netId) {
-        // check net id
-        return netId == this.mgr.getSelfNetId();
     }
 
     //    private String getReadOverflowMsg(int prevCnt, int cnt) {

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskReceive.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskReceive.java
@@ -1,23 +1,25 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.aion.p2p.Handler;
+import org.slf4j.Logger;
 
 public class TaskReceive implements Runnable {
 
+    private final Logger p2pLOG;
     private final AtomicBoolean start;
     private final BlockingQueue<MsgIn> receiveMsgQue;
     private final Map<Integer, List<Handler>> handlers;
 
     public TaskReceive(
+            final Logger p2pLOG,
             final AtomicBoolean _start,
             final BlockingQueue<MsgIn> _receiveMsgQue,
             final Map<Integer, List<Handler>> _handlers) {
+        this.p2pLOG = p2pLOG;
         this.start = _start;
         this.receiveMsgQue = _receiveMsgQue;
         this.handlers = _handlers;

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskSend.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskSend.java
@@ -1,7 +1,5 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.util.concurrent.BlockingQueue;
@@ -15,9 +13,11 @@ import org.aion.p2p.INode;
 import org.aion.p2p.INodeMgr;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.P2pConstant;
+import org.slf4j.Logger;
 
 public class TaskSend implements Runnable {
 
+    private final Logger p2pLOG;
     private final IP2pMgr mgr;
     private final AtomicBoolean start;
     private final BlockingQueue<MsgOut> sendMsgQue;
@@ -28,6 +28,7 @@ public class TaskSend implements Runnable {
     private static final int THREAD_Q_LIMIT = 20000;
 
     public TaskSend(
+            final Logger p2pLOG,
             final IP2pMgr _mgr,
             final int _lane,
             final BlockingQueue<MsgOut> _sendMsgQue,
@@ -35,6 +36,7 @@ public class TaskSend implements Runnable {
             final INodeMgr _nodeMgr,
             final Selector _selector) {
 
+        this.p2pLOG = p2pLOG;
         this.mgr = _mgr;
         this.lane = _lane;
         this.sendMsgQue = _sendMsgQue;
@@ -92,6 +94,7 @@ public class TaskSend implements Runnable {
                         if (attachment != null) {
                             tpe.execute(
                                     new TaskWrite(
+                                            p2pLOG,
                                             node.getIdShort(),
                                             node.getChannel(),
                                             mo.getMsg(),

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskStatus.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskStatus.java
@@ -1,13 +1,13 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.aion.p2p.INodeMgr;
+import org.slf4j.Logger;
 
 public class TaskStatus implements Runnable {
 
+    private final Logger p2pLOG;
     private final INodeMgr nodeMgr;
     private final String selfShortId;
     private final BlockingQueue<MsgOut> sendMsgQue;
@@ -17,11 +17,13 @@ public class TaskStatus implements Runnable {
     private final AtomicBoolean start;
 
     public TaskStatus(
+            final Logger p2pLOG,
             final AtomicBoolean _start,
             final INodeMgr _nodeMgr,
             final String _selfShortId,
             final BlockingQueue<MsgOut> _sendMsgQue,
             final BlockingQueue<MsgIn> _receiveMsgQue) {
+        this.p2pLOG = p2pLOG;
         this.nodeMgr = _nodeMgr;
         this.selfShortId = _selfShortId;
         this.sendMsgQue = _sendMsgQue;

--- a/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskWrite.java
+++ b/modP2pImpl/src/org/aion/p2p/impl1/tasks/TaskWrite.java
@@ -1,7 +1,5 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -9,10 +7,12 @@ import java.nio.channels.SocketChannel;
 import org.aion.p2p.Header;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.Msg;
+import org.slf4j.Logger;
 
 /** @author chris */
 public class TaskWrite implements Runnable {
 
+    private final Logger p2pLOG;
     private final String nodeShortId;
     private final SocketChannel sc;
     private final Msg msg;
@@ -22,11 +22,13 @@ public class TaskWrite implements Runnable {
     private static final long MIN_TRACE_BUFFER_WRITE_TIME = 10_000_000L;
 
     TaskWrite(
+            final Logger p2pLOG,
             final String _nodeShortId,
             final SocketChannel _sc,
             final Msg _msg,
             final ChannelBuffer _cb,
             final IP2pMgr _p2pMgr) {
+        this.p2pLOG = p2pLOG;
         this.nodeShortId = _nodeShortId;
         this.sc = _sc;
         this.msg = _msg;

--- a/modP2pImpl/test/org/aion/p2p/impl/LastThousands.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/LastThousands.java
@@ -8,14 +8,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.aion.p2p.impl1.P2pMgr;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LastThousands {
 
-    private static Logger p2pLOG = LoggerFactory.getLogger("P2P");
+    @Mock private Logger p2pLOG;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     private boolean checkPort(String host, int port) {
         boolean result = true;
@@ -38,7 +45,7 @@ public class LastThousands {
         int maxPort = port + max;
         String[] testerP2p = new String[] {"p2p://" + nodeId + "@" + ip + ":" + port};
         P2pMgr tester =
-                new P2pMgr(0, "", nodeId, ip, port, new String[] {}, false, max, max, false, 50);
+                new P2pMgr(p2pLOG, 0, "", nodeId, ip, port, new String[] {}, false, max, max, false, 50);
 
         List<P2pMgr> examiners = new ArrayList<>();
 
@@ -47,6 +54,7 @@ public class LastThousands {
                 System.out.println("examiner " + i);
                 P2pMgr examiner =
                         new P2pMgr(
+                                p2pLOG,
                                 0,
                                 "",
                                 UUID.randomUUID().toString(),

--- a/modP2pImpl/test/org/aion/p2p/impl/P2pMgrTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/P2pMgrTest.java
@@ -5,10 +5,17 @@ import static org.junit.Assert.assertEquals;
 import java.util.Map;
 import java.util.UUID;
 import org.aion.p2p.impl1.P2pMgr;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 /** @author chris */
 public class P2pMgrTest {
+
+    @Mock
+    private Logger p2pLOG;
 
     private String nodeId1 = UUID.randomUUID().toString();
     private String nodeId2 = UUID.randomUUID().toString();
@@ -16,6 +23,11 @@ public class P2pMgrTest {
     private String ip2 = "192.168.0.11";
     private int port1 = 30303;
     private int port2 = 30304;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     public Map.Entry<P2pMgr, P2pMgr> newTwoNodeSetup() {
         String ip = "127.0.0.1";
@@ -32,11 +44,11 @@ public class P2pMgrTest {
         // to guarantee they don't receive the same port
 
         System.out.println("connector on: " + TestUtilities.formatAddr(id1, ip, port1));
-        P2pMgr connector = new P2pMgr(0, "", id1, ip, port1, nodes, false, 128, 128, false, 50);
+        P2pMgr connector = new P2pMgr(p2pLOG, 0, "", id1, ip, port1, nodes, false, 128, 128, false, 50);
 
         System.out.println("receiver on: " + TestUtilities.formatAddr(id2, ip, port2));
         P2pMgr receiver =
-                new P2pMgr(0, "", id2, ip, port2, new String[0], false, 128, 128, false, 50);
+                new P2pMgr(p2pLOG, 0, "", id2, ip, port2, new String[0], false, 128, 128, false, 50);
 
         return Map.entry(connector, receiver);
     }
@@ -46,7 +58,7 @@ public class P2pMgrTest {
 
         String[] nodes = new String[] {"p2p://" + nodeId1 + "@" + ip2 + ":" + port2};
 
-        P2pMgr p2p = new P2pMgr(0, "", nodeId1, ip1, port1, nodes, false, 128, 128, false, 50);
+        P2pMgr p2p = new P2pMgr(p2pLOG, 0, "", nodeId1, ip1, port1, nodes, false, 128, 128, false, 50);
 
         assertEquals(p2p.getTempNodesCount(), 0);
     }
@@ -56,7 +68,7 @@ public class P2pMgrTest {
 
         String[] nodes = new String[] {"p2p://" + nodeId2 + "@" + ip1 + ":" + port1};
 
-        P2pMgr p2p = new P2pMgr(0, "", nodeId1, ip1, port1, nodes, false, 128, 128, false, 50);
+        P2pMgr p2p = new P2pMgr(p2pLOG, 0, "", nodeId1, ip1, port1, nodes, false, 128, 128, false, 50);
         assertEquals(0, p2p.getTempNodesCount());
     }
 
@@ -70,7 +82,7 @@ public class P2pMgrTest {
                     "p2p://" + nodeId2 + "@" + ip2 + ":" + port2,
                 };
 
-        P2pMgr p2p = new P2pMgr(0, "", nodeId1, ip1, port1, nodes, false, 128, 128, false, 50);
+        P2pMgr p2p = new P2pMgr(p2pLOG, 0, "", nodeId1, ip1, port1, nodes, false, 128, 128, false, 50);
         assertEquals(p2p.getTempNodesCount(), 3);
     }
 }

--- a/modP2pImpl/test/org/aion/p2p/impl/TaskRequestActiveNodesTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/TaskRequestActiveNodesTest.java
@@ -7,11 +7,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.INode;
 import org.aion.p2p.IP2pMgr;
 import org.aion.p2p.impl.zero.msg.ReqActiveNodes;
@@ -27,16 +22,11 @@ public class TaskRequestActiveNodesTest {
 
     @Mock private INode node;
 
-    private Logger p2pLOG;
+    @Mock private Logger p2pLOG;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.TRACE.name());
-        AionLoggerFactory.init(logMap);
-        p2pLOG = AionLoggerFactory.getLogger(LogEnum.P2P.name());
     }
 
     @Test(timeout = 10_000)

--- a/modP2pImpl/test/org/aion/p2p/impl/comm/NodeMgrTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/comm/NodeMgrTest.java
@@ -454,7 +454,7 @@ public class NodeMgrTest {
         INode node = nMgr.allocNode(ip2, 1);
         addNodetoOutbound(node, UUID.fromString(nodeId1));
 
-        when(p2p.getSelfIdHash()).thenReturn(node.getIdHash());
+        when(p2p.isSelf(node)).thenReturn(true);
 
         nMgr.movePeerToActive(node.getIdHash(), "outbound");
         assertTrue(nMgr.getActiveNodesMap().isEmpty());

--- a/modP2pImpl/test/org/aion/p2p/impl/comm/NodeMgrTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/comm/NodeMgrTest.java
@@ -22,9 +22,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.INode;
 import org.aion.p2p.impl1.P2pMgr;
 import org.junit.Before;
@@ -44,7 +41,8 @@ public class NodeMgrTest {
     private String ip1 = "127.0.0.1";
     private String ip2 = "192.168.0.11";
     private int port1 = 30304;
-    private Logger LOGGER;
+
+    @Mock private Logger LOGGER;
 
     @Mock private P2pMgr p2p;
 
@@ -58,11 +56,6 @@ public class NodeMgrTest {
 
     @Before
     public void setup() {
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.INFO.name());
-        AionLoggerFactory.init(logMap);
-        LOGGER = AionLoggerFactory.getLogger(LogEnum.P2P.name());
-
         MockitoAnnotations.initMocks(this);
 
         nMgr = new NodeMgr(p2p, MAX_ACTIVE_NODES, MAX_TEMP_NODES, LOGGER);
@@ -538,7 +531,7 @@ public class NodeMgrTest {
         addActiveNode();
 
         String dump2 = nMgr.dumpNodeInfo("testId", true);
-        LOGGER.info(dump2);
+        System.out.println(dump2);
         assertTrue(dump2.length() > dump.length());
     }
 

--- a/modP2pImpl/test/org/aion/p2p/impl/comm/NodeTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/comm/NodeTest.java
@@ -210,4 +210,40 @@ public class NodeTest {
         assertNotNull(n.getConnection());
         assertEquals(cn, n.getConnection());
     }
+
+    @Test
+    public void testToHexString() {
+        String expected = "844358ea1e0368c7d37fe232a61687dde2254d3e4c99c797993c2b95fe835bab";
+        byte[] input =
+                new byte[] {
+                    -124, 67, 88, -22, 30, 3, 104, -57, -45, 127, -30, 50, -90, 22, -121, -35, -30,
+                    37, 77, 62, 76, -103, -57, -105, -103, 60, 43, -107, -2, -125, 91, -85
+                };
+        String actual = Node.toHexString(input, 64);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testToHexStringLeadOne0() {
+        String expected = "044358ea1e0368c7d37fe232a61687dde2254d3e4c99c797993c2b95fe835bab";
+        byte[] input =
+                new byte[] {
+                    4, 67, 88, -22, 30, 3, 104, -57, -45, 127, -30, 50, -90, 22, -121, -35, -30, 37,
+                    77, 62, 76, -103, -57, -105, -103, 60, 43, -107, -2, -125, 91, -85
+                };
+        String actual = Node.toHexString(input, 64);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testToHexStringLeadTwo0() {
+        String expected = "004358ea1e0368c7d37fe232a61687dde2254d3e4c99c797993c2b95fe835bab";
+        byte[] input =
+                new byte[] {
+                    0, 67, 88, -22, 30, 3, 104, -57, -45, 127, -30, 50, -90, 22, -121, -35, -30, 37,
+                    77, 62, 76, -103, -57, -105, -103, 60, 43, -107, -2, -125, 91, -85
+                };
+        String actual = Node.toHexString(input, 64);
+        assertEquals(expected, actual);
+    }
 }

--- a/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ReqHandshake1Test.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ReqHandshake1Test.java
@@ -16,8 +16,9 @@ import org.aion.p2p.impl.comm.Act;
 import org.aion.p2p.impl.comm.Node;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** @author chris */
 public class ReqHandshake1Test {
@@ -30,7 +31,8 @@ public class ReqHandshake1Test {
 
     private int port = ThreadLocalRandom.current().nextInt();
 
-    private static Logger p2pLOG = LoggerFactory.getLogger("P2P");
+    @Mock
+    private Logger p2pLOG;
 
     private String randomIp =
             ThreadLocalRandom.current().nextInt(0, 256)
@@ -47,7 +49,7 @@ public class ReqHandshake1Test {
 
     @Before
     public void reqHandshake2Test() {
-
+        MockitoAnnotations.initMocks(this);
         randomRevision = new byte[Byte.MAX_VALUE];
         ThreadLocalRandom.current().nextBytes(randomRevision);
         randomVersions = new ArrayList<>();
@@ -85,7 +87,7 @@ public class ReqHandshake1Test {
                         randomVersions);
         byte[] bytes = req1.encode();
 
-        ReqHandshake1 req2 = ReqHandshake1.decode(bytes);
+        ReqHandshake1 req2 = ReqHandshake1.decode(bytes, p2pLOG);
         assertNotNull(req2.getNodeId());
         assertArrayEquals(req1.getNodeId(), req2.getNodeId());
         assertArrayEquals(req1.getIp(), req2.getIp());
@@ -108,7 +110,7 @@ public class ReqHandshake1Test {
         byte[] bytes = req1.encode();
         assertNull(bytes);
 
-        ReqHandshake1 req2 = ReqHandshake1.decode(bytes);
+        ReqHandshake1 req2 = ReqHandshake1.decode(bytes, p2pLOG);
         assertNull(req2);
     }
 

--- a/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ResActiveNodesTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ResActiveNodesTest.java
@@ -13,10 +13,20 @@ import org.aion.p2p.INode;
 import org.aion.p2p.Ver;
 import org.aion.p2p.impl.comm.Act;
 import org.aion.p2p.impl.comm.Node;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 /** @author chris */
 public class ResActiveNodesTest {
+    @Mock private Logger p2pLOG;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     private Node randomNode() {
         return new Node(
@@ -36,7 +46,7 @@ public class ResActiveNodesTest {
     @Test
     public void testRoute() {
 
-        ResActiveNodes res = new ResActiveNodes(new ArrayList<>());
+        ResActiveNodes res = new ResActiveNodes(p2pLOG, new ArrayList<>());
         assertEquals(Ver.V0, res.getHeader().getVer());
         assertEquals(Ctrl.NET, res.getHeader().getCtrl());
         assertEquals(Act.RES_ACTIVE_NODES, res.getHeader().getAction());
@@ -51,7 +61,7 @@ public class ResActiveNodesTest {
             srcNodes.add(randomNode());
         }
 
-        ResActiveNodes res = ResActiveNodes.decode(new ResActiveNodes(srcNodes).encode());
+        ResActiveNodes res = ResActiveNodes.decode(new ResActiveNodes(p2pLOG, srcNodes).encode(), p2pLOG);
         assertEquals(res.getNodes().size(), m);
         List<INode> tarNodes = res.getNodes();
         for (int i = 0; i < m; i++) {
@@ -77,7 +87,7 @@ public class ResActiveNodesTest {
             srcNodes.add(randomNode());
         }
 
-        ResActiveNodes res = ResActiveNodes.decode(new ResActiveNodes(srcNodes).encode());
+        ResActiveNodes res = ResActiveNodes.decode(new ResActiveNodes(p2pLOG, srcNodes).encode(), p2pLOG);
         assertEquals(40, res.getNodes().size());
 
         List<INode> tarNodes = res.getNodes();

--- a/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ResHandshake1Test.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ResHandshake1Test.java
@@ -7,26 +7,24 @@ import static org.junit.Assert.assertNull;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Ver;
 import org.aion.p2p.impl.comm.Act;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 /** @author chris */
 public class ResHandshake1Test {
+    @Mock
+    private Logger p2pLOG;
 
     @Before
     public void setup() {
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.TRACE.name());
-        AionLoggerFactory.init(logMap);
+        MockitoAnnotations.initMocks(this);
     }
 
     @Test
@@ -38,7 +36,7 @@ public class ResHandshake1Test {
         String randomBinaryVersion = new String(randomBytes, "UTF-8");
 
         ResHandshake1 rh1 =
-                new ResHandshake1(ThreadLocalRandom.current().nextBoolean(), randomBinaryVersion);
+                new ResHandshake1(p2pLOG, ThreadLocalRandom.current().nextBoolean(), randomBinaryVersion);
 
         // test route
         assertEquals(Ver.V0, rh1.getHeader().getVer());
@@ -47,7 +45,7 @@ public class ResHandshake1Test {
 
         // test encode / decode
         byte[] mhBytes = rh1.encode();
-        ResHandshake1 rh2 = ResHandshake1.decode(mhBytes);
+        ResHandshake1 rh2 = ResHandshake1.decode(mhBytes, p2pLOG);
 
         assertEquals(rh1.getSuccess(), rh2.getSuccess());
         assertEquals(rh1.getBinaryVersion().length(), rh2.getBinaryVersion().length());
@@ -68,18 +66,18 @@ public class ResHandshake1Test {
 
     @Test
     public void testDecodeNull() {
-        assertNull(ResHandshake1.decode(null));
-        assertNull(ResHandshake1.decode(new byte[1]));
+        assertNull(ResHandshake1.decode(null, p2pLOG));
+        assertNull(ResHandshake1.decode(new byte[1], p2pLOG));
 
         byte[] msg = new byte[2];
         msg[1] = 2;
-        assertNull(ResHandshake1.decode(msg));
+        assertNull(ResHandshake1.decode(msg, p2pLOG));
     }
 
     @Test
     public void testEncode() {
         String bv = "0.2.9";
-        ResHandshake1 rs1 = new ResHandshake1(true, bv);
+        ResHandshake1 rs1 = new ResHandshake1(p2pLOG, true, bv);
         assertNotNull(rs1);
 
         byte[] ec = rs1.encode();
@@ -103,7 +101,7 @@ public class ResHandshake1Test {
         truncatedBv = bv.toString();
         bv.append("2");
 
-        ResHandshake1 rs1 = new ResHandshake1(true, bv.toString());
+        ResHandshake1 rs1 = new ResHandshake1(p2pLOG, true, bv.toString());
         assertNotNull(rs1);
 
         assertEquals(truncatedBv, rs1.getBinaryVersion());

--- a/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ResHandshakeTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl/zero/msg/ResHandshakeTest.java
@@ -30,7 +30,7 @@ public class ResHandshakeTest {
 
     @Test
     public void testDecodeNull() {
-        assertNull(ResHandshake1.decode(null));
-        assertNull(ResHandshake1.decode(new byte[1]));
+        assertNull(ResHandshake1.decode(null, null));
+        assertNull(ResHandshake1.decode(new byte[1], null));
     }
 }

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/ChannelBufferTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/ChannelBufferTest.java
@@ -10,21 +10,19 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.Header;
 import org.aion.p2p.impl1.tasks.ChannelBuffer.RouteStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 public class ChannelBufferTest {
+
+    @Mock private Logger p2pLOG;
 
     private ChannelBuffer cb;
     private Random r;
@@ -37,11 +35,7 @@ public class ChannelBufferTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.INFO.name());
-        AionLoggerFactory.init(logMap);
-
-        cb = new ChannelBuffer();
+        cb = new ChannelBuffer(p2pLOG);
         r = new Random();
     }
 

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskClearTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskClearTest.java
@@ -3,33 +3,28 @@ package org.aion.p2p.impl1.tasks;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.INodeMgr;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 public class TaskClearTest {
+    @Mock private Logger p2pLOG;
+
     @Mock private INodeMgr nodeMgr;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.INFO.name());
-        AionLoggerFactory.init(logMap);
     }
 
     @Test(timeout = 20_000)
     public void testRun() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskClear tc = new TaskClear(nodeMgr, atb);
+        TaskClear tc = new TaskClear(p2pLOG, nodeMgr, atb);
         assertNotNull(tc);
 
         Thread t = new Thread(tc);

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskConnectPeersTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskConnectPeersTest.java
@@ -1,6 +1,5 @@
 package org.aion.p2p.impl1.tasks;
 
-import static org.aion.p2p.impl1.P2pMgr.p2pLOG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -14,15 +13,10 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.INode;
 import org.aion.p2p.INodeMgr;
 import org.aion.p2p.IP2pMgr;
@@ -33,8 +27,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 public class TaskConnectPeersTest {
+
+    @Mock private Logger p2pLOG;
 
     @Mock private INodeMgr nodeMgr;
 
@@ -96,7 +93,7 @@ public class TaskConnectPeersTest {
                                 sc.socket().setSendBufferSize(P2pConstant.SEND_BUFFER_SIZE);
 
                                 SelectionKey sk = sc.register(this.selector, SelectionKey.OP_READ);
-                                sk.attach(new ChannelBuffer());
+                                sk.attach(new ChannelBuffer(p2pLOG));
                                 System.out.println("socket connected!");
                             }
                         }
@@ -113,9 +110,6 @@ public class TaskConnectPeersTest {
     @Before
     public void setup() throws IOException {
         MockitoAnnotations.initMocks(this);
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.INFO.name());
-        AionLoggerFactory.init(logMap);
 
         System.setProperty("java.net.preferIPv4Stack", "true");
         ssc = ServerSocketChannel.open();
@@ -145,7 +139,7 @@ public class TaskConnectPeersTest {
     public void testRun() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskConnectPeers tcp =
-                new TaskConnectPeers(p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
+                new TaskConnectPeers(p2pLOG, p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
         assertNotNull(tcp);
 
         Thread t = new Thread(tcp);
@@ -162,7 +156,7 @@ public class TaskConnectPeersTest {
     public void testRun1() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskConnectPeers tcp =
-                new TaskConnectPeers(p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
+                new TaskConnectPeers(p2pLOG, p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
         assertNotNull(tcp);
 
         when(nodeMgr.activeNodesSize()).thenReturn(128);
@@ -202,7 +196,7 @@ public class TaskConnectPeersTest {
     public void testRunException() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskConnectPeers tcp =
-                new TaskConnectPeers(p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
+                new TaskConnectPeers(p2pLOG, p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
         assertNotNull(tcp);
 
         when(node.getIdHash()).thenReturn(1);
@@ -240,7 +234,7 @@ public class TaskConnectPeersTest {
     public void testRunException2() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskConnectPeers tcp =
-                new TaskConnectPeers(p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
+                new TaskConnectPeers(p2pLOG, p2pMgr, atb, nodeMgr, 128, selector, sendMsgQue, rhs);
         assertNotNull(tcp);
 
         when(node.getIdHash()).thenReturn(1);

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskInboundTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskInboundTest.java
@@ -18,7 +18,6 @@ import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,9 +25,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.Handler;
 import org.aion.p2p.Header;
 import org.aion.p2p.INode;
@@ -39,8 +35,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 public class TaskInboundTest {
+    @Mock private Logger p2pLOG;
 
     @Mock private INodeMgr nodeMgr;
 
@@ -127,16 +125,13 @@ public class TaskInboundTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.INFO.name());
-        AionLoggerFactory.init(logMap);
     }
 
     @Test(timeout = 10_000)
     public void testRun() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         when(selector.selectNow()).thenReturn(0);
@@ -155,7 +150,7 @@ public class TaskInboundTest {
     public void testRunException() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         doThrow(ClosedSelectorException.class).when(selector).selectNow();
@@ -175,7 +170,7 @@ public class TaskInboundTest {
     public void testRunClosedSelectorException() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         when(selector.selectNow()).thenReturn(1);
@@ -195,7 +190,7 @@ public class TaskInboundTest {
     public void testRun2() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         when(sk.isValid()).thenReturn(false);
@@ -208,7 +203,7 @@ public class TaskInboundTest {
         when(sk3.isValid()).thenReturn(true);
         when(sk3.isAcceptable()).thenReturn(true);
         when(sk3.isReadable()).thenReturn(true);
-        ChannelBuffer cb = new ChannelBuffer();
+        ChannelBuffer cb = new ChannelBuffer(p2pLOG);
 
         when(sk3.attachment()).thenReturn(cb);
 
@@ -234,7 +229,7 @@ public class TaskInboundTest {
     public void testAccept() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         when(sk2.isValid()).thenReturn(true);
@@ -268,7 +263,7 @@ public class TaskInboundTest {
     public void testAccept2() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         when(sk2.isValid()).thenReturn(true);
@@ -302,7 +297,7 @@ public class TaskInboundTest {
     public void testAccept3() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         when(sk.isValid()).thenReturn(true);
@@ -341,7 +336,7 @@ public class TaskInboundTest {
     public void testReadBuffer() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         // settings for readBuffer
@@ -373,7 +368,7 @@ public class TaskInboundTest {
     public void testReadBuffer2() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         // settings for readBuffer
@@ -409,7 +404,7 @@ public class TaskInboundTest {
     public void testReadBuffer3() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
         TaskInbound ti =
-                new TaskInbound(p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
+                new TaskInbound(p2pLOG, p2pMgr, selector, atb, nodeMgr, hldrMap, msgOutQue, rhs1, msgInQue);
         assertNotNull(ti);
 
         // settings for readBuffer

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskRecvTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskRecvTest.java
@@ -18,8 +18,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 public class TaskRecvTest {
+    @Mock private Logger p2pLOG;
 
     @Mock private BlockingQueue<MsgIn> recvMsgQue;
 
@@ -35,7 +37,7 @@ public class TaskRecvTest {
     @Test(timeout = 10_000)
     public void testRun() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskReceive ts = new TaskReceive(atb, recvMsgQue, handler);
+        TaskReceive ts = new TaskReceive(p2pLOG, atb, recvMsgQue, handler);
         assertNotNull(ts);
 
         Thread t = new Thread(ts);
@@ -51,7 +53,7 @@ public class TaskRecvTest {
     @Test(timeout = 10_000)
     public void testRunMsgIn() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskReceive ts = new TaskReceive(atb, recvMsgQue, handler);
+        TaskReceive ts = new TaskReceive(p2pLOG, atb, recvMsgQue, handler);
         assertNotNull(ts);
 
         int route = 1;
@@ -80,7 +82,7 @@ public class TaskRecvTest {
     @Test(expected = Exception.class, timeout = 10_000)
     public void testRunMsgIn2() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskReceive ts = new TaskReceive(atb, recvMsgQue, handler);
+        TaskReceive ts = new TaskReceive(p2pLOG, atb, recvMsgQue, handler);
         assertNotNull(ts);
 
         int route = 1;

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskSendTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskSendTest.java
@@ -8,14 +8,9 @@ import java.io.IOException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.INode;
 import org.aion.p2p.INodeMgr;
 import org.aion.p2p.IP2pMgr;
@@ -25,8 +20,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 public class TaskSendTest {
+
+    @Mock private Logger p2pLOG;
 
     @Mock private INodeMgr nodeMgr;
 
@@ -48,9 +46,6 @@ public class TaskSendTest {
     public void setup() throws IOException {
         lane = Math.min(Runtime.getRuntime().availableProcessors() << 1, 32);
         MockitoAnnotations.initMocks(this);
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.INFO.name());
-        AionLoggerFactory.init(logMap);
 
         selector = Selector.open();
         assertNotNull(selector);
@@ -59,7 +54,7 @@ public class TaskSendTest {
     @Test(timeout = 10_000)
     public void testRun() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskSend ts = new TaskSend(p2pMgr, r.nextInt(lane), sendMsgQue, atb, nodeMgr, selector);
+        TaskSend ts = new TaskSend(p2pLOG, p2pMgr, r.nextInt(lane), sendMsgQue, atb, nodeMgr, selector);
         assertNotNull(ts);
 
         Thread t = new Thread(ts);
@@ -75,7 +70,7 @@ public class TaskSendTest {
     @Test(timeout = 10_000)
     public void testRunMsgOutTimeout() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskSend ts = new TaskSend(p2pMgr, r.nextInt(lane), sendMsgQue, atb, nodeMgr, selector);
+        TaskSend ts = new TaskSend(p2pLOG, p2pMgr, r.nextInt(lane), sendMsgQue, atb, nodeMgr, selector);
         assertNotNull(ts);
 
         MsgOut mo = new MsgOut(r.nextInt(), "1", msg, Dest.OUTBOUND);
@@ -96,7 +91,7 @@ public class TaskSendTest {
     @Test(timeout = 10_000)
     public void testRunLane() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskSend ts = new TaskSend(p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
+        TaskSend ts = new TaskSend(p2pLOG, p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
         assertNotNull(ts);
 
         MsgOut mo = new MsgOut(1, "1", msg, Dest.OUTBOUND);
@@ -117,7 +112,7 @@ public class TaskSendTest {
     @Test(timeout = 10_000)
     public void testRun2() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskSend ts = new TaskSend(p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
+        TaskSend ts = new TaskSend(p2pLOG, p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
         assertNotNull(ts);
 
         MsgOut mo = new MsgOut(0, "1", msg, Dest.OUTBOUND);
@@ -126,7 +121,7 @@ public class TaskSendTest {
         when(sendMsgQue.take()).thenReturn(mo);
         when(nodeMgr.getOutboundNode(0)).thenReturn(node);
 
-        ChannelBuffer cb = new ChannelBuffer();
+        ChannelBuffer cb = new ChannelBuffer(p2pLOG);
         SocketChannel ch = SocketChannel.open();
         assertNotNull(ch);
 
@@ -149,7 +144,7 @@ public class TaskSendTest {
     @Test(timeout = 10_000)
     public void testRun3() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskSend ts = new TaskSend(p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
+        TaskSend ts = new TaskSend(p2pLOG, p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
         assertNotNull(ts);
 
         MsgOut mo = new MsgOut(0, "1", msg, Dest.ACTIVE);
@@ -158,7 +153,7 @@ public class TaskSendTest {
         when(sendMsgQue.take()).thenReturn(mo);
         when(nodeMgr.getActiveNode(0)).thenReturn(node);
 
-        ChannelBuffer cb = new ChannelBuffer();
+        ChannelBuffer cb = new ChannelBuffer(p2pLOG);
         SocketChannel ch = SocketChannel.open();
         assertNotNull(ch);
 
@@ -181,7 +176,7 @@ public class TaskSendTest {
     @Test(timeout = 10_000)
     public void testRun4() throws InterruptedException, IOException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskSend ts = new TaskSend(p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
+        TaskSend ts = new TaskSend(p2pLOG, p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
         assertNotNull(ts);
 
         MsgOut mo = new MsgOut(0, "1", msg, Dest.INBOUND);
@@ -190,7 +185,7 @@ public class TaskSendTest {
         when(sendMsgQue.take()).thenReturn(mo);
         when(nodeMgr.getInboundNode(0)).thenReturn(node);
 
-        ChannelBuffer cb = new ChannelBuffer();
+        ChannelBuffer cb = new ChannelBuffer(p2pLOG);
         SocketChannel ch = SocketChannel.open();
         assertNotNull(ch);
 
@@ -213,7 +208,7 @@ public class TaskSendTest {
     @Test(timeout = 10_000)
     public void testRunNullNode() throws InterruptedException {
         AtomicBoolean atb = new AtomicBoolean(true);
-        TaskSend ts = new TaskSend(p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
+        TaskSend ts = new TaskSend(p2pLOG, p2pMgr, 0, sendMsgQue, atb, nodeMgr, selector);
         assertNotNull(ts);
 
         MsgOut mo = new MsgOut(0, "1", msg, Dest.INBOUND);

--- a/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskStatusTest.java
+++ b/modP2pImpl/test/org/aion/p2p/impl1/tasks/TaskStatusTest.java
@@ -6,20 +6,17 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.aion.log.AionLoggerFactory;
-import org.aion.log.LogEnum;
-import org.aion.log.LogLevel;
 import org.aion.p2p.INodeMgr;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
 
 public class TaskStatusTest {
+    @Mock private Logger p2pLOG;
 
     @Mock private BlockingQueue<MsgOut> msgOutQue;
 
@@ -30,10 +27,6 @@ public class TaskStatusTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-
-        Map<String, String> logMap = new HashMap<>();
-        logMap.put(LogEnum.P2P.name(), LogLevel.INFO.name());
-        AionLoggerFactory.init(logMap);
     }
 
     @Test(timeout = 10_000)
@@ -41,7 +34,7 @@ public class TaskStatusTest {
 
         final AtomicBoolean ab = new AtomicBoolean(true);
 
-        TaskStatus ts = new TaskStatus(ab, nodeMgr, "1", msgOutQue, msgInQue);
+        TaskStatus ts = new TaskStatus(p2pLOG, ab, nodeMgr, "1", msgOutQue, msgInQue);
         assertNotNull(ts);
         when(nodeMgr.dumpNodeInfo(anyString(), anyBoolean())).thenReturn("get Status");
 


### PR DESCRIPTION
## Description

- Removed the dependency on aion.log and aion.util from aion.p2p.impl:
    - The `Logger` object is now passed as input to constructors and methods.
    - The `Node` class implements its own hex string conversion with unit tests to ensure correctness.

Fixes Issue AKI-326.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.
