### PR TITLE
AKI-358: synchronize on account unlocking & locking

### DIFF
--- a/modApiServer/src/org/aion/api/server/account/AccountManager.java
+++ b/modApiServer/src/org/aion/api/server/account/AccountManager.java
@@ -61,7 +61,7 @@ public class AccountManager {
         return new ArrayList<>(this.accounts.values());
     }
 
-    public boolean unlockAccount(AionAddress _address, String _password, int _timeout) {
+    public synchronized boolean unlockAccount(AionAddress _address, String _password, int _timeout) {
 
         ECKey key = Keystore.getKey(_address.toString(), _password);
 
@@ -95,7 +95,7 @@ public class AccountManager {
         }
     }
 
-    public boolean lockAccount(AionAddress _address, String _password) {
+    public synchronized boolean lockAccount(AionAddress _address, String _password) {
 
         ECKey key = Keystore.getKey(_address.toString(), _password);
 


### PR DESCRIPTION
- This is to fix an OutOfMemory issue that occurs when multiple rpc threads
  are attempting to unlock (or lock) accounts simultaneously. This is a very
  memory-intensive call, requiring 200-230MB of space for each call. The
  synchronization here prevents multiple threads from allocating this space
  concurrently and therefore allows for it to be gc'ed, keeping the memory
  usage low in this case.
