### PR TITLE
Bugfix: Corrected resource locks on AionBlockStore

### DIFF
--- a/modAionImpl/test/org/aion/util/TestResources.java
+++ b/modAionImpl/test/org/aion/util/TestResources.java
@@ -123,8 +123,8 @@ public class TestResources {
     }
 
     /** @return a set of blocks to be used for testing. */
-    public static List<AionBlock> blocks(int limit) {
-        List<AionBlock> parameters = new ArrayList<>();
+    public static List<Block> blocks(int limit) {
+        List<Block> parameters = new ArrayList<>();
 
         for (byte[] rawData : rawBlockData(limit, rawDataFileWithRandomBlocks)) {
             parameters.add(new AionBlock(rawData));

--- a/modAionImpl/test/org/aion/zero/impl/db/AionBlockStoreTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/db/AionBlockStoreTest.java
@@ -1,13 +1,20 @@
 package org.aion.zero.impl.db;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.aion.db.impl.ByteArrayKeyValueDatabase;
 import org.aion.db.impl.mockdb.MockDB;
 import org.aion.mcf.blockchain.Block;
@@ -265,5 +272,136 @@ public class AionBlockStoreTest {
         Block storedBlk = store.getBestBlock();
         assertThat(storedBlk.getNumber() == 1);
         assertThat(storedBlk.getDifficulty().equals(BigInteger.TEN.toByteArray()));
+    }
+
+    private static final int TIME_OUT = 100; // in seconds
+
+    private void addThread_saveBlock(List<Runnable> threads, AionBlockStore store, Block block) {
+        threads.add(
+                () -> {
+                    store.saveBlock(block, block.getDifficultyBI(), true);
+                    assertThat(store.getBlockByHash(block.getHash())).isNotNull();
+                });
+    }
+
+    private void addThread_getBlockByHash(
+            List<Runnable> threads, AionBlockStore store, Block block) {
+        threads.add(
+                () -> {
+                    Block fromDB = store.getBlockByHash(block.getHash());
+                    if (fromDB != null) {
+                        assertThat(fromDB).isEqualTo(block);
+                    }
+                });
+    }
+
+    private void addThread_getBlockHashByNumber(
+            List<Runnable> threads, AionBlockStore store, Block block) {
+        threads.add(
+                () -> {
+                    // because the blocks are added randomly
+                    // must check if the block exists to avoid NullPointerException
+                    if (store.getChainBlockByNumber(block.getNumber()) != null) {
+                        byte[] fromDB = store.getBlockHashByNumber(block.getNumber());
+                        if (fromDB != null) {
+                            assertThat(fromDB).isEqualTo(block.getHash());
+                        }
+                    }
+                });
+    }
+
+    private void addThread_getChainBlockByNumber(
+            List<Runnable> threads, AionBlockStore store, Block block) {
+        threads.add(
+                () -> {
+                    Block fromDB = store.getChainBlockByNumber(block.getNumber());
+                    if (fromDB != null) {
+                        assertThat(fromDB).isEqualTo(block);
+                    }
+                });
+    }
+
+    @Test
+    public void testConcurrent() throws InterruptedException {
+        System.out.println("Note: If this test fails there may be a thread synchronization issue inside the AionBlockStore.");
+
+        // set up block store with cache to replicate normal execution
+        AionBlockStore store = new AionBlockStore(index, blocks, false, 10);
+
+        List<Block> testBlocks = TestResources.consecutiveBlocks(20);
+        List<Runnable> threads = new ArrayList<>();
+        for (Block blk : testBlocks) {
+            addThread_saveBlock(threads, store, blk);
+            addThread_getBlockByHash(threads, store, blk);
+            addThread_getBlockHashByNumber(threads, store, blk);
+            addThread_getChainBlockByNumber(threads, store, blk);
+        }
+
+        System.out.format("%nTest 1: Running the %d generated threads...%n", threads.size());
+        assertConcurrent("Testing concurrent use of AionBlockStore", threads, TIME_OUT);
+
+        testBlocks = TestResources.blocks(20);
+        for (Block blk : testBlocks) {
+            addThread_saveBlock(threads, store, blk);
+            addThread_getBlockByHash(threads, store, blk);
+            addThread_getBlockHashByNumber(threads, store, blk);
+            addThread_getChainBlockByNumber(threads, store, blk);
+        }
+
+        System.out.format("%nTest 2: Running the %d generated threads...%n", threads.size());
+        assertConcurrent("Testing concurrent use of AionBlockStore", threads, TIME_OUT);
+    }
+
+    /**
+     * From <a
+     * href="https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency">JUnit
+     * Wiki on multithreaded code and concurrency</a>
+     */
+    public static void assertConcurrent(
+            final String message,
+            final List<? extends Runnable> runnables,
+            final int maxTimeoutSeconds)
+            throws InterruptedException {
+        final int numThreads = runnables.size();
+        final List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+        try {
+            final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+            final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+            final CountDownLatch allDone = new CountDownLatch(numThreads);
+            for (final Runnable submittedTestRunnable : runnables) {
+                threadPool.submit(
+                        () -> {
+                            allExecutorThreadsReady.countDown();
+                            try {
+                                afterInitBlocker.await();
+                                submittedTestRunnable.run();
+                            } catch (final Exception e) {
+                                exceptions.add(e);
+                            } finally {
+                                allDone.countDown();
+                            }
+                        });
+            }
+            // wait until all threads are ready
+            assertTrue(
+                    "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent",
+                    allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS));
+            // start all test runners
+            afterInitBlocker.countDown();
+            assertTrue(
+                    message + " timeout! More than" + maxTimeoutSeconds + "seconds",
+                    allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
+        } finally {
+            threadPool.shutdownNow();
+        }
+        if (!exceptions.isEmpty()) {
+            for (Exception e : exceptions) {
+                e.printStackTrace();
+            }
+        }
+        assertTrue(
+                message + "failed with " + exceptions.size() + " exception(s):" + exceptions,
+                exceptions.isEmpty());
     }
 }


### PR DESCRIPTION
## Description

Replaced the read-write lock in AionBlockStore with a single lock and added a concurrency test to prevent future issues.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.
