### PR TITLE
Added getBlockdDetails method [AKI-351]

### DIFF
--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -13,6 +13,7 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -2267,6 +2268,57 @@ public class ApiWeb3Aion extends ApiAion {
         return new RpcMsg(result);
     }
 
+    public RpcMsg ops_getBlockDetailsByNumber(Object _params){
+        String _blockNumber;
+        if (_params instanceof JSONArray) {
+            _blockNumber = ((JSONArray) _params).get(0) + "";
+        } else if (_params instanceof JSONObject) {
+            _blockNumber = ((JSONObject) _params).get("block") + "";
+        } else {
+            return new RpcMsg(null, RpcError.INVALID_PARAMS, "Invalid parameters");
+        }
+        AionBlock block;
+        Long bn = this.parseBnOrId(_blockNumber);
+
+        // user passed a Long block number
+        if (bn != null && bn >= 0) {
+            block = (AionBlock) this.ac.getBlockchain().getBlockByNumber(bn);
+            if (block == null) {
+                return new RpcMsg(JSONObject.NULL);
+            }
+        }else {
+            return new RpcMsg(JSONObject.NULL);
+        }
+
+        return rpcBlockDetailsFromBlock(block);
+    }
+
+
+    public RpcMsg ops_getBlockDetailsByHash(Object _params){
+        String _blockHash;
+        if (_params instanceof JSONArray) {
+            _blockHash = ((JSONArray) _params).get(0) + "";
+        } else if (_params instanceof JSONObject) {
+            _blockHash = ((JSONObject) _params).get("block") + "";
+        } else {
+            return new RpcMsg(null, RpcError.INVALID_PARAMS, "Invalid parameters");
+        }
+
+        Block block = this.ac.getBlockchain().getBlockByHash(ByteUtil.hexStringToBytes(_blockHash));
+
+        if (block == null) {
+                return new RpcMsg(JSONObject.NULL);
+        }
+
+        Block mainBlock = this.ac.getBlockchain().getBlockByNumber(block.getNumber());
+
+        if (mainBlock == null || !Arrays.equals(block.getHash(), mainBlock.getHash())) {
+            return new RpcMsg(JSONObject.NULL);
+        }
+
+        return rpcBlockDetailsFromBlock(block);
+    }
+
     public RpcMsg ops_getBlock(Object _params) {
         String _bnOrHash;
         boolean _fullTx;
@@ -2999,6 +3051,41 @@ public class ApiWeb3Aion extends ApiAion {
             LOG.debug("err on parsing block number #" + _bnOrId);
             return null;
         }
+    }
+
+
+    private RpcMsg rpcBlockDetailsFromBlock(Block block){
+
+        BigInteger blkReward =
+            ((AionBlockchainImpl) ac.getBlockchain())
+                .getChainConfiguration()
+                .getRewardsCalculator()
+                .calculateReward(block.getHeader().getNumber());
+        BigInteger totalDiff =
+            this.ac.getAionHub().getBlockStore().getTotalDifficultyForHash(block.getHash());
+
+        List<AionTxInfo> txInfoList = new ArrayList<>();
+        for (AionTransaction transaction: block.getTransactionsList()){
+            AionTxInfo txInfo = this.ac.getAionHub()
+                .getBlockchain()
+                .getTransactionInfo(transaction.getTransactionHash());
+            txInfoList.add(txInfo);
+        }
+        Block previousBlock = this.ac.getBlockchain().getBlockByHash(block.getParentHash());
+        // get the parent block
+
+        Long previousTimestamp;
+
+        if (previousBlock == null){
+            previousTimestamp = null;
+        }
+        else {
+            previousTimestamp = previousBlock.getTimestamp();
+        }
+
+        return new RpcMsg(
+            Blk.aionBlockDetailsToJson(block, txInfoList, previousTimestamp, totalDiff, blkReward
+            ));
     }
 
     public void shutdown() {

--- a/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcMethods.java
@@ -126,6 +126,8 @@ public class RpcMethods {
                             "ops_getChainHeadViewBestBlock",
                             (params) -> api.ops_getChainHeadViewBestBlock()),
                     Map.entry("ops_getTransaction", (params) -> api.ops_getTransaction(params)),
+                    Map.entry("ops_getBlockDetailsByNumber", (params) -> api.ops_getBlockDetailsByNumber(params)),
+                    Map.entry("ops_getBlockDetailsByHash", (params) -> api.ops_getBlockDetailsByHash(params)),
                     Map.entry("ops_getBlock", (params) -> api.ops_getBlock(params)),
                     Map.entry("ops_getChainHeadView", (params) -> api.ops_getChainHeadView()),
                     Map.entry("eth_getBalance", (params) -> api.eth_getBalance(params)),

--- a/modApiServer/src/org/aion/api/server/types/Blk.java
+++ b/modApiServer/src/org/aion/api/server/types/Blk.java
@@ -10,7 +10,9 @@ import org.aion.base.TxUtil;
 import org.aion.types.AionAddress;
 import org.aion.util.bytes.ByteUtil;
 import org.aion.util.string.StringUtils;
+import org.aion.zero.impl.core.BloomFilter;
 import org.aion.zero.impl.types.AionBlock;
+import org.aion.zero.impl.types.AionTxInfo;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -93,6 +95,38 @@ public class Blk {
         obj.put("transactions", jsonTxs);
         return obj;
     }
+
+    public static JSONObject aionBlockDetailsToJson(Block genericBlock,
+        List<AionTxInfo> aionTxInfoList, Long previousTimestamp, BigInteger totalDifficulty,
+        BigInteger blockReward){
+
+        JSONObject obj = AionBlockOnlyToJson(genericBlock, totalDifficulty);
+
+        if(obj == null){
+            return null;
+        }
+
+        if (genericBlock.getNumber() == 0){
+            obj.put("blockTime", 0);
+        }
+        else if (previousTimestamp == null){
+            obj.put("blockTime", JSONObject.NULL);
+        }
+        else {
+            obj.put("blockTime", genericBlock.getTimestamp() - previousTimestamp);
+        }
+
+        obj.put("txTrieRoot", StringUtils.toJsonHex(genericBlock.getTxTrieRoot()));
+        obj.put("blockReward", new NumericalValue(blockReward).toHexString());
+        JSONArray transactions = new JSONArray();
+        for(AionTxInfo tx: aionTxInfoList){
+            transactions.put(Tx.aionTxInfoToDetailsJSON(tx, genericBlock));
+        }
+        obj.put("transactions", transactions);
+
+        return obj;
+    }
+
 
     @SuppressWarnings("Duplicates")
     public static JSONObject AionBlockOnlyToJson(Block genericBlock, BigInteger totalDifficulty) {

--- a/modApiServer/src/org/aion/api/server/types/Tx.java
+++ b/modApiServer/src/org/aion/api/server/types/Tx.java
@@ -130,9 +130,9 @@ public class Tx {
             obj.put("input", StringUtils.toJsonHex(transaction.getData()));
             obj.put("timestamp", new NumericalValue(transaction.getTimestamp()).toHexString());
             obj.put("error", info.getReceipt().getError());
-            obj.put("nonce", StringUtils.toJsonHex(transaction.getNonce()));
             obj.put("type", StringUtils.toJsonHex(transaction.getType()));
-            obj.put("value", new NumericalValue(transaction.getValueBI()).toHexString());
+            obj.put("nrgUsed", new NumericalValue(info.getReceipt().getEnergyUsed()).toHexString());
+            obj.put("gasUsed", new NumericalValue(info.getReceipt().getEnergyUsed()).toHexString());
             obj.put("hasInternalTransactions", info.hasInternalTransactions());
 
             JSONArray txLogs = new JSONArray();

--- a/modApiServer/test/org/aion/api/server/types/BlkTest.java
+++ b/modApiServer/test/org/aion/api/server/types/BlkTest.java
@@ -1,0 +1,127 @@
+package org.aion.api.server.types;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import org.aion.crypto.HashUtil;
+import org.aion.types.AionAddress;
+import org.aion.util.string.StringUtils;
+import org.aion.zero.impl.core.BloomFilter;
+import org.aion.zero.impl.types.AionBlock;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class BlkTest {
+
+    @Test
+    public void aionBlockDetailsToJsonTest(){
+        JSONObject nullObject = Blk.aionBlockDetailsToJson(null, Collections.emptyList(), null, null, null);
+        assertNull(nullObject);
+        byte[] emptyByteArray = new byte[32];
+        Arrays.fill(emptyByteArray, (byte) 0);
+        AionAddress coinBase = new AionAddress(Arrays.copyOf(emptyByteArray, 32));
+        byte[] parentHash = HashUtil.h256("parent".getBytes());
+        byte[] bloom = BloomFilter.create().getBloomFilterBytes();
+        byte[] difficulty = BigInteger.TEN.toByteArray();
+        long blockNumber = 1;
+        long timestamp = System.currentTimeMillis();
+        byte[] extraData = new byte[0];
+        byte[] nonce = BigInteger.valueOf(100).toByteArray();
+        byte[] receiptsRoot = Arrays.copyOf(emptyByteArray, 32);
+        byte[] transactionsRoot = Arrays.copyOf(emptyByteArray, 32);
+        byte[] stateRoot = Arrays.copyOf(emptyByteArray, 32);
+        byte[] solution = new byte[256];
+        long nrgConsumed = 0L;
+        long nrgLimit = 0;
+        BigInteger totalDifficulty = BigInteger.valueOf(20);
+        AionBlock block = new AionBlock(parentHash,
+            coinBase,
+            bloom,
+            difficulty,
+            blockNumber,
+            timestamp,
+            extraData,
+            nonce,
+            receiptsRoot,
+            transactionsRoot,
+            stateRoot,
+            Collections.emptyList(),
+            solution,
+            nrgConsumed,
+            nrgLimit);
+        byte[] hash = block.getHash();
+
+        JSONObject blkObject = Blk.aionBlockDetailsToJson(block,
+            Collections.emptyList(), timestamp - 10, totalDifficulty, BigInteger.valueOf(1).pow(18));
+
+        assertEquals(blkObject.get("miner"), StringUtils.toJsonHex(coinBase.toString()));
+        assertEquals(blkObject.get("number"), blockNumber);
+        assertEquals(blkObject.get("logsBloom"), StringUtils.toJsonHex(block.getLogBloom()));
+        assertEquals(blkObject.get("stateRoot"), StringUtils.toJsonHex(stateRoot));
+        assertEquals(blkObject.get("blockTime"), 10L);
+        assertEquals(blkObject.get("timestamp"), StringUtils.toJsonHex(timestamp));
+        assertEquals(blkObject.get("hash"), StringUtils.toJsonHex(hash));
+        assertEquals(blkObject.get("parentHash"), StringUtils.toJsonHex(parentHash));
+        assertEquals(blkObject.get("receiptsRoot"), StringUtils.toJsonHex(receiptsRoot));
+        assertEquals(blkObject.get("difficulty"), StringUtils.toJsonHex(difficulty));
+        assertEquals(blkObject.get("totalDifficulty"), StringUtils.toJsonHex(totalDifficulty));
+        assertEquals(blkObject.get("nonce"), StringUtils.toJsonHex(nonce));
+        assertEquals(blkObject.get("solution"), StringUtils.toJsonHex(solution));
+        assertEquals(blkObject.get("gasUsed"), StringUtils.toJsonHex(block.getHeader().getEnergyConsumed()));
+        assertEquals(blkObject.get("gasLimit"), StringUtils.toJsonHex(block.getHeader().getEnergyLimit()));
+        assertEquals(blkObject.get("nrgUsed"), StringUtils.toJsonHex(block.getHeader().getEnergyConsumed()));
+        assertEquals(blkObject.get("nrgLimit"), StringUtils.toJsonHex(block.getHeader().getEnergyLimit()));
+        assertEquals(blkObject.get("extraData"), StringUtils.toJsonHex(block.getExtraData()));
+        assertEquals(blkObject.get("size"), block.size());
+        assertEquals(blkObject.get("numTransactions"), 0);
+        assertEquals(blkObject.get("txTrieRoot"), StringUtils.toJsonHex(block.getTxTrieRoot()));
+        assertEquals(blkObject.get("blockReward"), new NumericalValue(BigInteger.valueOf(1).pow(18)).toHexString());
+        JSONArray array = (JSONArray) blkObject.get("transactions");
+        assertTrue(array.isEmpty());
+
+        block = new AionBlock(parentHash,
+            coinBase,
+            bloom,
+            difficulty,
+            0,
+            timestamp,
+            extraData,
+            nonce,
+            receiptsRoot,
+            transactionsRoot,
+            stateRoot,
+            Collections.emptyList(),
+            solution,
+            nrgConsumed,
+            nrgLimit);
+
+        blkObject = Blk.aionBlockDetailsToJson(block,
+            Collections.emptyList(), null, totalDifficulty, BigInteger.valueOf(1).pow(18));
+        assertEquals(blkObject.get("blockTime"), 0);
+
+        block = new AionBlock(parentHash,
+            coinBase,
+            bloom,
+            difficulty,
+            10,
+            timestamp,
+            extraData,
+            nonce,
+            receiptsRoot,
+            transactionsRoot,
+            stateRoot,
+            Collections.emptyList(),
+            solution,
+            nrgConsumed,
+            nrgLimit);
+
+        blkObject = Blk.aionBlockDetailsToJson(block, Collections.emptyList(), null, totalDifficulty, BigInteger.valueOf(1).pow(18));
+        assertEquals(blkObject.get("blockTime"), JSONObject.NULL);
+    }
+
+}

--- a/modApiServer/test/org/aion/api/server/types/TxTest.java
+++ b/modApiServer/test/org/aion/api/server/types/TxTest.java
@@ -1,0 +1,153 @@
+package org.aion.api.server.types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.aion.base.AionTransaction;
+import org.aion.base.AionTxReceipt;
+import org.aion.crypto.HashUtil;
+import org.aion.types.AionAddress;
+import org.aion.types.Log;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.util.string.StringUtils;
+import org.aion.zero.impl.core.BloomFilter;
+import org.aion.zero.impl.types.AionBlock;
+import org.aion.zero.impl.types.AionTxInfo;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class TxTest {
+
+
+    @Test
+    public void testTxInfoToJsonDetails(){
+        byte[] emptyByteArray = new byte[32];
+        Arrays.fill(emptyByteArray, (byte) 0);
+        AionAddress coinBase = new AionAddress(Arrays.copyOf(emptyByteArray, 32));
+        byte[] parentHash = HashUtil.h256("parent".getBytes());
+        byte[] bloom = BloomFilter.create().getBloomFilterBytes();
+        byte[] difficulty = BigInteger.TEN.toByteArray();
+        long blockNumber = 1;
+        long timestamp = System.currentTimeMillis();
+        byte[] extraData = new byte[0];
+        byte[] nonce = BigInteger.valueOf(100).toByteArray();
+        byte[] receiptsRoot = Arrays.copyOf(emptyByteArray, 32);
+        byte[] transactionsRoot = Arrays.copyOf(emptyByteArray, 32);
+        byte[] stateRoot = Arrays.copyOf(emptyByteArray, 32);
+        byte[] solution = new byte[256];
+        long nrgConsumed = 0L;
+        long nrgLimit = 0;
+
+        byte[] txNonce = ByteUtil.bigIntegerToBytes(BigInteger.ONE);
+        AionAddress to = new AionAddress(emptyByteArray);
+        AionAddress from = new AionAddress(emptyByteArray);
+        byte[] value = ByteUtil.bigIntegerToBytes(BigInteger.TEN);
+        byte[] data = Arrays.copyOf(emptyByteArray, 32);
+        long txNrgLimit = 10L;
+        long txNrgPrice = 10L;
+        byte type = 0b1;
+        long txNrgUsed = 5L;
+        AionTransaction transaction = AionTransaction.createWithoutKey(txNonce,from, to, value, data, txNrgLimit, txNrgPrice, type);
+
+        AionTxReceipt txReceipt = new AionTxReceipt();
+        txReceipt.setTransaction(transaction);
+        txReceipt.setNrgUsed(txNrgUsed);
+
+        AionBlock block =
+                new AionBlock(
+                        parentHash,
+                        coinBase,
+                        bloom,
+                        difficulty,
+                        blockNumber,
+                        timestamp,
+                        extraData,
+                        nonce,
+                        receiptsRoot,
+                        transactionsRoot,
+                        stateRoot,
+                        List.of(transaction),
+                        solution,
+                        nrgConsumed,
+                        nrgLimit);
+        byte[] hash = block.getHash();
+
+        JSONObject object = Tx.aionTxInfoToDetailsJSON(AionTxInfo.newInstance(txReceipt,hash,0), block);
+        assertNotNull(object);
+        assertEquals(ByteUtil.byteArrayToLong(txNonce), object.get("nonce"));
+        assertEquals(StringUtils.toJsonHex(data), object.get("input"));
+        assertEquals(StringUtils.toJsonHex(to.toByteArray()), object.get("to"));
+        assertEquals(StringUtils.toJsonHex(from.toByteArray()), object.get("from"));
+        assertEquals(txNrgLimit, object.get("nrg"));
+        assertEquals(StringUtils.toJsonHex(value), object.get("value"));
+        assertEquals(StringUtils.toJsonHex(txNrgPrice), object.get("nrgPrice"));
+        assertEquals(new NumericalValue(transaction.getTimestamp()).toHexString(), object.get("timestamp"));
+        assertEquals(StringUtils.toJsonHex(blockNumber), object.get("blockNumber"));
+        assertEquals(StringUtils.toJsonHex(hash), object.get("blockHash"));
+        assertEquals("", object.get("error"));
+        assertEquals(new NumericalValue(value).toHexString(), object.get("value"));
+        assertFalse(object.getBoolean("hasInternalTransactions"));
+        assertTrue(object.getJSONArray("logs").isEmpty());
+        assertEquals(new NumericalValue(txNrgUsed).toHexString(), object.get("nrgUsed") );
+        assertEquals(new NumericalValue(txNrgUsed).toHexString(), object.get("gasUsed") );
+
+        byte[] onesArray = new byte[32];
+        byte[] twosArray = new byte[32];
+        Arrays.fill(onesArray, (byte) 1);
+        Arrays.fill(twosArray, (byte) 2);
+        byte[] logData = new byte[32];
+        Arrays.fill(logData, (byte) 7);
+        List<byte[]> topics = List.of(onesArray, twosArray);
+        Log txLog = Log.topicsAndData(to.toByteArray(), topics, logData);
+
+
+        AionTransaction transactionWithLog = AionTransaction.createWithoutKey(txNonce,from, to, value, data, txNrgLimit, txNrgPrice, type);
+
+        AionTxReceipt txReceiptWithLog = new AionTxReceipt();
+        txReceiptWithLog.setLogs(List.of(txLog));
+        txReceiptWithLog.setTransaction(transactionWithLog);
+        txReceiptWithLog.setNrgUsed(txNrgUsed);
+
+        AionBlock blockWithLog =
+            new AionBlock(
+                parentHash,
+                coinBase,
+                bloom,
+                difficulty,
+                blockNumber,
+                timestamp,
+                extraData,
+                nonce,
+                receiptsRoot,
+                transactionsRoot,
+                stateRoot,
+                List.of(transactionWithLog),
+                solution,
+                nrgConsumed,
+                nrgLimit);
+        byte[] hashWithLog = block.getHash();
+
+        JSONObject jsonWithLogs = Tx.aionTxInfoToDetailsJSON(AionTxInfo.newInstance(txReceiptWithLog, hashWithLog, 0), blockWithLog);
+
+        assertNotNull(jsonWithLogs);
+        List<Object> jsonArray = jsonWithLogs.getJSONArray("logs").toList();
+
+        for (Object log : jsonArray){
+            assertEquals(StringUtils.toJsonHex(to.toByteArray()), ((Map)log).get("address"));
+            assertEquals(StringUtils.toJsonHex(logData), ((Map)log).get("data"));
+            ArrayList jsonTopics = (ArrayList) ((Map) log).get("topics");
+            for (int i = 0; i <topics.size(); i++) {
+                assertEquals(StringUtils.toJsonHex(topics.get(i)), jsonTopics.get(i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This change adds a new ops_getBlockDetails method which returns a blockdetails similar to the blockdetails found in the Java API.

Fixes Issue # AKI-351

## Type of change
- [ ] Bug fix.
- [x] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing
- deployed the build and synced to mainnet
- executed requests using blocks that contained no transaction, one transaction and more than one transaction. Requests made: 
```
curl localhost:8545 -H 'Content-Type: application/json' -s -d '{"json-Mc":"2.0","method":"ops_getBlockDetails","params": [1]}'
```

```
curl localhost:8545 -H 'Content-Type: application/json' -s -d '{"json-Mc":"2.0","method":"ops_getBlockDetails","params": {"block":6753}}'
```

```
curl 192.168.1.67:8545 -H 'Content-Type: application/json' -s -d '{"json-Mc":"2.0","method":"ops_getBlockDetails","params": [1174759]}'
```
- added functional test cases to the dashboard ETL


