### PR TITLE
Analysis logs

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/AionHub.java
@@ -51,8 +51,8 @@ import org.slf4j.Logger;
 public class AionHub {
 
     private static final Logger genLOG = AionLoggerFactory.getLogger(LogEnum.GEN.name());
-
     private static final Logger syncLOG = AionLoggerFactory.getLogger(LogEnum.SYNC.name());
+    private static final Logger surveyLOG = AionLoggerFactory.getLogger(LogEnum.SURVEY.name());
 
     private IP2pMgr p2pMgr;
     private int chainId; // TODO: can be made final upon constructor refactoring
@@ -233,14 +233,14 @@ public class AionHub {
                         p2pMgr,
                         cfg.getGenesis().getHash(),
                         apiVersion));
-        cbs.add(new ResStatusHandler(syncLOG, p2pMgr, syncMgr));
+        cbs.add(new ResStatusHandler(syncLOG, surveyLOG, p2pMgr, syncMgr));
         boolean inSyncOnlyMode = cfg.getNet().getP2p().inSyncOnlyMode();
         cbs.add(new ReqBlocksHeadersHandler(syncLOG, blockchain, p2pMgr, inSyncOnlyMode));
-        cbs.add(new ResBlocksHeadersHandler(syncLOG, syncMgr, p2pMgr));
+        cbs.add(new ResBlocksHeadersHandler(syncLOG, surveyLOG, syncMgr, p2pMgr));
         cbs.add(new ReqBlocksBodiesHandler(syncLOG, blockchain, syncMgr, p2pMgr, inSyncOnlyMode));
-        cbs.add(new ResBlocksBodiesHandler(syncLOG, syncMgr, p2pMgr));
+        cbs.add(new ResBlocksBodiesHandler(syncLOG, surveyLOG, syncMgr, p2pMgr));
         cbs.add(new BroadcastTxHandler(syncLOG, mempool, p2pMgr, inSyncOnlyMode));
-        cbs.add(new BroadcastNewBlockHandler(syncLOG, propHandler, p2pMgr));
+        cbs.add(new BroadcastNewBlockHandler(syncLOG, surveyLOG, propHandler, p2pMgr));
         this.p2pMgr.register(cbs);
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -45,6 +45,8 @@ public final class SyncMgr {
     private static final int INTERVAL_SHOW_STATUS = 10000;
 
     private static final Logger log = AionLoggerFactory.getLogger(LogEnum.SYNC.name());
+    private static final Logger survey_log = AionLoggerFactory.getLogger(LogEnum.SURVEY.name());
+
     private final NetworkStatus networkStatus = new NetworkStatus();
     // peer syncing states
     private final Map<Integer, PeerState> peerStates = new ConcurrentHashMap<>();
@@ -198,13 +200,14 @@ public final class SyncMgr {
         syncIb =
                 new Thread(
                         new TaskImportBlocks(
+                                log,
+                                survey_log,
                                 chain,
                                 start,
                                 stats,
                                 downloadedBlocks,
                                 importedBlockHashes,
                                 peerStates,
-                                log,
                                 _slowImportTime,
                                 _compactFrequency),
                         "sync-ib");

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksHeadersHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResBlocksHeadersHandler.java
@@ -18,23 +18,34 @@ import org.slf4j.Logger;
 public final class ResBlocksHeadersHandler extends Handler {
 
     private final Logger log;
+    private final Logger surveyLog;
 
     private final SyncMgr syncMgr;
 
     private final IP2pMgr p2pMgr;
 
     public ResBlocksHeadersHandler(
-            final Logger _log, final SyncMgr _syncMgr, final IP2pMgr _p2pMgr) {
+            final Logger syncLog, final Logger surveyLog, final SyncMgr _syncMgr, final IP2pMgr _p2pMgr) {
         super(Ver.V0, Ctrl.SYNC, Act.RES_BLOCKS_HEADERS);
+        this.log = syncLog;
+        this.surveyLog = surveyLog;
         this.syncMgr = _syncMgr;
-        this.log = _log;
         this.p2pMgr = _p2pMgr;
     }
 
     @Override
     public void receive(int _nodeIdHashcode, String _displayId, final byte[] _msgBytes) {
+        // for runtime survey information
+        long startTime, duration;
+
         if (_msgBytes == null || _msgBytes.length == 0) return;
+
+        startTime = System.nanoTime();
         ResBlocksHeaders resHeaders = ResBlocksHeaders.decode(_msgBytes);
+        duration = System.nanoTime() - startTime;
+        surveyLog.info("Receive Stage 2: decode headers, duration = {} ns.", duration);
+
+        startTime = System.nanoTime();
         if (resHeaders != null) {
 
             this.syncMgr
@@ -67,5 +78,7 @@ public final class ResBlocksHeadersHandler extends Handler {
                         "res-headers decode-error dump: {}", ByteUtil.toHexString(_msgBytes));
             }
         }
+        duration = System.nanoTime() - startTime;
+        surveyLog.info("Receive Stage 3: validate headers, duration = {} ns.", duration);
     }
 }

--- a/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/handler/ResStatusHandler.java
@@ -18,21 +18,28 @@ import org.slf4j.Logger;
 public final class ResStatusHandler extends Handler {
 
     private final Logger log;
+    private final Logger surveyLog;
 
     private final IP2pMgr p2pMgr;
 
     private final SyncMgr syncMgr;
 
-    public ResStatusHandler(final Logger _log, final IP2pMgr _p2pMgr, final SyncMgr _syncMgr) {
+    public ResStatusHandler(final Logger syncLog, final Logger surveyLog, final IP2pMgr _p2pMgr, final SyncMgr _syncMgr) {
         super(Ver.V0, Ctrl.SYNC, Act.RES_STATUS);
-        this.log = _log;
+        this.log = syncLog;
+        this.surveyLog = surveyLog;
         this.p2pMgr = _p2pMgr;
         this.syncMgr = _syncMgr;
     }
 
     @Override
     public void receive(int _nodeIdHashcode, String _displayId, final byte[] _msgBytes) {
+        // for runtime survey information
+        long startTime, duration;
+
         if (_msgBytes == null || _msgBytes.length == 0) return;
+
+        startTime = System.nanoTime();
         ResStatus rs = ResStatus.decode(_msgBytes);
 
         if (rs == null) {
@@ -83,5 +90,7 @@ public final class ResStatusHandler extends Handler {
                         latency);
             }
         }
+        duration = System.nanoTime() - startTime;
+        surveyLog.info("Receive Stage 1: process status, duration = {} ns.", duration);
     }
 }

--- a/modLogger/src/main/java/org/aion/log/LogEnum.java
+++ b/modLogger/src/main/java/org/aion/log/LogEnum.java
@@ -15,6 +15,7 @@ public enum LogEnum {
     TX,
     P2P,
     ROOT,
+    SURVEY,
     GUI;
 
     public static boolean contains(String _module) {

--- a/modMcf/src/org/aion/mcf/config/CfgLog.java
+++ b/modMcf/src/org/aion/mcf/config/CfgLog.java
@@ -138,8 +138,11 @@ public class CfgLog {
         if (modules.containsKey(logEnum) && !modules.get(logEnum).equalsIgnoreCase(logLevel)){
             modules.replace(logEnum, logLevel);
             return true;
-        }
-        else {
+        } else if (!modules.containsKey(logEnum)) {
+            // allows introducing new logs
+            modules.put(logEnum, logLevel);
+            return true;
+        } else {
             return false;
         }
     }

--- a/modMcf/src/org/aion/mcf/config/CfgLog.java
+++ b/modMcf/src/org/aion/mcf/config/CfgLog.java
@@ -36,6 +36,7 @@ public class CfgLog {
         modules.put(LogEnum.TX.name(), LogLevel.ERROR.name());
         modules.put(LogEnum.TXPOOL.name(), LogLevel.ERROR.name());
         modules.put(LogEnum.GUI.name(), LogLevel.INFO.name());
+        modules.put(LogEnum.SURVEY.name(), LogLevel.ERROR.name());
         this.logFile = false;
         this.logPath = "log";
     }


### PR DESCRIPTION
## Description

Timing runtime critical operations for survey on sync time distribution:
 - introduced a new logging level SURVEY for runtime stats;
 - TaskImportBlocks logs times according to stages in the import algorithm;
 - ResStatusHandler, ResBlocksHeadersHandler, ResBlocksBodiesHandler and BroadcastNewBlockHandler log times for decoding and validating blocks.

The CLI edit option can now add entries that were not in the initial config.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.
