### PR TITLE
AIP010 Beacon hash check

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/IAionBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/IAionBlockchain.java
@@ -181,4 +181,25 @@ public interface IAionBlockchain extends IPowChain {
     //         BlockIdentifierImpl identifier, int skip, int limit, boolean reverse);
 
     List<byte[]> getListOfBodiesByHashes(List<byte[]> hashes);
+
+    /**
+     * Checks whether a hash is indexed as main chain or side chain.
+     *
+     * @param hash the hash for which we check its chain status
+     * @param level the height at which the block should be indexed
+     * @return {@code true} if the block is indexed as a main chain block, {@code false} if the
+     *     block is not indexed or is a side chain block
+     */
+    boolean isMainChain(byte[] hash, long level);
+
+    /**
+     * Checks if a hash is indexed as main chain or side chain
+     *
+     * @param hash the hash for which we check its chain status
+     *
+     * @return {@code true} if the block is indexed as a main chain block, {@code false} if the
+     *     block is not indexed or is a side chain block
+     */
+    public boolean isMainChain(byte[] hash);
+
 }

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/StakingContractHelper.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/StakingContractHelper.java
@@ -99,7 +99,8 @@ public class StakingContractHelper {
                         abi,
                         2_000_000L,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT,
+                        null);
 
         AionTxReceipt receipt = callConstant(callTx);
 
@@ -171,7 +172,8 @@ public class StakingContractHelper {
                         abi,
                         2_000_000L,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT,
+                        null);
 
         AionTxReceipt receipt = callConstant(callTx);
 

--- a/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
@@ -1429,6 +1429,20 @@ public class AionBlockStore implements IBlockStoreBase {
     }
 
     /**
+     * Checks if a hash is indexed as main chain or side chain; like
+     * {@link #isMainChain(byte[], long)}, but less efficient
+     *
+     * @param hash the hash for which we check its chain status
+     *
+     * @return {@code true} if the block is indexed as a main chain block, {@code false} if the
+     *     block is not indexed or is a side chain block
+     */
+    public boolean isMainChain(byte[] hash) {
+        Block block = getBlockByHash(hash);
+        return block == null ? false : isMainChain(hash, block.getNumber());
+    }
+
+    /**
      * First checks if the size key is missing or smaller than it should be. If it is incorrect, the
      * method attempts to correct it by setting it to the given level.
      */

--- a/modAionImpl/src/org/aion/zero/impl/valid/BeaconHashValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/BeaconHashValidator.java
@@ -1,0 +1,176 @@
+package org.aion.zero.impl.valid;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.aion.base.AionTransaction;
+import org.aion.log.LogEnum;
+import org.aion.mcf.blockchain.Block;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.zero.impl.blockchain.IAionBlockchain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Validates beacon hash of transaction */
+public class BeaconHashValidator {
+    private final IAionBlockchain blockchain;
+    private final long fork050Number;
+    private static final Logger TX_LOG = LoggerFactory.getLogger(LogEnum.TX.name());
+
+    /**
+     * The value to use for fork050Number when calling constructor {@link
+     * #BeaconHashValidator(IAionBlockchain, long)} if beacon hash validation is
+     * disabled.
+     */
+    public static final long FORK_050_DISABLED = Long.MAX_VALUE;
+
+    /**
+     * Constructor.
+     *
+     * @param blockchain blockchain
+     * @param fork050Number the block number at which hard fork 0.5.0 takes effect.  Use
+     *                      {@link #FORK_050_DISABLED} if validation should be disabled;
+     *                      i.e. behave as if fork050 never happens and always return true
+     *                      when {@link #validateTxForBlock(AionTransaction, Block)} or
+     *                      {@link #validateTxForPendingState(AionTransaction)} is called
+     */
+    public BeaconHashValidator(IAionBlockchain blockchain, long fork050Number) {
+        Preconditions.checkNotNull(blockchain, "Blockstore can't be null");
+        Preconditions.checkArgument(fork050Number >= 0, "Invalid fork0.5.0 block number: must be >= 0");
+
+        this.blockchain = blockchain;
+        this.fork050Number = fork050Number;
+    }
+
+    /**
+     * Evaluate if a transaction's (possibly null) beacon hash is valid for a particular block.
+     *
+     * If the block has not reached the fork 0.5.0 block number, or fork 0.5.0 is disabled,
+     * the transaction must not provide a beacon hash (i.e. must be null), otherwise it is
+     * not valid.
+     *
+     * If the block has reached the fork 0.5.0 block number, the transaction is valid if
+     * either the beacon hash is absent (i.e. is null) or the beacon hash is the hash of a
+     * block on the chain that {@link Block#getParentHash()} is on.
+     *
+     * @param tx transaction to validate
+     * @param block block that the transaction is in
+     * @return whether beacon hash of transaction is valid
+     */
+    public boolean validateTxForBlock(AionTransaction tx, Block block) {
+        long t0 = System.nanoTime();
+        try {
+            Preconditions.checkNotNull(tx, "AionTransaction must not be null");
+            Preconditions.checkNotNull(tx, "Block must not be null");
+
+            byte[] beaconHash = tx.getBeaconHash();
+            if (beaconHash == null) {
+                return true;
+            }
+
+            if (!isAfterFork050(block.getNumber()) && beaconHash != null) {
+                return false;
+            }
+
+            if (blockchain.isMainChain(block.getParentHash())) {
+                boolean isMainChain = blockchain.isMainChain(beaconHash);
+                TX_LOG.debug(String.format(
+                        "BeaconHashValidator#validateTxForBlock: isMainChain(0x%s) = %b.",
+                        ByteUtil.toHexString(beaconHash), isMainChain));
+                return isMainChain;
+            } else {
+                boolean onCorrectSidechain = checkSideChain(beaconHash,
+                        blockchain.getBlockByHash(block.getParentHash()));
+                TX_LOG.debug(String.format(
+                        "BeaconHashValidator#validateTxForBlock: checkSideChain(0x%s, 0x%s) = %b.",
+                        ByteUtil.toHexString(beaconHash),
+                        ByteUtil.toHexString(block.getParentHash()),
+                        onCorrectSidechain));
+                return onCorrectSidechain;
+            }
+        } finally {
+            TX_LOG.debug("BeaconHashValidator#validateTxForBlock: tx {} took {} usec",
+                    ByteUtil.toHexString(block.getHash()),
+                    (System.nanoTime() - t0)/1000);
+        }
+    }
+
+    /**
+     * Evaluate if a transaction's (possibly null) beacon hash is valid for pending state.
+     *
+     * If the main chain's (best block + 1) has not reached the fork 0.5.0 block number, or
+     * fork 0.5.0 is disabled, the transaction must not provide a beacon hash (i.e.
+     * must be null), otherwise it is not valid.
+     *
+     * If the main chain's (best block + 1) has reached the fork 0.5.0 block number, the
+     * transaction is valid if either the beacon hash is absent (i.e. is null) or the beacon
+     * hash is on the main chain.
+     *
+     * @param tx transaction to validate
+     * @return whether beacon hash of transaction is valid
+     */
+    public boolean validateTxForPendingState(AionTransaction tx) {
+        long t0 = System.nanoTime();
+        try {
+            Preconditions.checkNotNull(tx, "AionTransaction must not be null");
+
+            byte[] beaconHash = tx.getBeaconHash();
+            if (beaconHash == null) {
+                return true;
+            }
+
+            // the next block number might be larger than (current best + 1), but
+            // we will tolerate false negatives
+            long minNextBlockNumber = blockchain.getBestBlock().getNumber() + 1;
+            if (!isAfterFork050(minNextBlockNumber) && beaconHash != null) {
+                return false;
+            }
+
+            boolean isMainChain = blockchain.isMainChain(beaconHash);
+            TX_LOG.debug(String.format("BeaconHashValidator#validate: isMainChain(0x%s) = %b.",
+                    ByteUtil.toHexString(beaconHash), isMainChain));
+            return isMainChain;
+        } finally {
+            TX_LOG.debug("BeaconHashValidator#validateTxForPendingState: took {} usec",
+                    (System.nanoTime() - t0)/1000);
+        }
+    }
+
+    /**
+     * @return true if blockNumber >= fork050Number and fork050 not disabled;
+     *         false in all other cases
+     */
+    @VisibleForTesting boolean isAfterFork050(long blockNumber) {
+        return blockNumber >= fork050Number && fork050Number != FORK_050_DISABLED;
+    }
+
+    private boolean checkSideChain(byte[] beaconHash, Block sideChainHead) {
+        Block beaconBlock = blockchain.getBlockByHash(beaconHash);
+        if(beaconBlock == null) {
+            return false;
+        }
+
+        Block cur = sideChainHead;
+        long beaconNumber = beaconBlock.getNumber();
+
+        while(null != cur) {
+            if(beaconHash.equals(cur.getHash())) {
+                return true;
+            } else if(beaconNumber >= cur.getNumber()) {
+                TX_LOG.debug("BeaconHashValidator#checkSideChain: reached level of beacon hash block {}",
+                        ByteUtil.toHexString(cur.getHash()));
+                return false;
+            } else if(blockchain.isMainChain(cur.getHash(), cur.getNumber())) {
+                TX_LOG.debug("BeaconHashValidator#checkSideChain: found fork point to mainchain at {}",
+                        ByteUtil.toHexString(cur.getHash()));
+                return blockchain.isMainChain(beaconHash);
+            }
+
+            cur = blockchain.getBlockByHash(cur.getParentHash());
+        }
+
+        // should not actually reach this since genesis block is a main chain block;
+        // there is either a bug in the code or something broken in the db
+        throw new IllegalStateException(
+                "BeaconHashValidator#checkSideChain: reached orphaned block without finding mainchain");
+    }
+}

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainAccountStateBenchmark.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainAccountStateBenchmark.java
@@ -183,7 +183,7 @@ public class BlockchainAccountStateBenchmark {
                             ZERO_BYTE,
                             21000,
                             1,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             transactions.add(sendTransaction);
             accountNonce = accountNonce.add(BigInteger.ONE);
         }
@@ -253,7 +253,7 @@ public class BlockchainAccountStateBenchmark {
                         ByteUtil.hexStringToBytes(STATE_EXPANSION_BYTECODE),
                         1000000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block =
                 bc.createNewBlock(parentBlock, Collections.singletonList(creationTx), true);
@@ -290,7 +290,7 @@ public class BlockchainAccountStateBenchmark {
                             callData,
                             200000,
                             1,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             transactions.add(sendTransaction);
             accountNonce = accountNonce.add(BigInteger.ONE);
         }

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainAccountStateTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainAccountStateTest.java
@@ -59,7 +59,7 @@ public class BlockchainAccountStateTest {
                             ZERO_BYTE,
                             21000,
                             1,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             transactions.add(sendTransaction);
             accountNonce = accountNonce.add(BigInteger.ONE);
         }
@@ -123,7 +123,7 @@ public class BlockchainAccountStateTest {
                             ZERO_BYTE,
                             21000,
                             1,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             transactions.add(sendTransaction);
         }
 

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainEnergyTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainEnergyTest.java
@@ -76,7 +76,7 @@ public class BlockchainEnergyTest {
                             ByteUtil.EMPTY_BYTE_ARRAY,
                             21000L,
                             BigInteger.valueOf(5).multiply(BigInteger.TEN.pow(9)).longValue(),
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             txs.add(atx);
         }
         AionBlock block = bc.createNewBlock(bc.getBestBlock(), txs, true);

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainForkingTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainForkingTest.java
@@ -750,7 +750,7 @@ public class BlockchainForkingTest {
                 ByteUtil.hexStringToBytes(contractCode),
                 5_000_000L,
                 10_123_456_789L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private AionTransaction callSetValue(
@@ -770,7 +770,7 @@ public class BlockchainForkingTest {
                 Hex.decode(contractCode),
                 2_000_000L,
                 10_123_456_789L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private AionTransaction callSetValue2(
@@ -794,7 +794,7 @@ public class BlockchainForkingTest {
                 Hex.decode(contractCode),
                 2_000_000L,
                 10_123_456_789L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     /**
@@ -1031,7 +1031,7 @@ public class BlockchainForkingTest {
                 statefulnessAVM,
                 5_000_000L,
                 10_123_456_789L,
-                TransactionTypes.AVM_CREATE_CODE);
+                TransactionTypes.AVM_CREATE_CODE, null);
     }
 
     private List<AionTransaction> callStatefulnessAVM(
@@ -1051,7 +1051,7 @@ public class BlockchainForkingTest {
                             ABIUtil.encodeMethodArguments("incrementCounter"),
                             2_000_000L,
                             10_123_456_789L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             txs.add(transaction);
             // increment nonce
             nonce = nonce.add(BigInteger.ONE);
@@ -1067,7 +1067,7 @@ public class BlockchainForkingTest {
                         ABIUtil.encodeMethodArguments("getCount"),
                         2_000_000L,
                         10_123_456_789L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         txs.add(transaction);
 
         return txs;

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainFvm040Fork.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainFvm040Fork.java
@@ -194,7 +194,7 @@ public class BlockchainFvm040Fork {
                         ByteUtil.hexStringToBytes(deepContractCode),
                         1000000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block1 =
                 bc.createNewBlock(bc.getGenesis(), Collections.singletonList(deployTx), true);
@@ -215,7 +215,7 @@ public class BlockchainFvm040Fork {
                         callData,
                         1000000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block2 = bc.createNewBlock(block1, Collections.singletonList(txCall), true);
         result = bc.tryToConnectAndFetchSummary(block2);
@@ -234,7 +234,7 @@ public class BlockchainFvm040Fork {
                         callData,
                         1000000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block3 = bc.createNewBlock(block2, Collections.singletonList(txCall), true);
         result = bc.tryToConnectAndFetchSummary(block3);

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainIntegrationTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainIntegrationTest.java
@@ -131,7 +131,7 @@ public class BlockchainIntegrationTest {
                         ByteUtil.EMPTY_BYTE_ARRAY,
                         1L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block = bc.createNewBlock(bc.getBestBlock(), Collections.singletonList(tx), true);
 
@@ -169,7 +169,7 @@ public class BlockchainIntegrationTest {
                         ByteUtil.EMPTY_BYTE_ARRAY,
                         21000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block = bc.createNewBlock(bc.getBestBlock(), Collections.singletonList(tx), true);
 
@@ -244,7 +244,7 @@ public class BlockchainIntegrationTest {
                         ByteUtil.EMPTY_BYTE_ARRAY,
                         21000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         // create a new block containing a single transaction (tx)
         AionBlock block = bc.createNewBlock(bc.getBestBlock(), Collections.singletonList(tx), true);
@@ -281,7 +281,7 @@ public class BlockchainIntegrationTest {
                         ByteUtil.hexStringToBytes(cryptoKittiesCode),
                         4699999L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block =
                 blockchain.createNewBlock(

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainTestUtils.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainTestUtils.java
@@ -71,7 +71,7 @@ public class BlockchainTestUtils {
                                 ZERO_BYTE,
                                 NRG,
                                 NRG_PRICE,
-                                TransactionTypes.DEFAULT);
+                                TransactionTypes.DEFAULT, null);
                 transactions.add(newTx);
                 accountNonce = accountNonce.add(BigInteger.ONE);
                 nonces.put(key, accountNonce);

--- a/modAionImpl/test/org/aion/zero/impl/consensus/BalanceTransferConsensusTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/consensus/BalanceTransferConsensusTest.java
@@ -94,7 +94,8 @@ public class BalanceTransferConsensusTest {
                         new byte[0],
                         2_000_000,
                         ENERGY_PRICE,
-                        (byte) 11); // legal type before the fork
+                        (byte) 11, // legal type before the fork
+                        null);
 
         // check that the transaction is valid
         assertThat(TransactionTypeValidator.isValid(transaction)).isTrue();
@@ -142,7 +143,8 @@ public class BalanceTransferConsensusTest {
                         new byte[0],
                         2_000_000,
                         ENERGY_PRICE,
-                        (byte) 11); // illegal type after the fork
+                        (byte) 11,  // illegal type after the fork
+                        null);
 
         // check that the transaction is not valid
         assertThat(TransactionTypeValidator.isValid(transaction)).isFalse();
@@ -167,8 +169,8 @@ public class BalanceTransferConsensusTest {
                         new byte[0],
                         2_000_000,
                         ENERGY_PRICE,
-                        TransactionTypes
-                                .AVM_CREATE_CODE); // illegal type for the balance transfer after
+                        TransactionTypes.AVM_CREATE_CODE, // illegal type for the balance transfer after
+                        null);
         // the fork
 
         // check that the transaction is not valid
@@ -194,7 +196,8 @@ public class BalanceTransferConsensusTest {
                         new byte[0],
                         2_000_000,
                         ENERGY_PRICE,
-                        TransactionTypes.DEFAULT); // the only valid type after the fork
+                        TransactionTypes.DEFAULT, // the only valid type after the fork
+                        null);
 
         // check that the transaction is not valid
         assertThat(TransactionTypeValidator.isValid(transaction)).isTrue();
@@ -380,7 +383,7 @@ public class BalanceTransferConsensusTest {
                 new byte[] {0x1, 0x2, 0x3},
                 2_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private BigInteger getBalance(AionAddress address) {

--- a/modAionImpl/test/org/aion/zero/impl/consensus/ConsensusTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/consensus/ConsensusTest.java
@@ -371,7 +371,7 @@ public class ConsensusTest {
                 getContractCode(),
                 2_000_000,
                 1,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     /** Calls the function: addOwner(Address) in Wallet.sol */
@@ -386,7 +386,7 @@ public class ConsensusTest {
                 callData,
                 2_000_000,
                 1,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     /**
@@ -405,7 +405,7 @@ public class ConsensusTest {
                 callData,
                 2_000_000,
                 1,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     /**
@@ -425,7 +425,7 @@ public class ConsensusTest {
                 callData,
                 24_460,
                 1,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     /**
@@ -445,7 +445,7 @@ public class ConsensusTest {
                 callData,
                 22_326,
                 2,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     /** Transfers the specified amount of value from OWNER account to OTHER. */
@@ -459,7 +459,7 @@ public class ConsensusTest {
                 new byte[0],
                 21_000,
                 1,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     /** The binary of the contract: Wallet.sol */

--- a/modAionImpl/test/org/aion/zero/impl/consensus/FvmBalanceTransferConsensusTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/consensus/FvmBalanceTransferConsensusTest.java
@@ -88,7 +88,7 @@ public class FvmBalanceTransferConsensusTest {
                         new byte[] {},
                         2_000_000,
                         ENERGY_PRICE,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         // Process the transaction.
         Pair<ImportResult, AionBlockSummary> results = processTransaction(transaction, 1);
@@ -150,7 +150,7 @@ public class FvmBalanceTransferConsensusTest {
                                 "a6f9dae1a048613dd3cb89685cb3f9cfa410ecf606c7ec7320e721edacd194050828c6b0"),
                         2_000_000,
                         ENERGY_PRICE,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         // Process the transaction.
         Pair<ImportResult, AionBlockSummary> results = processTransaction(transaction, 1);
@@ -210,7 +210,7 @@ public class FvmBalanceTransferConsensusTest {
                         new byte[] {},
                         2_000_000,
                         ENERGY_PRICE,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         // Process the transaction.
         Pair<ImportResult, AionBlockSummary> results = processTransaction(transaction, 1);
@@ -276,7 +276,7 @@ public class FvmBalanceTransferConsensusTest {
                         Hex.decode("abcdef0123456789"),
                         2_000_000,
                         ENERGY_PRICE,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         // Process the transaction.
         Pair<ImportResult, AionBlockSummary> results = processTransaction(transaction, 1);
@@ -345,7 +345,7 @@ public class FvmBalanceTransferConsensusTest {
                         Hex.decode("abcdef0123456789"),
                         2_000_000,
                         ENERGY_PRICE,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         // Process the transaction.
         Pair<ImportResult, AionBlockSummary> results = processTransaction(transaction, 1);
@@ -794,7 +794,7 @@ public class FvmBalanceTransferConsensusTest {
                 getNonpayableConstructorContractBytes(),
                 5_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private static AionTransaction makeCreateAndTransferToFvmPayableConstructorContractTx(
@@ -808,7 +808,7 @@ public class FvmBalanceTransferConsensusTest {
                 getPayableConstructorContractBytes(),
                 5_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private static AionTransaction makeCreatePayableFallbackContractTx() {
@@ -821,7 +821,7 @@ public class FvmBalanceTransferConsensusTest {
                 getPayableFallbackContractBytes(),
                 5_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private static AionTransaction makeCreateNonpayableFallbackContractTx() {
@@ -834,7 +834,7 @@ public class FvmBalanceTransferConsensusTest {
                 getNonpayableFallbackContractBytes(),
                 5_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private static AionTransaction makeCreatePayableContractTx() {
@@ -847,7 +847,7 @@ public class FvmBalanceTransferConsensusTest {
                 getPayableContractBytes(),
                 5_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private static AionTransaction makeCallNonpayableFunctionTx(
@@ -861,7 +861,7 @@ public class FvmBalanceTransferConsensusTest {
                 callNonpayableFunctionEncoding(),
                 2_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private static AionTransaction makeCallFallbackFunctionTx(
@@ -875,7 +875,7 @@ public class FvmBalanceTransferConsensusTest {
                 new byte[0],
                 2_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private static AionTransaction makeCallPayableFunctionTx(
@@ -889,7 +889,7 @@ public class FvmBalanceTransferConsensusTest {
                 callPayableFunctionEncoding(),
                 2_000_000,
                 ENERGY_PRICE,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private Pair<ImportResult, AionBlockSummary> processTransaction(

--- a/modAionImpl/test/org/aion/zero/impl/pendingState/PendingStateTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/pendingState/PendingStateTest.java
@@ -83,7 +83,7 @@ public class PendingStateTest {
                         new byte[0],
                         1_000_000L,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.SUCCESS);
     }
@@ -101,7 +101,7 @@ public class PendingStateTest {
                         new byte[0],
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.INVALID_TX_NRG_PRICE);
     }
@@ -125,7 +125,7 @@ public class PendingStateTest {
                         jar,
                         5_000_000,
                         10_000_000_000L,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         assertEquals(pendingState.addPendingTransaction(transaction), TxResponse.SUCCESS);
     }
@@ -149,7 +149,7 @@ public class PendingStateTest {
                         jar,
                         5_000_000,
                         10_000_000_000L,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         assertEquals(pendingState.addPendingTransaction(createTransaction), TxResponse.SUCCESS);
 
@@ -179,7 +179,7 @@ public class PendingStateTest {
                         call,
                         2_000_000,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(callTransaction), TxResponse.SUCCESS);
     }
@@ -194,7 +194,7 @@ public class PendingStateTest {
                 1000_000L,
                 10_000_000_000L,
                 TransactionTypes.DEFAULT,
-                timeStamp);
+                timeStamp, null);
     }
 
     private AionTransaction genTransaction(byte[] nonce) {
@@ -206,7 +206,7 @@ public class PendingStateTest {
                 ByteUtils.fromHexString("1"),
                 1000_000L,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     @Test
@@ -264,7 +264,7 @@ public class PendingStateTest {
                     ByteUtils.fromHexString("1"),
                     1000_000L,
                     10_000_000_000L,
-                    TransactionTypes.DEFAULT);
+                    TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.SUCCESS);
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.REPAYTX_LOWPRICE);
@@ -318,7 +318,7 @@ public class PendingStateTest {
                         ByteUtils.fromHexString("1"),
                         1000_000L,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.CACHED_NONCE);
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.ALREADY_CACHED);
@@ -335,7 +335,7 @@ public class PendingStateTest {
                         ByteUtils.fromHexString("1"),
                         10L,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.INVALID_TX);
     }
@@ -351,7 +351,7 @@ public class PendingStateTest {
                         ByteUtils.fromHexString("1"),
                         1000_000L,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionTransaction tx2 =
                 AionTransaction.create(
@@ -362,7 +362,7 @@ public class PendingStateTest {
                         ByteUtils.fromHexString("2"),
                         1000_000L,
                         20_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.SUCCESS);
 
@@ -387,7 +387,7 @@ public class PendingStateTest {
                 ByteUtils.fromHexString("1"),
                 1000_000L,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx2 =
             AionTransaction.create(
@@ -398,7 +398,7 @@ public class PendingStateTest {
                 ByteUtils.fromHexString("1"),
                 1000_000L,
                 19_999_999_999L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx1));
         assertEquals(TxResponse.REPAYTX_LOWPRICE, pendingState.addPendingTransaction(tx2));
@@ -416,7 +416,7 @@ public class PendingStateTest {
                 ByteUtils.fromHexString("1"),
                 1000_000L,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx2 =
             AionTransaction.create(
@@ -427,7 +427,7 @@ public class PendingStateTest {
                 ByteUtils.fromHexString("1"),
                 1000_000L,
                 20_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx1));
         assertEquals(TxResponse.REPAID, pendingState.addPendingTransaction(tx2));
@@ -456,7 +456,7 @@ public class PendingStateTest {
                 ByteUtils.fromHexString("1"),
                 1000_000L,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx2 =
             AionTransaction.create(
@@ -467,7 +467,7 @@ public class PendingStateTest {
                 ByteUtils.fromHexString("1"),
                 1000_000L,
                 20_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx1));
         assertEquals(TxResponse.REPAID, pendingState.addPendingTransaction(tx2));
@@ -499,7 +499,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx2 =
             AionTransaction.create(
@@ -510,7 +510,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         /* tx1 and tx3 should use the entire balance. If tx2 is removed properly, tx3 should be
          * able to replace it in the pending state */
@@ -523,7 +523,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 20_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         // This would execute fine on top of tx2, but should have insufficient balance on top of tx3
         AionTransaction tx4 =
@@ -535,7 +535,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx1));
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx2));
@@ -569,7 +569,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx2 =
             AionTransaction.create(
@@ -580,7 +580,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         /* tx1 and tx3 should use the entire balance. If tx2 is removed properly, tx3 should be
          * able to replace it in the pending state */
@@ -593,7 +593,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 40_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         // This would execute fine on top of tx2, but should have insufficient balance on top of tx3
         AionTransaction tx4 =
@@ -605,7 +605,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 40_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx5 =
             AionTransaction.create(
@@ -616,7 +616,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx1));
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx2));
@@ -651,7 +651,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx2 =
             AionTransaction.create(
@@ -662,7 +662,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionTransaction tx3 =
             AionTransaction.create(
@@ -673,7 +673,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 40_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         // This tx will get dropped after tx3 is rejected
         AionTransaction tx4 =
@@ -685,7 +685,7 @@ public class PendingStateTest {
                 new byte[0],
                 21000,
                 10_000_000_000L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx1));
         assertEquals(TxResponse.SUCCESS, pendingState.addPendingTransaction(tx2));
@@ -714,7 +714,7 @@ public class PendingStateTest {
                         ByteUtils.fromHexString("1"),
                         21_000L,
                         10_000_000_000L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(pendingState.addPendingTransaction(tx), TxResponse.SUCCESS);
 

--- a/modAionImpl/test/org/aion/zero/impl/pendingState/PendingTxCacheTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/pendingState/PendingTxCacheTest.java
@@ -51,7 +51,7 @@ public class PendingTxCacheTest {
                             ByteUtil.hexStringToBytes("1"),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
 
             txn.add(tx);
         }
@@ -81,7 +81,7 @@ public class PendingTxCacheTest {
                             ByteUtil.hexStringToBytes(data),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
 
             txn.add(tx);
         }

--- a/modAionImpl/test/org/aion/zero/impl/types/AionTransactionTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/types/AionTransactionTest.java
@@ -3,6 +3,7 @@ package org.aion.zero.impl.types;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.math.BigInteger;
 import org.aion.base.AionTransaction;
@@ -10,6 +11,9 @@ import org.aion.base.TransactionTypes;
 import org.aion.base.TxUtil;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
+import org.aion.rlp.RLP;
+import org.aion.rlp.RLPList;
+import org.aion.util.bytes.ByteUtil;
 import org.aion.util.types.DataWord;
 import org.aion.types.AionAddress;
 import org.apache.commons.lang3.RandomUtils;
@@ -52,7 +56,7 @@ public class AionTransactionTest {
                         data,
                         nrg,
                         nrgPrice,
-                        type);
+                        type, null);
 
         AionTransaction tx2 = TxUtil.decode(tx.getEncoded());
 
@@ -78,7 +82,7 @@ public class AionTransactionTest {
                         data,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         long expected = 21000;
         for (byte b : data) {
@@ -103,7 +107,7 @@ public class AionTransactionTest {
                 data,
                 nrg,
                 nrgPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         long expected = 200000 + 21000;
         for (byte b : data) {
@@ -111,4 +115,84 @@ public class AionTransactionTest {
         }
         assertEquals(expected, TxUtil.calculateTransactionCost(tx));
     }
+    @Test
+    public void testBeaconHashPresent() {
+        byte[] nonce = RandomUtils.nextBytes(16);
+        AionAddress to = new AionAddress(RandomUtils.nextBytes(32));
+        byte[] value = RandomUtils.nextBytes(16);
+        byte[] data = RandomUtils.nextBytes(64);
+        long nrg = 0;
+        long nrgPrice = 0;
+        byte type = 0;
+        byte[] beaconHash = ByteUtil.hexStringToBytes(
+                "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe");
+
+        AionTransaction tx =
+                AionTransaction.create(
+                        key,
+                        nonce,
+                        to,
+                        value,
+                        data,
+                        nrg,
+                        nrgPrice,
+                        type,
+                        beaconHash);
+
+        assertArrayEquals(
+                "AionTransaction#getBeaconHash should equal the beacon hash provided in ctor",
+                beaconHash,
+                tx.getBeaconHash());
+
+        RLPList decoded = (RLPList) RLP.decode2(tx.getEncoded()).get(0);
+        assertEquals("wrong number of elements in RLP encoding of AionTransaction with beacon hash",
+                TxUtil.RLP_TX_BEACON_HASH,
+                decoded.size() - 1
+        );
+        assertArrayEquals(
+                "beacon hash given in AionTransaction ctor should be present in its RLP encoding",
+                decoded.get(TxUtil.RLP_TX_BEACON_HASH).getRLPData(),
+                beaconHash
+        );
+
+        AionTransaction tx2 = TxUtil.decode(tx.getEncoded());
+        assertNotNull(tx2);
+        assertTransactionEquals(tx, tx2);
+    }
+
+    @Test
+    public void testBeaconHashAbsent() {
+        byte[] nonce = RandomUtils.nextBytes(16);
+        AionAddress to = new AionAddress(RandomUtils.nextBytes(32));
+        byte[] value = RandomUtils.nextBytes(16);
+        byte[] data = RandomUtils.nextBytes(64);
+        long nrg = 0;
+        long nrgPrice = 0;
+        byte type = 0;
+
+        AionTransaction tx =
+                AionTransaction.create(
+                        key,
+                        nonce,
+                        to,
+                        value,
+                        data,
+                        nrg,
+                        nrgPrice,
+                        type,
+                        null);
+
+        assertNull("beacon hash should be null", tx.getBeaconHash());
+
+        RLPList decoded = (RLPList) RLP.decode2(tx.getEncoded()).get(0);
+        assertEquals("wrong number of elements in RLP encoding of AionTransaction without beacon hash",
+                TxUtil.RLP_TX_SIG,
+                decoded.size() - 1
+        );
+
+        AionTransaction tx2 = TxUtil.decode(tx.getEncoded());
+        assertNotNull(tx2);
+        assertTransactionEquals(tx, tx2);
+    }
+
 }

--- a/modAionImpl/test/org/aion/zero/impl/valid/BeaconHashValidatorTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/valid/BeaconHashValidatorTest.java
@@ -1,0 +1,476 @@
+package org.aion.zero.impl.valid;
+
+import org.aion.base.AionTransaction;
+import org.aion.mcf.blockchain.Block;
+import org.aion.types.AionAddress;
+import org.aion.util.bytes.ByteUtil;
+import org.aion.zero.impl.blockchain.IAionBlockchain;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BeaconHashValidatorTest {
+    @Test
+    public void validateTxForBlockOnMainchainAndBeaconHashOnMainchain() {
+        long fork050Number = 7;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        byte[] goodBlockHash = ByteUtil.hexStringToBytes("0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe");
+        when(blockchain.isMainChain(goodBlockHash)).thenReturn(true);
+
+        Block block = mock(Block.class);
+        byte[] blockParent = ByteUtil.hexStringToBytes("0x1333333333333333333333333333333333333333333333333333333333333337");
+        when(block.getParentHash()).thenReturn(blockParent);
+        when(blockchain.isMainChain(blockParent)).thenReturn(true);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                goodBlockHash                               // beacon hash - exists in blockstore
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+
+        when(block.getNumber()).thenReturn(fork050Number - 1);
+        assertWithMessage("any beacon hash should fail if block_number < fork050_number")
+                .that(unit.validateTxForBlock(tx, block))
+                .isFalse();
+        when(block.getNumber()).thenReturn(fork050Number);
+        assertWithMessage("beacon hash on chain of new block should pass if block_number = fork050_number")
+                .that(unit.validateTxForBlock(tx, block))
+                .isTrue();
+        when(block.getNumber()).thenReturn(fork050Number + 1);
+        assertWithMessage("beacon hash on chain of new block should pass if block_number > fork050_number")
+                .that(unit.validateTxForBlock(tx, block))
+                .isTrue();
+    }
+
+    @Test
+    public void validateTxForBlockOnMainchainAndBeaconHashNotOnMainchain() {
+        long fork050Number = 13;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        byte[] nonExistentBlockhash = ByteUtil.hexStringToBytes("0xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad0");
+        when(blockchain.isMainChain(nonExistentBlockhash)).thenReturn(false);
+
+        Block block = mock(Block.class);
+        byte[] blockParent = ByteUtil.hexStringToBytes("0x1333333333333333333333333333333333333333333333333333333333333337");
+        when(block.getParentHash()).thenReturn(blockParent);
+        when(blockchain.isMainChain(blockParent)).thenReturn(true);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                nonExistentBlockhash                        // beacon hash - does not exist in blockstore
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+
+        when(block.getNumber()).thenReturn(fork050Number - 1);
+        assertWithMessage("any beacon hash should fail if block_number < fork050_number")
+                .that(unit.validateTxForBlock(tx, block))
+                .isFalse();
+        when(block.getNumber()).thenReturn(fork050Number);
+        assertWithMessage("beacon hash not on chain of new block should fail if block_number = fork050_number")
+                .that(unit.validateTxForBlock(tx, block))
+                .isFalse();
+        when(block.getNumber()).thenReturn(fork050Number + 1);
+        assertWithMessage("beacon hash not on chain of new block should fail if block_number > fork050_number")
+                .that(unit.validateTxForBlock(tx, block))
+                .isFalse();
+    }
+
+    @Test
+    public void validateTxForBlockOnMainchainAndBeaconHashNotGiven() {
+        long fork050Number = 2;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        Block block = mock(Block.class);
+        byte[] blockParent = ByteUtil.hexStringToBytes("0x1333333333333333333333333333333333333333333333333333333333333337");
+        when(block.getParentHash()).thenReturn(blockParent);
+        when(blockchain.isMainChain(blockParent)).thenReturn(true);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                null                                        // beacon hash - not present
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+
+        when(block.getNumber()).thenReturn(fork050Number - 1);
+        assertWithMessage("validation should pass if beacon hash not present")
+                .that(unit.validateTxForBlock(tx, block))
+                .isTrue();
+        when(block.getNumber()).thenReturn(fork050Number);
+        assertWithMessage("validation should pass if beacon hash not present")
+                .that(unit.validateTxForBlock(tx, block))
+                .isTrue();
+        when(block.getNumber()).thenReturn(fork050Number + 1);
+        assertWithMessage("validation should pass if beacon hash not present")
+                .that(unit.validateTxForBlock(tx, block))
+                .isTrue();
+    }
+
+    @Test
+    public void validateTxForBlockOnSidechainAndBeaconHashOnSideChain() {
+        /*
+         * Visualization of this case (x is the block of beacon hash , * is the new block):
+         *
+         *   o--o--o---o--o     main chain
+         *         |
+         *          \--x--o--*  side chain
+         */
+        long fork050Number = 5;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        LinkedList<Block> sideChain = mockChain(fork050Number, 4, blockchain);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                sideChain.get(3).getHash()                  // beacon hash
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+        assertWithMessage("beacon hash on chain of new block should pass if block_number = fork050_number")
+                .that(unit.validateTxForBlock(tx, sideChain.get(0)))
+                .isTrue();
+        // not doing all the "if new block > fork050" and "new block < fork050" cases
+        // for the side chain test cases because those paths already checked by the
+        // mainchain tests
+    }
+
+    @Test
+    public void validateTxForBlockOnSidechainAndBeaconHashOnMainchainBeforeSidechainFork() {
+        /*
+         * Visualization of this case (x is the block of beacon hash , * is the new block):
+         *
+         *   o--x--o---o--o     main chain
+         *         |
+         *          \--o--o--*  side chain
+         */
+        long fork050Number = 0;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        LinkedList<Block> sideChain = mockChain(0, 5, blockchain);
+        when(blockchain.isMainChain(sideChain.get(2).getHash(), sideChain.get(2).getNumber())).thenReturn(true);
+        when(blockchain.isMainChain(sideChain.get(4).getHash())).thenReturn(true);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                sideChain.get(4).getHash()                  // beacon hash
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+        assertWithMessage("beacon hash on chain of new block should pass if block_number = fork050_number")
+                .that(unit.validateTxForBlock(tx, sideChain.get(0)))
+                .isTrue();
+        // not doing all the "if new block > fork050" and "new block < fork050" cases
+        // for the side chain test cases because those paths already checked by the
+        // mainchain tests
+    }
+
+    @Test
+    public void validateTxForBlockOnSidechainAndBeaconHashOnMainchainAfterSidechainFork() {
+        /*
+         * Visualization of this case (x is the block of beacon hash , * is the new block):
+         *
+         *   o--o--o---x--o     main chain
+         *         |
+         *          \--o--o--*  side chain
+         */
+        long fork050Number = 0;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        // mocking up a block as if it were on the main chain but not the sidechain
+        Block mainchainOnlyBlock = mock(Block.class);
+        long mainchainOnlyBlockNum = 3l;
+        byte[] mainchainOnlyBlockHash = ByteUtil.hexStringToBytes(
+                "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe");
+        when(mainchainOnlyBlock.getNumber()).thenReturn(mainchainOnlyBlockNum);
+        when(blockchain.isMainChain(mainchainOnlyBlockHash)).thenReturn(true);
+        when(blockchain.getBlockByHash(mainchainOnlyBlockHash)).thenReturn(mainchainOnlyBlock);
+
+        // need to set up the side chain so that its head block number is > mainchainOnlyBlockNum
+        LinkedList<Block> sideChain = mockChain(0, 4, blockchain);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                mainchainOnlyBlockHash                      // beacon hash
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+        assertWithMessage("beacon hash not on chain of new block should fail if block_number = fork050_number")
+                .that(unit.validateTxForBlock(tx, sideChain.get(0)))
+                .isFalse();
+        // not doing all the "if new block > fork050" and "new block < fork050" cases
+        // for the side chain test cases because those paths already checked by the
+        // mainchain tests
+    }
+
+    @Test
+    public void validateTxForBlockOnSidechainAndBeaconHashNotInDb() {
+        /*
+         * Visualization of this case (beacon hash not in any chain, * is the new block):
+         *
+         *   o--o--o---o--o     main chain
+         *         |
+         *          \--o--o--*  side chain
+         */
+        long fork050Number = 0;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        byte[] nonExistentBlockhash = ByteUtil.hexStringToBytes(
+                "0xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad0");
+
+        LinkedList<Block> sideChain = mockChain(0, 4, blockchain);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                nonExistentBlockhash                        // beacon hash
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+        assertWithMessage("beacon hash not on chain of new block should fail if block_number = fork050_number")
+                .that(unit.validateTxForBlock(tx, sideChain.get(0)))
+                .isFalse();
+    }
+
+    @Test
+    public void validateTxForPendingStateWhenBeaconHashOnMainchain() {
+        long fork050Number = 7;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+        Block bestBlock = mock(Block.class);
+
+        byte[] goodBlockHash = ByteUtil.hexStringToBytes(
+                "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe");
+        when(blockchain.isMainChain(goodBlockHash)).thenReturn(true);
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                goodBlockHash                               // beacon hash - exists in blockstore
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+
+        when(bestBlock.getNumber()).thenReturn(fork050Number - 2);
+        assertWithMessage("any beacon hash should fail for pending state if best_block_number+1 < fork050_number")
+                .that(unit.validateTxForPendingState(tx))
+                .isFalse();
+        when(bestBlock.getNumber()).thenReturn(fork050Number - 1);
+        assertWithMessage("mainchain hash should pass for pending state if best_block_number+1 = fork050_number")
+                .that(unit.validateTxForPendingState(tx))
+                .isTrue();
+        when(bestBlock.getNumber()).thenReturn(fork050Number);
+        assertWithMessage("mainchain hash should pass for pending state if best_block_number+1 > fork050_number")
+                .that(unit.validateTxForPendingState(tx))
+                .isTrue();
+    }
+
+    @Test
+    public void validateTxForPendingStateWhenBeaconHashNotOnMainchain() {
+        long fork050Number = 3;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+        Block bestBlock = mock(Block.class);
+
+        byte[] badBlockhash = ByteUtil.hexStringToBytes(
+                "0xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad0");
+        when(blockchain.isMainChain(badBlockhash)).thenReturn(false);
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                badBlockhash                                // beacon hash - does not exist in blockstore
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+
+        when(bestBlock.getNumber()).thenReturn(fork050Number - 2);
+        assertWithMessage("any beacon hash should fail for pending state if best_block_number+1 < fork050_number")
+                .that(unit.validateTxForPendingState(tx))
+                .isFalse();
+        when(bestBlock.getNumber()).thenReturn(fork050Number - 1);
+        assertWithMessage("non-mainchain hash validation should fail for pending state if best_block_number+1 = fork050_number")
+                .that(unit.validateTxForPendingState(tx))
+                .isFalse();
+        when(bestBlock.getNumber()).thenReturn(fork050Number);
+        assertWithMessage("non-mainchain hash validation should fail for pending state if best_block_number+1 > fork050_number")
+                .that(unit.validateTxForPendingState(tx))
+                .isFalse();
+    }
+
+    @Test
+    public void validateTxForPendingStateWithoutBeaconHash() {
+        long fork050Number = 3;
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+        Block bestBlock = mock(Block.class);
+
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
+
+        AionTransaction tx = AionTransaction.createWithoutKey(
+                new byte[] { 1 },                           // nonce - any val
+                new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
+                        "0xa000000000000000000000000000000000000000000000000000000000000000")),
+                new AionAddress(ByteUtil.hexStringToBytes(  // destination - any val
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                new byte[] { 1 },                           // value - any val
+                new byte[] { },                             // data - any val
+                1l,                                         // energyLimit - any val
+                1l,                                         // energyPrice - any val
+                (byte) 1,                                   // type - any val
+                null                                        // beacon hash - absent
+        );
+
+        BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
+
+        when(bestBlock.getNumber()).thenReturn(fork050Number - 2);
+        assertWithMessage("validation should pass for pending state if beacon hash absent")
+                .that(unit.validateTxForPendingState(tx))
+                .isTrue();
+        when(bestBlock.getNumber()).thenReturn(fork050Number - 1);
+        assertWithMessage("validation should pass for pending state if beacon hash absent")
+                .that(unit.validateTxForPendingState(tx))
+                .isTrue();
+        when(bestBlock.getNumber()).thenReturn(fork050Number);
+        assertWithMessage("validation should pass for pending state if beacon hash absent")
+                .that(unit.validateTxForPendingState(tx))
+                .isTrue();
+    }
+
+    @Test
+    public void isAfterFork050AllCombinations() {
+        IAionBlockchain blockchain = mock(IAionBlockchain.class);
+
+        assertWithMessage("isAfterFork050 should always be false if fork 0.5.0 disabled")
+                .that(new BeaconHashValidator(blockchain, BeaconHashValidator.FORK_050_DISABLED)
+                        .isAfterFork050(312l))
+                .isFalse();
+        assertWithMessage("isAfterFork050 should always be false if fork 0.5.0 disabled")
+                .that(new BeaconHashValidator(blockchain, BeaconHashValidator.FORK_050_DISABLED)
+                        .isAfterFork050(BeaconHashValidator.FORK_050_DISABLED))
+                .isFalse();
+        assertWithMessage("isAfterFork050 should be false if block_number < fork050_number")
+                .that(new BeaconHashValidator(blockchain, 1337)
+                        .isAfterFork050(1336))
+                .isFalse();
+        assertWithMessage("isAfterFork050 should be true if block_number = fork050_number")
+                .that(new BeaconHashValidator(blockchain, 1337)
+                        .isAfterFork050(1337))
+                .isTrue();
+        assertWithMessage("isAfterFork050 should be true if block_number > fork050_number")
+                .that(new BeaconHashValidator(blockchain, 1337)
+                        .isAfterFork050(1338))
+                .isTrue();
+    }
+
+    /**
+     * Create mocks of {@link Block}s that behave as if they were one chain (i.e one
+     * is the parent of the preceding one); set up the given mockBlockchain to behave
+     * as if those blocks are in the blockchain.
+     *
+     * @return mocked blocks that form a chain with the head as first element */
+    private static LinkedList<Block> mockChain(long initialNumber,
+                                               int howMany,
+                                               IAionBlockchain mockBlockchain) {
+        LinkedList<Block> ret = new LinkedList<>();
+        byte[] lastHash = null;
+
+        for(long ix = initialNumber; ix < initialNumber + howMany; ++ix) {
+            Block block = mock(Block.class);
+            byte[] hash = ByteUtil.hexStringToBytes(String.format("0x%064x", ix));
+            when(mockBlockchain.getBlockByHash(hash)).thenReturn(block);
+            when(block.getNumber()).thenReturn((long)ix);
+            when(block.getHash()).thenReturn(hash);
+            when(block.getParentHash()).thenReturn(lastHash);
+
+            lastHash = hash;
+            ret.push(block);
+        }
+
+        return ret;
+    }
+}

--- a/modAionImpl/test/org/aion/zero/impl/vm/AlternatingVmBlockTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/AlternatingVmBlockTest.java
@@ -173,7 +173,7 @@ public class AlternatingVmBlockTest {
                 jar,
                 5_000_000,
                 1,
-                TransactionTypes.AVM_CREATE_CODE);
+                TransactionTypes.AVM_CREATE_CODE, null);
     }
 
     private byte[] getJarBytes() {
@@ -194,7 +194,7 @@ public class AlternatingVmBlockTest {
                 contractBytes,
                 5_000_000,
                 1,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private long getAvmContractDeploymentCost(BigInteger nonce) {

--- a/modAionImpl/test/org/aion/zero/impl/vm/AvmBulkTransactionTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/AvmBulkTransactionTest.java
@@ -99,7 +99,7 @@ public class AvmBulkTransactionTest {
                         new byte[0],
                         5_000_000L,
                         10_123_456_789L,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         Block parentBlock = blockchain.getBestBlock();
         AionBlock block =
@@ -202,7 +202,7 @@ public class AvmBulkTransactionTest {
                         ByteUtil.hexStringToBytes(contractCode),
                         5_000_000L,
                         energyPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionAddress fvmContract = TxUtil.calculateContractAddress(deployTxFVM);
         transactions.add(deployTxFVM);
@@ -224,7 +224,7 @@ public class AvmBulkTransactionTest {
                         Hex.decode("62eb702a00000000000000000000000000000006"),
                         2_000_000L,
                         energyPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         transactions.add(contractCallTx);
         expectedNonce = expectedNonce.add(BigInteger.ONE);
 
@@ -403,7 +403,7 @@ public class AvmBulkTransactionTest {
                 jar,
                 5_000_000,
                 this.energyPrice,
-                TransactionTypes.AVM_CREATE_CODE);
+                TransactionTypes.AVM_CREATE_CODE, null);
     }
 
     private AionTransaction makeAvmContractCallTransaction(
@@ -416,7 +416,7 @@ public class AvmBulkTransactionTest {
                 abiEncodeMethodCall("incrementCounter"),
                 2_000_000,
                 this.energyPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private AionTransaction makeValueTransferTransaction(
@@ -430,7 +430,7 @@ public class AvmBulkTransactionTest {
                 new byte[0],
                 2_000_000,
                 this.energyPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private int getDeployedStatefulnessCountValue(
@@ -445,7 +445,7 @@ public class AvmBulkTransactionTest {
                         abiEncodeMethodCall("getCount"),
                         2_000_000,
                         this.energyPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlockSummary summary =
                 sendTransactionsInBulkInSingleBlock(Collections.singletonList(transaction));

--- a/modAionImpl/test/org/aion/zero/impl/vm/AvmHelloWorldTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/AvmHelloWorldTest.java
@@ -76,7 +76,7 @@ public class AvmHelloWorldTest {
                         jar,
                         5_000_000,
                         1,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         AionBlock block =
                 this.blockchain.createNewBlock(
@@ -111,7 +111,7 @@ public class AvmHelloWorldTest {
                         jar,
                         5_000_000,
                         1,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         AionBlock block =
                 this.blockchain.createNewBlock(
@@ -140,7 +140,7 @@ public class AvmHelloWorldTest {
                         call,
                         2_000_000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         block =
                 this.blockchain.createNewBlock(
@@ -169,7 +169,7 @@ public class AvmHelloWorldTest {
                         jar,
                         5_000_000,
                         1,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         List<AionTransaction> ls = new ArrayList<>();
         ls.add(transaction);
@@ -184,7 +184,7 @@ public class AvmHelloWorldTest {
                         call,
                         2_000_000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         ls.add(transaction2);
 

--- a/modAionImpl/test/org/aion/zero/impl/vm/AvmInternalTxTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/AvmInternalTxTest.java
@@ -75,7 +75,7 @@ public class AvmInternalTxTest {
                         jar,
                         5_000_000,
                         1,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         AionBlock block =
                 this.blockchain.createNewBlock(
@@ -116,7 +116,7 @@ public class AvmInternalTxTest {
                         call,
                         2_000_000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block =
                 this.blockchain.createNewBlock(

--- a/modAionImpl/test/org/aion/zero/impl/vm/AvmLogAndInternalTransactionTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/AvmLogAndInternalTransactionTest.java
@@ -125,7 +125,7 @@ public class AvmLogAndInternalTransactionTest {
                         data,
                         2_000_000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block =
                 this.blockchain.createBlock(
@@ -148,7 +148,7 @@ public class AvmLogAndInternalTransactionTest {
                         jar,
                         5_000_000,
                         1,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         AionBlock block =
                 this.blockchain.createBlock(

--- a/modAionImpl/test/org/aion/zero/impl/vm/Benchmark.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/Benchmark.java
@@ -105,7 +105,7 @@ public class Benchmark {
                 deployer,
                 nrg,
                 nrgPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         // save contract address
         contract = TxUtil.calculateContractAddress(tx);
@@ -147,7 +147,7 @@ public class Benchmark {
                     data,
                     nrg,
                     nrgPrice,
-                    TransactionTypes.DEFAULT);
+                    TransactionTypes.DEFAULT, null);
 
             list.add(tx);
         }
@@ -231,7 +231,7 @@ public class Benchmark {
                     data,
                     nrg,
                     nrgPrice,
-                    TransactionTypes.DEFAULT);
+                    TransactionTypes.DEFAULT, null);
 
             AionTxExecSummary summary = executeTransaction(tx);
             assertFalse(summary.isFailed());

--- a/modAionImpl/test/org/aion/zero/impl/vm/ContractIntegTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/ContractIntegTest.java
@@ -161,7 +161,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -226,7 +226,7 @@ public class ContractIntegTest {
                         new byte[0],
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -277,7 +277,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -327,7 +327,7 @@ public class ContractIntegTest {
                         new byte[0],
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -376,7 +376,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -426,7 +426,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -477,7 +477,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -528,7 +528,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
 
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
@@ -547,7 +547,7 @@ public class ContractIntegTest {
                             Hex.decode(getMsgFunctionHash),
                             nrg,
                             nrgPrice,
-                            txType);
+                            txType, null);
             assertFalse(tx.isContractCreationTransaction());
 
             AionBlock block = makeBlock(tx);
@@ -580,7 +580,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -604,7 +604,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -630,7 +630,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertFalse(tx.isContractCreationTransaction());
 
         block = makeBlock(tx);
@@ -661,7 +661,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -687,7 +687,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -720,7 +720,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -744,7 +744,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -776,7 +776,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -805,7 +805,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -839,7 +839,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -867,7 +867,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -902,7 +902,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress multiFeatureContract =
@@ -929,7 +929,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         nonce = nonce.add(BigInteger.ONE);
         AionAddress callerContract =
                 deployContract(repo, tx, contractName, null, value, nrg, nrgPrice, nonce);
@@ -948,7 +948,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -980,7 +980,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         block = makeBlock(tx);
@@ -1012,7 +1012,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -1040,7 +1040,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -1073,7 +1073,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         block = makeBlock(tx);
@@ -1152,7 +1152,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
 
         // Mock up the repo so that the contract address already exists.
         AionRepositoryCache repo = mock(AionRepositoryCache.class);
@@ -1201,7 +1201,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -1222,7 +1222,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         BigInteger senderBalance = repo.getBalance(deployer);
@@ -1260,7 +1260,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         repo = blockchain.getRepository().startTracking();
@@ -1300,7 +1300,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
 
@@ -1323,7 +1323,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx2.isContractCreationTransaction());
         ls.add(tx2);
 
@@ -1374,7 +1374,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         RepositoryCache repo = blockchain.getRepository().startTracking();
         nonce = nonce.add(BigInteger.ONE);
         AionAddress contract =
@@ -1398,7 +1398,7 @@ public class ContractIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -1437,7 +1437,7 @@ public class ContractIntegTest {
                         new byte[0],
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -1471,7 +1471,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -1520,7 +1520,7 @@ public class ContractIntegTest {
                         new byte[0],
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -1554,7 +1554,7 @@ public class ContractIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        txType);
+                        txType, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -1610,7 +1610,7 @@ public class ContractIntegTest {
                         new byte[0],
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertFalse(tx.isContractCreationTransaction());
 
         AionBlock block = makeBlock(tx);
@@ -1653,7 +1653,7 @@ public class ContractIntegTest {
                         call,
                         2_000_000,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         block =
                 this.blockchain.createNewBlock(
@@ -1972,7 +1972,7 @@ public class ContractIntegTest {
                         jar,
                         5_000_000L,
                         1,
-                        TransactionTypes.AVM_CREATE_CODE);
+                        TransactionTypes.AVM_CREATE_CODE, null);
 
         AionBlock block =
                 this.blockchain.createNewBlock(

--- a/modAionImpl/test/org/aion/zero/impl/vm/FvmBulkTransactionTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/FvmBulkTransactionTest.java
@@ -155,7 +155,7 @@ public class FvmBulkTransactionTest {
                 contractBytes,
                 5_000_000,
                 this.energyPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private AionTransaction makeFvmContractCallTransaction(
@@ -172,7 +172,7 @@ public class FvmBulkTransactionTest {
                 callBytes,
                 2_000_000,
                 this.energyPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private int getDeployedTickerCountValue(ECKey sender, BigInteger nonce, AionAddress contract) {
@@ -189,7 +189,7 @@ public class FvmBulkTransactionTest {
                         callBytes,
                         2_000_000,
                         this.energyPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlockSummary summary =
                 sendTransactionsInBulkInSingleBlock(Collections.singletonList(transaction));

--- a/modAionImpl/test/org/aion/zero/impl/vm/FvmExploitsTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/FvmExploitsTest.java
@@ -48,7 +48,7 @@ public class FvmExploitsTest {
                 ByteUtil.hexStringToBytes(testerByteCode),
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
         assertThat(tx.isContractCreationTransaction()).isTrue();
 
         BlockContext context =
@@ -77,7 +77,7 @@ public class FvmExploitsTest {
                 funcSig,
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         BlockContext context2 =
             bc.createNewBlockContext(
@@ -104,7 +104,7 @@ public class FvmExploitsTest {
                 funcSig,
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
         BlockContext context3 =
             bc.createNewBlockContext(
                 bc.getBestBlock(), Collections.singletonList(anotherMakeTestCall), false);
@@ -146,7 +146,7 @@ public class FvmExploitsTest {
                 ByteUtil.hexStringToBytes(testerByteCode),
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertThat(tx.isContractCreationTransaction()).isTrue();
 
@@ -170,7 +170,7 @@ public class FvmExploitsTest {
                 new byte[0],
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         BlockContext context2 =
             bc.createNewBlockContext(bc.getBestBlock(), Collections.singletonList(tx2), false);
@@ -224,7 +224,7 @@ public class FvmExploitsTest {
                 ByteUtil.hexStringToBytes(testerByteCode),
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         assertThat(tx.isContractCreationTransaction()).isTrue();
 
@@ -248,7 +248,7 @@ public class FvmExploitsTest {
                 ByteUtil.hexStringToBytes("0xe61a60bb"), // getEleven()
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         BlockContext context2 =
             bc.createNewBlockContext(bc.getBestBlock(), Collections.singletonList(tx2), false);
@@ -277,7 +277,7 @@ public class FvmExploitsTest {
                         deployerAccount.getAddress())), // addUser(address)
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         BlockContext context3 =
             bc.createNewBlockContext(bc.getBestBlock(), Collections.singletonList(tx3), false);
@@ -304,7 +304,7 @@ public class FvmExploitsTest {
                 ByteUtil.hexStringToBytes("0xe61a60bb"), // getEleven()
                 1_000_000L,
                 1L,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         BlockContext context4 =
             bc.createNewBlockContext(bc.getBestBlock(), Collections.singletonList(tx4), false);

--- a/modAionImpl/test/org/aion/zero/impl/vm/InternalTransactionTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/InternalTransactionTest.java
@@ -120,7 +120,7 @@ public class InternalTransactionTest {
                         ByteUtil.hexStringToBytes(contractA),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         nonce = nonce.add(BigInteger.ONE);
         AionTransaction tx2 =
@@ -132,7 +132,7 @@ public class InternalTransactionTest {
                         ByteUtil.hexStringToBytes(contractB),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 bc.createNewBlockContext(bc.getBestBlock(), List.of(tx1, tx2), false);
@@ -158,7 +158,7 @@ public class InternalTransactionTest {
                         ByteUtil.hexStringToBytes("0x26121ff0"),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         context = bc.createNewBlockContext(bc.getBestBlock(), List.of(tx3), false);
         result = bc.tryToConnect(context.block);
@@ -185,7 +185,7 @@ public class InternalTransactionTest {
                                 new DataWord(80_000).getData()),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         context = bc.createNewBlockContext(bc.getBestBlock(), List.of(tx4), false);
         result = bc.tryToConnect(context.block);
@@ -213,7 +213,7 @@ public class InternalTransactionTest {
                                 new DataWord(20_000).getData()),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         context = bc.createNewBlockContext(bc.getBestBlock(), List.of(tx6), false);
         result = bc.tryToConnect(context.block);
@@ -263,7 +263,7 @@ public class InternalTransactionTest {
                         ByteUtil.hexStringToBytes(contractA),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context = bc.createNewBlockContext(bc.getBestBlock(), List.of(tx1), false);
         ImportResult result = bc.tryToConnect(context.block);
@@ -288,7 +288,7 @@ public class InternalTransactionTest {
                                 new DataWord(2).getData()),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         context = bc.createNewBlockContext(bc.getBestBlock(), List.of(tx2), false);
         AionTxExecSummary summary = executeTransaction(bc, context, tx2);
@@ -336,7 +336,7 @@ public class InternalTransactionTest {
                         ByteUtil.hexStringToBytes(contractA),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context = bc.createNewBlockContext(bc.getBestBlock(), List.of(tx1), false);
         AionTxExecSummary summary = executeTransaction(bc, context, tx1);
@@ -383,7 +383,7 @@ public class InternalTransactionTest {
                         new byte[0],
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block parentBlock = bc.getBestBlock();
 
@@ -411,7 +411,7 @@ public class InternalTransactionTest {
                         ByteUtil.hexStringToBytes(contractA),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         parentBlock = bc.getBestBlock();
         newBlock =
@@ -438,7 +438,7 @@ public class InternalTransactionTest {
                         ByteUtil.hexStringToBytes(contractA),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         System.out.println("contractaddr: " + TxUtil.calculateContractAddress(tx));
 

--- a/modAionImpl/test/org/aion/zero/impl/vm/InvalidBlockTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/InvalidBlockTest.java
@@ -105,7 +105,7 @@ public class InvalidBlockTest {
                             jar,
                             5_000_000L,
                             10_000_000_000L,
-                            TransactionTypes.AVM_CREATE_CODE);
+                            TransactionTypes.AVM_CREATE_CODE, null);
 
             transactions.add(transaction);
             nonce = nonce.add(BigInteger.ONE);

--- a/modAionImpl/test/org/aion/zero/impl/vm/OldTxExecutorTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/OldTxExecutorTest.java
@@ -131,7 +131,7 @@ public class OldTxExecutorTest {
                 data,
                 nrg,
                 nrgPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionBlock block = createDummyBlock();
 
@@ -177,7 +177,7 @@ public class OldTxExecutorTest {
                 data,
                 nrg,
                 nrgPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
 
         AionBlock block = createDummyBlock();
 
@@ -221,7 +221,7 @@ public class OldTxExecutorTest {
                         data,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block = createDummyBlock();
 
@@ -264,7 +264,7 @@ public class OldTxExecutorTest {
                         data,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         AionBlock block = createDummyBlock();
 

--- a/modAionImpl/test/org/aion/zero/impl/vm/OpcodeIntegTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/OpcodeIntegTest.java
@@ -113,7 +113,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 blockchain.createNewBlockContext(
@@ -158,7 +158,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 blockchain.createNewBlockContext(
@@ -199,7 +199,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 blockchain.createNewBlockContext(
@@ -249,7 +249,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -272,7 +272,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -295,7 +295,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(E, tx.getDestinationAddress());
 
@@ -331,7 +331,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -377,7 +377,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -423,7 +423,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -446,7 +446,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -468,7 +468,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(E, tx.getDestinationAddress());
 
@@ -504,7 +504,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -552,7 +552,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertEquals(deployer, tx.getSenderAddress());
         assertEquals(D, tx.getDestinationAddress());
 
@@ -596,7 +596,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 blockchain.createNewBlockContext(
@@ -647,7 +647,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 blockchain.createNewBlockContext(
@@ -693,7 +693,7 @@ public class OpcodeIntegTest {
                         input,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 blockchain.createNewBlockContext(
@@ -737,7 +737,7 @@ public class OpcodeIntegTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         AionAddress contract =
                 deployContract(
                         repo, tx, contractName, contractFilename, value, nrg, nrgPrice, nonce);

--- a/modAionImpl/test/org/aion/zero/impl/vm/SolidityTypeTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/SolidityTypeTest.java
@@ -108,7 +108,7 @@ public class SolidityTypeTest {
                 callData,
                 nrg,
                 nrgPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private RepositoryCache createRepository(AionTransaction tx) throws IOException {

--- a/modAionImpl/test/org/aion/zero/impl/vm/StatefulnessTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/StatefulnessTest.java
@@ -217,7 +217,7 @@ public class StatefulnessTest {
                         jar,
                         5_000_000,
                         this.energyPrice,
-                        txType);
+                        txType, null);
 
         return sendTransactions(transaction);
     }
@@ -232,7 +232,7 @@ public class StatefulnessTest {
                         abiEncodeMethodCall(method, arguments),
                         2_000_000,
                         this.energyPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         return sendTransactions(transaction);
     }
@@ -247,7 +247,7 @@ public class StatefulnessTest {
                         new byte[0],
                         2_000_000,
                         this.energyPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         return sendTransactions(transaction);
     }

--- a/modAionImpl/test/org/aion/zero/impl/vm/TransactionExecutorTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/TransactionExecutorTest.java
@@ -104,7 +104,7 @@ public class TransactionExecutorTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertTrue(tx.isContractCreationTransaction());
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
         assertEquals(BigInteger.ZERO, blockchain.getRepository().getNonce(deployer));
@@ -154,7 +154,7 @@ public class TransactionExecutorTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));
@@ -201,7 +201,7 @@ public class TransactionExecutorTest {
                         callingCode,
                         1_000_000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertFalse(tx.isContractCreationTransaction());
 
         BlockContext context =
@@ -231,7 +231,7 @@ public class TransactionExecutorTest {
                         callingCode,
                         1_000_000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertFalse(tx.isContractCreationTransaction());
 
         context =
@@ -282,7 +282,7 @@ public class TransactionExecutorTest {
                         callingCode,
                         1_000_000,
                         1,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertFalse(tx.isContractCreationTransaction());
 
         BlockContext context =
@@ -318,7 +318,7 @@ public class TransactionExecutorTest {
                         deployCode,
                         nrg,
                         nrgPrice,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         assertTrue(tx.isContractCreationTransaction());
 
         assertEquals(Builder.DEFAULT_BALANCE, blockchain.getRepository().getBalance(deployer));

--- a/modAionImpl/test/org/aion/zero/impl/vm/VMTxStateAlignTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/vm/VMTxStateAlignTest.java
@@ -122,7 +122,7 @@ public class VMTxStateAlignTest {
                 new byte[10],
                 2_000_000,
                 this.energyPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     // Deploys the Ticker.sol contract.
@@ -138,7 +138,7 @@ public class VMTxStateAlignTest {
                 contractBytes,
                 5_000_000,
                 this.energyPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private AionTransaction makeFvmContractCallTransaction(
@@ -155,7 +155,7 @@ public class VMTxStateAlignTest {
                 callBytes,
                 2_000_000,
                 this.energyPrice,
-                TransactionTypes.DEFAULT);
+                TransactionTypes.DEFAULT, null);
     }
 
     private AionBlock genNewBlock(List<AionTransaction> transactions, StandaloneBlockchain bc) {

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -595,7 +595,8 @@ public abstract class ApiAion extends Api {
                                 _params.getData(),
                                 _params.getNrg(),
                                 _params.getNrgPrice(),
-                                _params.getType(), null);
+                                _params.getType(),
+                                _params.getBeaconHash());
 
                 return (new ApiTxResponse(
                         pendingState.addPendingTransaction(tx), tx.getTransactionHash()));

--- a/modApiServer/src/org/aion/api/server/ApiAion.java
+++ b/modApiServer/src/org/aion/api/server/ApiAion.java
@@ -464,7 +464,7 @@ public abstract class ApiAion extends Api {
                         _params.getData(),
                         _params.getNrg(),
                         _params.getNrgPrice(),
-                        _params.getType());
+                        _params.getType(), null);
         AionTxReceipt rec =
                 this.ac.callConstant(tx, this.ac.getAionHub().getBlockchain().getBestBlock());
         return rec.getTransactionOutput();
@@ -482,7 +482,7 @@ public abstract class ApiAion extends Api {
                         params.getData(),
                         params.getNrg(),
                         params.getNrgPrice(),
-                        params.getType());
+                        params.getType(), null);
 
         AionTxReceipt receipt =
                 this.ac.callConstant(tx, this.ac.getAionHub().getBlockchain().getBestBlock());
@@ -527,7 +527,7 @@ public abstract class ApiAion extends Api {
                                 _params.getData(),
                                 _params.getNrg(),
                                 _params.getNrgPrice(),
-                                _params.getType());
+                                _params.getType(), null);
 
                 TxResponse rsp = pendingState.addPendingTransaction(tx);
 
@@ -595,7 +595,7 @@ public abstract class ApiAion extends Api {
                                 _params.getData(),
                                 _params.getNrg(),
                                 _params.getNrgPrice(),
-                                _params.getType());
+                                _params.getType(), null);
 
                 return (new ApiTxResponse(
                         pendingState.addPendingTransaction(tx), tx.getTransactionHash()));
@@ -657,7 +657,7 @@ public abstract class ApiAion extends Api {
                         _params.getData(),
                         _params.getNrg(),
                         _params.getNrgPrice(),
-                        _params.getType());
+                        _params.getType(), null);
             }
         } catch (Exception ex) {
             if (LOG.isDebugEnabled()) {

--- a/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
+++ b/modApiServer/src/org/aion/api/server/pb/ApiAion0.java
@@ -424,7 +424,8 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                         BigInteger.ZERO,
                                         BigInteger.ZERO,
                                         req.getNrgLimit(),
-                                        req.getNrgPrice());
+                                        req.getNrgPrice(),
+                                        null /* beacon hash */);
 
                         LOG.debug(
                                 "ApiAion0.process.ContractDeploy - ArgsTxCall: [{}] ",
@@ -790,7 +791,8 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                         new BigInteger(req.getNonce().toByteArray()),
                                         new BigInteger(req.getValue().toByteArray()),
                                         req.getNrg(),
-                                        req.getNrgPrice());
+                                        req.getNrgPrice(),
+                                        null /* beacon hash */);
 
                         result = this.sendTransaction(params);
                     } catch (InvalidProtocolBufferException e) {
@@ -945,7 +947,8 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                         BigInteger.ZERO,
                                         value,
                                         req.getNrg(),
-                                        req.getNrgPrice());
+                                        req.getNrgPrice(),
+                                        null /* beacon hash */);
                         Message.rsp_call rsp =
                                 Message.rsp_call
                                         .newBuilder()
@@ -1593,7 +1596,8 @@ public class ApiAion0 extends ApiAion implements IApiAion {
                                         BigInteger.ZERO,
                                         new BigInteger(req.getValue().toByteArray()),
                                         req.getNrg(),
-                                        req.getNrgPrice());
+                                        req.getNrgPrice(),
+                                        null /* beacon hash */);
 
                         result = this.estimateNrg(params);
                     } catch (InvalidProtocolBufferException e) {

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -825,7 +825,9 @@ public class ApiWeb3Aion extends ApiAion {
                         txParams.getData(),
                         txParams.getNrg(),
                         txParams.getNrgPrice(),
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT,
+                        null // TODO beacon hash goes here
+                        );
 
         AionTxReceipt receipt = this.ac.callConstant(tx, b);
 

--- a/modApiServer/src/org/aion/api/server/rpc/RpcError.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcError.java
@@ -41,7 +41,7 @@ public enum RpcError {
     // custom error codes
     UNAUTHORIZED(1, "Unauthorized"),
     NOT_ALLOWED(2, "Action not allowed"),
-    EXECUTION_ERROR(3, "Execution error");
+    EXECUTION_ERROR(3, "Execution error"),
 
     private final int code;
     private final String message;

--- a/modApiServer/src/org/aion/api/server/rpc/RpcError.java
+++ b/modApiServer/src/org/aion/api/server/rpc/RpcError.java
@@ -41,7 +41,7 @@ public enum RpcError {
     // custom error codes
     UNAUTHORIZED(1, "Unauthorized"),
     NOT_ALLOWED(2, "Action not allowed"),
-    EXECUTION_ERROR(3, "Execution error"),
+    EXECUTION_ERROR(3, "Execution error");
 
     private final int code;
     private final String message;

--- a/modApiServer/src/org/aion/api/server/rpc2/RpcImpl.java
+++ b/modApiServer/src/org/aion/api/server/rpc2/RpcImpl.java
@@ -73,7 +73,8 @@ public class RpcImpl implements Rpc {
                         var0.getData(),
                         CfgAion.inst().getApi().getNrg().getNrgPriceDefault(),
                         Long.MAX_VALUE,
-                        (byte)1
+                        (byte)1,
+                        null
                 );
         return AionImpl
                 .inst()

--- a/modApiServer/src/org/aion/api/server/types/ArgTxCall.java
+++ b/modApiServer/src/org/aion/api/server/types/ArgTxCall.java
@@ -25,11 +25,14 @@ public final class ArgTxCall {
     private final BigInteger value;
     private final long nrg;
     private final long nrgPrice;
+    private final byte[] beaconHash;
 
     protected static final Logger LOG = AionLoggerFactory.getLogger(LogEnum.API.name());
 
     // @Jay
     // TODO: create a builder class for create this class
+
+    // TODO: should store common field names in constants (AKI-372)
 
     public ArgTxCall(
             final AionAddress _from,
@@ -38,8 +41,9 @@ public final class ArgTxCall {
             final BigInteger _nonce,
             final BigInteger _value,
             final long _nrg,
-            final long _nrgPrice) {
-        this(_from, _to, _data, _nonce, _value, _nrg, _nrgPrice, TransactionTypes.DEFAULT);
+            final long _nrgPrice,
+            final byte[] beaconHash) {
+        this(_from, _to, _data, _nonce, _value, _nrg, _nrgPrice, TransactionTypes.DEFAULT, beaconHash);
     }
 
     public ArgTxCall(
@@ -50,7 +54,8 @@ public final class ArgTxCall {
             final BigInteger _value,
             final long _nrg,
             final long _nrgPrice,
-            final byte _type) {
+            final byte _type,
+            final byte[] beaconHash) {
         this.from = _from;
         this.to = _to;
         this.data = _data == null ? ByteUtil.EMPTY_BYTE_ARRAY : _data;
@@ -59,6 +64,7 @@ public final class ArgTxCall {
         this.nrg = _nrg;
         this.nrgPrice = _nrgPrice;
         this.type = _type;
+        this.beaconHash = beaconHash;
     }
 
     public static ArgTxCall fromJSON(final JSONObject _jsonObj, long defaultNrgPrice) {
@@ -118,7 +124,13 @@ public final class ArgTxCall {
                                 ? StringUtils.StringHexToBigInteger(nrgPriceStr).longValue()
                                 : StringUtils.StringNumberAsBigInt(nrgPriceStr).longValue();
 
-            return new ArgTxCall(from, to, data, nonce, value, nrg, nrgPrice, type);
+            byte[] beaconHash = null;
+            String maybeBeaconHash = _jsonObj.has("beaconHash") ? _jsonObj.getString("beaconHash") : null;
+            if(maybeBeaconHash != null) {
+                beaconHash = StringUtils.StringHexToByteArray(maybeBeaconHash);
+            }
+
+            return new ArgTxCall(from, to, data, nonce, value, nrg, nrgPrice, type, beaconHash);
         } catch (Exception e) {
             LOG.debug("Failed to parse transaction call object from input parameters", e);
             return null;
@@ -155,5 +167,9 @@ public final class ArgTxCall {
 
     public byte getType() {
         return type;
+    }
+
+    public byte[] getBeaconHash() {
+        return beaconHash;
     }
 }

--- a/modApiServer/test/org/aion/api/server/ApiAionTest.java
+++ b/modApiServer/test/org/aion/api/server/ApiAionTest.java
@@ -88,7 +88,7 @@ public class ApiAionTest {
                             new byte[0],
                             0L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             List<AionTransaction> l1 = new ArrayList<>();
             l1.add(tx);
             l1.add(tx);
@@ -287,7 +287,7 @@ public class ApiAionTest {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -353,7 +353,7 @@ public class ApiAionTest {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         ArgTxCall txcall =
                 new ArgTxCall(

--- a/modApiServer/test/org/aion/api/server/ApiAionTest.java
+++ b/modApiServer/test/org/aion/api/server/ApiAionTest.java
@@ -331,7 +331,8 @@ public class ApiAionTest {
                         repo.getNonce(addr),
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertNotNull(api.doCall(txcall));
     }
@@ -353,7 +354,8 @@ public class ApiAionTest {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT, null);
+                        TransactionTypes.DEFAULT,
+                        null);
 
         ArgTxCall txcall =
                 new ArgTxCall(
@@ -363,7 +365,8 @@ public class ApiAionTest {
                         repo.getNonce(addr),
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertEquals(impl.estimateTxNrg(tx, api.getBestBlock()), api.estimateNrg(txcall));
     }
@@ -388,7 +391,8 @@ public class ApiAionTest {
                         BigInteger.ONE,
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertEquals(api.createContract(txcall).getType(), TxResponse.INVALID_FROM);
 
@@ -400,7 +404,8 @@ public class ApiAionTest {
                         BigInteger.ONE,
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertEquals(api.createContract(txcall).getType(), TxResponse.INVALID_FROM);
 
@@ -416,7 +421,8 @@ public class ApiAionTest {
                         repo.getNonce(addr),
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertEquals(api.createContract(txcall).getType(), TxResponse.INVALID_ACCOUNT);
     }
@@ -457,7 +463,8 @@ public class ApiAionTest {
                         BigInteger.ONE,
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertEquals(api.sendTransaction(txcall).getType(), TxResponse.INVALID_FROM);
 
@@ -469,7 +476,8 @@ public class ApiAionTest {
                         BigInteger.ONE,
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertEquals(api.sendTransaction(txcall).getType(), TxResponse.INVALID_FROM);
 
@@ -485,7 +493,8 @@ public class ApiAionTest {
                         repo.getNonce(addr),
                         BigInteger.ONE,
                         100000,
-                        100000);
+                        100000,
+                        null);
 
         assertEquals(api.sendTransaction(txcall).getType(), TxResponse.INVALID_ACCOUNT);
     }

--- a/modApiServer/test/org/aion/api/server/TxRecptLgTest.java
+++ b/modApiServer/test/org/aion/api/server/TxRecptLgTest.java
@@ -73,7 +73,7 @@ public class TxRecptLgTest {
                         ByteUtil.hexStringToBytes(contractA),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         nonce = nonce.add(BigInteger.ONE);
         AionTransaction tx2 =
@@ -85,7 +85,7 @@ public class TxRecptLgTest {
                         ByteUtil.hexStringToBytes(contractB),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         BlockContext context =
                 bc.createNewBlockContext(bc.getBestBlock(), List.of(tx1, tx2), false);
@@ -113,7 +113,7 @@ public class TxRecptLgTest {
                         ByteUtil.merge(functionAA, addressB.toByteArray()),
                         1_000_000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         context = bc.createNewBlockContext(bc.getBestBlock(), List.of(tx3), false);
         result = bc.tryToConnect(context.block);

--- a/modApiServer/test/org/aion/api/server/pb/ApiAion0Test.java
+++ b/modApiServer/test/org/aion/api/server/pb/ApiAion0Test.java
@@ -484,7 +484,7 @@ public class ApiAion0Test {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -614,7 +614,7 @@ public class ApiAion0Test {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -668,7 +668,7 @@ public class ApiAion0Test {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -722,7 +722,7 @@ public class ApiAion0Test {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -774,7 +774,7 @@ public class ApiAion0Test {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -826,7 +826,7 @@ public class ApiAion0Test {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -876,7 +876,7 @@ public class ApiAion0Test {
                         msg,
                         100000,
                         100000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         Block blk =
                 impl.getAionHub()
@@ -1075,7 +1075,7 @@ public class ApiAion0Test {
                         msg,
                         1000,
                         5000,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         assertEquals(AionImpl.instForTest().estimateTxNrg(tx, api.getBestBlock()), rslt.getNrg());
 

--- a/modApiServer/test/org/aion/api/server/types/TxTest.java
+++ b/modApiServer/test/org/aion/api/server/types/TxTest.java
@@ -56,7 +56,7 @@ public class TxTest {
         long txNrgPrice = 10L;
         byte type = 0b1;
         long txNrgUsed = 5L;
-        AionTransaction transaction = AionTransaction.createWithoutKey(txNonce,from, to, value, data, txNrgLimit, txNrgPrice, type);
+        AionTransaction transaction = AionTransaction.createWithoutKey(txNonce,from, to, value, data, txNrgLimit, txNrgPrice, type, null);
 
         AionTxReceipt txReceipt = new AionTxReceipt();
         txReceipt.setTransaction(transaction);
@@ -110,7 +110,7 @@ public class TxTest {
         Log txLog = Log.topicsAndData(to.toByteArray(), topics, logData);
 
 
-        AionTransaction transactionWithLog = AionTransaction.createWithoutKey(txNonce,from, to, value, data, txNrgLimit, txNrgPrice, type);
+        AionTransaction transactionWithLog = AionTransaction.createWithoutKey(txNonce,from, to, value, data, txNrgLimit, txNrgPrice, type, null);
 
         AionTxReceipt txReceiptWithLog = new AionTxReceipt();
         txReceiptWithLog.setLogs(List.of(txLog));

--- a/modBase/src/org/aion/base/AionTransaction.java
+++ b/modBase/src/org/aion/base/AionTransaction.java
@@ -38,6 +38,9 @@ public class AionTransaction {
     /** rlpEncoding is saved because it is needed to calculate the transactionHash */
     private final byte[] rlpEncoding;
 
+    /** beacon hash */
+    private final byte[] beaconHash;
+
     /** Constructor for AionTransaction */
     private AionTransaction(
             byte[] nonce,
@@ -52,7 +55,8 @@ public class AionTransaction {
             byte[] transactionHashWithoutSignature,
             ISignature signature,
             byte[] rlpEncoding,
-            byte[] transactionHash) {
+            byte[] transactionHash,
+            byte[] beaconHash) {
 
         this.nonce = nonce;
         this.value = value;
@@ -84,6 +88,8 @@ public class AionTransaction {
                             energyLimit,
                             energyPrice);
         }
+
+        this.beaconHash = beaconHash;
     }
 
     /** Factory method used by most of the kernel to create AionTransactions */
@@ -95,7 +101,8 @@ public class AionTransaction {
             byte[] data,
             long energyLimit,
             long energyPrice,
-            byte type) {
+            byte type,
+            byte[] beaconHash) {
 
         byte[] timeStamp = ByteUtil.longToBytes(TimeInstant.now().toEpochMicro());
 
@@ -108,7 +115,8 @@ public class AionTransaction {
                         timeStamp,
                         energyLimit,
                         energyPrice,
-                        type));
+                        type,
+                        beaconHash));
 
         ISignature signature = key.sign(transactionHashWithoutSignature);
 
@@ -122,7 +130,8 @@ public class AionTransaction {
                         energyLimit,
                         energyPrice,
                         type,
-                        signature);
+                        signature,
+                        beaconHash);
 
         byte[] transactionHash = HashUtil.h256(rlpEncoding);
 
@@ -139,7 +148,8 @@ public class AionTransaction {
                 transactionHashWithoutSignature,
                 signature,
                 rlpEncoding,
-                transactionHash);
+                transactionHash,
+                beaconHash);
     }
 
     /** Factory method used by ApiAion to perform ethCalls */
@@ -151,7 +161,8 @@ public class AionTransaction {
             byte[] data,
             long energyLimit,
             long energyPrice,
-            byte type) {
+            byte type,
+            byte[] beaconHash) {
 
         ECKey key = ECKeyFac.inst().create();
 
@@ -166,7 +177,8 @@ public class AionTransaction {
                         timeStamp,
                         energyLimit,
                         energyPrice,
-                        type));
+                        type,
+                        beaconHash));
 
         ISignature signature = key.sign(transactionHashWithoutSignature);
 
@@ -180,7 +192,8 @@ public class AionTransaction {
                         energyLimit,
                         energyPrice,
                         type,
-                        signature);
+                        signature,
+                        beaconHash);
 
         byte[] transactionHash = HashUtil.h256(rlpEncoding);
 
@@ -197,7 +210,8 @@ public class AionTransaction {
                 transactionHashWithoutSignature,
                 signature,
                 rlpEncoding,
-                transactionHash);
+                transactionHash,
+                beaconHash);
     }
 
     /** Factory method used by some tests to create multiple transactions with the same timestamp */
@@ -210,7 +224,8 @@ public class AionTransaction {
             long energyLimit,
             long energyPrice,
             byte type,
-            byte[] timeStamp) {
+            byte[] timeStamp,
+            byte[] beaconHash) {
 
         byte[] transactionHashWithoutSignature =
                 HashUtil.h256(TxUtil.rlpEncodeWithoutSignature(
@@ -221,7 +236,8 @@ public class AionTransaction {
                         timeStamp,
                         energyLimit,
                         energyPrice,
-                        type));
+                        type,
+                        beaconHash));
 
         ISignature signature = key.sign(transactionHashWithoutSignature);
 
@@ -235,7 +251,8 @@ public class AionTransaction {
                         energyLimit,
                         energyPrice,
                         type,
-                        signature);
+                        signature,
+                        beaconHash);
 
         byte[] transactionHash = HashUtil.h256(rlpEncoding);
 
@@ -252,7 +269,8 @@ public class AionTransaction {
                 transactionHashWithoutSignature,
                 signature,
                 rlpEncoding,
-                transactionHash);
+                transactionHash,
+                beaconHash);
     }
 
     /**
@@ -271,7 +289,8 @@ public class AionTransaction {
             byte type,
             byte[] timeStamp,
             ISignature signature,
-            byte[] rlpEncoding) {
+            byte[] rlpEncoding,
+            byte[] beaconHash) {
 
         byte[] transactionHashWithoutSignature =
                 HashUtil.h256(
@@ -283,7 +302,8 @@ public class AionTransaction {
                                 timeStamp,
                                 energyLimit,
                                 energyPrice,
-                                type));
+                                type,
+                                beaconHash));
 
         byte[] transactionHash = HashUtil.h256(rlpEncoding);
 
@@ -300,7 +320,8 @@ public class AionTransaction {
                 transactionHashWithoutSignature,
                 signature,
                 rlpEncoding,
-                transactionHash);
+                transactionHash,
+                beaconHash);
     }
 
     public byte[] getTransactionHash() {
@@ -371,6 +392,10 @@ public class AionTransaction {
         return transaction.senderAddress;
     }
 
+    public byte[] getBeaconHash() {
+        return beaconHash;
+    }
+
     @Override
     public String toString() {
         return "TransactionData ["
@@ -381,6 +406,8 @@ public class AionTransaction {
                 + ByteUtil.byteArrayToLong(timeStamp)
                 + ", signature="
                 + ((signature == null) ? "null" : signature.toString())
+                + ", beaconHash="
+                + ((beaconHash == null) ? "null" : ByteUtil.toHexString(beaconHash))
                 + "]";
     }
 

--- a/modTxPool/test/org/aion/txpool/test/TxnPoolTest.java
+++ b/modTxPool/test/org/aion/txpool/test/TxnPoolTest.java
@@ -117,7 +117,7 @@ public class TxnPoolTest {
                         ByteUtils.fromHexString("1"),
                         10000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         return Collections.singletonList(new PooledTransaction(tx, energyConsumed));
     }
@@ -230,7 +230,7 @@ public class TxnPoolTest {
                         ByteUtils.fromHexString("1"),
                         10000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         return new PooledTransaction(tx, energyConsumed);
     }
 
@@ -245,7 +245,7 @@ public class TxnPoolTest {
                         ByteUtils.fromHexString("1"),
                         10000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         return new PooledTransaction(tx, energyConsumed);
     }
 
@@ -259,7 +259,7 @@ public class TxnPoolTest {
                 10000L,
                 1L,
                 TransactionTypes.DEFAULT,
-                timeStamp);
+                timeStamp, null);
         return new PooledTransaction(tx, energyConsumed);
     }
 
@@ -273,7 +273,7 @@ public class TxnPoolTest {
                         ByteUtils.fromHexString("1"),
                         10000L,
                         r.nextInt(1000),
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
         return new PooledTransaction(tx, energyConsumed);
     }
 
@@ -704,7 +704,7 @@ public class TxnPoolTest {
                         ByteUtils.fromHexString("1"),
                         10000L,
                         1L,
-                        TransactionTypes.DEFAULT);
+                        TransactionTypes.DEFAULT, null);
 
         PooledTransaction pooledTx = new PooledTransaction(txn, 0);
 
@@ -824,7 +824,7 @@ public class TxnPoolTest {
                             ByteUtils.fromHexString("1"),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             PooledTransaction pooledTx = new PooledTransaction(txn, 100);
             txnl.add(pooledTx);
         }
@@ -865,7 +865,7 @@ public class TxnPoolTest {
                                 ByteUtils.fromHexString("1"),
                                 10000L,
                                 1L,
-                                TransactionTypes.DEFAULT);
+                                TransactionTypes.DEFAULT, null);
                 PooledTransaction pooledTx = new PooledTransaction(txn, 100);
                 txnl.add(pooledTx);
             }
@@ -909,7 +909,7 @@ public class TxnPoolTest {
                             ByteUtils.fromHexString("1"),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             PooledTransaction pooledTx = new PooledTransaction(txn, i + 1);
             txnl.add(pooledTx);
         }
@@ -1009,7 +1009,7 @@ public class TxnPoolTest {
                                 ByteUtils.fromHexString("1"),
                                 10000L,
                                 1L,
-                                TransactionTypes.DEFAULT);
+                                TransactionTypes.DEFAULT, null);
                 PooledTransaction pooledTx = new PooledTransaction(txn, 100);
                 txnl.add(pooledTx);
             }
@@ -1055,7 +1055,7 @@ public class TxnPoolTest {
                                 ByteUtils.fromHexString("1"),
                                 10000L,
                                 1L,
-                                TransactionTypes.DEFAULT);
+                                TransactionTypes.DEFAULT, null);
                 PooledTransaction pooledTx = new PooledTransaction(txn, 100);
                 txnl.add(pooledTx);
             }
@@ -1083,7 +1083,7 @@ public class TxnPoolTest {
                                 ByteUtils.fromHexString("1"),
                                 10000L,
                                 1L,
-                                TransactionTypes.DEFAULT);
+                                TransactionTypes.DEFAULT, null);
                 PooledTransaction pooledTx = new PooledTransaction(txn, 100);
                 txnl.add(pooledTx);
             }
@@ -1132,7 +1132,7 @@ public class TxnPoolTest {
                                 ByteUtils.fromHexString("1"),
                                 10000L,
                                 1L,
-                                TransactionTypes.DEFAULT);
+                                TransactionTypes.DEFAULT, null);
                 PooledTransaction pooledTx = new PooledTransaction(txn, 100);
                 txnl.add(pooledTx);
             }
@@ -1185,7 +1185,7 @@ public class TxnPoolTest {
                             ByteUtils.fromHexString("1"),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             PooledTransaction pooledTx = new PooledTransaction(txn, 100);
             txnl.add(pooledTx);
 
@@ -1249,7 +1249,7 @@ public class TxnPoolTest {
                                 ByteUtils.fromHexString("1"),
                                 10000L,
                                 1L,
-                                TransactionTypes.DEFAULT);
+                                TransactionTypes.DEFAULT, null);
                 PooledTransaction pooledTx = new PooledTransaction(txn, 100);
                 txnl.add(pooledTx);
             }
@@ -1294,7 +1294,7 @@ public class TxnPoolTest {
                             ByteUtils.fromHexString("1"),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             PooledTransaction pooledTx = new PooledTransaction(tx, 1);
             txs.add(pooledTx);
         }
@@ -1328,7 +1328,7 @@ public class TxnPoolTest {
                             ByteUtils.fromHexString("1"),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             PooledTransaction pooledTx = new PooledTransaction(tx, 1);
             txs.add(pooledTx);
         }
@@ -1358,7 +1358,7 @@ public class TxnPoolTest {
                             ByteUtils.fromHexString("1"),
                             10000L,
                             1L,
-                            TransactionTypes.DEFAULT);
+                            TransactionTypes.DEFAULT, null);
             PooledTransaction pooledTx = new PooledTransaction(tx, 100);
             txs.add(pooledTx);
         }


### PR DESCRIPTION
## Notice

Please submit your PR to the `master` branch and rebase your code on `master` before opening the pull request.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- modify AionTransaction and its RLP encoding to store beacon hash and "extension byte"
- RLP explanation: https://gist.github.com/aion-kelvin/f624c4f217441d4173d23e5a8839d3ad (will be moved to Confluence soon)
- modify RPC method eth_sendTransaction to take a 'beacon' field
- implemented a BeaconHashValidator and added it to the checks of AionPendingStateImpl and AIonBlockchainImpl

Fixes AIP010

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [x] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- added unit tests for validator
- raw transactions tested by node harness test (the new test not yet merged to node_harness_test/master, but you can see it here: https://github.com/aionnetwork/node_test_harness/blob/beacon/Tests/test/org/aion/harness/tests/integ/BeaconHashTest.java#L66)
- also tested manually via eth_sendTransaction.  Results below.

Bad beacon hash provided:
```
sergiu@aion-XPS-8930:~/repos/aion$ curl -sX POST --data '{"jsonrpc":"2.0", "id":"1", "method": "eth_sendTransaction", "params":[ { "from":"0xa04577e56a63000b7e2a4c690cb0418cc3f203e709b4d78ffdd2f25ac24f5e67", "to":"0xa0da8cda8e423792022ad58bb165268801c56112dedb1199d22b14c96fe16013", "value":"0xaa", "gasPrice": "0x2540be400", "beaconHash": "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe" } ] }' localhost:8545 | jq .
{
  "id": "1",
  "jsonrpc": "2.0",
  "error": {
    "code": -32602,
    "data": "Invalid transaction object",
    "message": "Invalid params"
  }
}
```

Without any beacon hash:
```
sergiu@aion-XPS-8930:~/repos/aion$ curl -sX POST --data '{"jsonrpc":"2.0", "id":"1", "method": "eth_sendTransaction", "params":[ { "from":"0xa04577e56a63000b7e2a4c690cb0418cc3f203e709b4d78ffdd2f25ac24f5e67", "to":"0xa0da8cda8e423792022ad58bb165268801c56112dedb1199d22b14c96fe16013", "value":"0xaa", "gasPrice": "0x2540be400" } ] }' localhost:8545 | jq .
{
  "result": "0x9e00812b6e9898e8d79d2e332bfd1ff8d61e1f9c1dcb48a6eed3c84c3542640c",
  "id": "1",
  "jsonrpc": "2.0"
}
sergiu@aion-XPS-8930:~/repos/aion$ curl -sX POST --data '{"jsonrpc":"2.0", "id":"1", "method": "eth_getTransactionByHash", "params":[ "0x9e00812b6e9898e8d79d2e332bfd1ff8d61e1f9c1dcb48a6eed3c84c3542640c" ] }' localhost:8545 | jq . 
{
  "result": {
    "nrgPrice": "0x2540be400",
    "blockHash": "0xb9bb01f54b2deb77dad6ab95d8f0bea136397bee8860653b54b858eb0001f0df",
    "nrg": 90000,
    "transactionIndex": 0,
    "nonce": 0,
    "input": "0x",
    "blockNumber": "0x21",
    "gas": 90000,
    "from": "0xa04577e56a63000b7e2a4c690cb0418cc3f203e709b4d78ffdd2f25ac24f5e67",
    "to": "0xa0da8cda8e423792022ad58bb165268801c56112dedb1199d22b14c96fe16013",
    "value": "0x00aa",
    "hash": "0x9e00812b6e9898e8d79d2e332bfd1ff8d61e1f9c1dcb48a6eed3c84c3542640c",
    "gasPrice": "0x2540be400",
    "timestamp": 1568266790
  },
  "id": "1",
  "jsonrpc": "2.0"
}
```

With valid beacon hash:
```
sergiu@aion-XPS-8930:~/repos/aion$ curl -sX POST --data '{"jsonrpc":"2.0", "id":"1", "method": "eth_sendTransaction", "params":[ { "from":"0xa04577e56a63000b7e2a4c690cb0418cc3f203e709b4d78ffdd2f25ac24f5e67", "to":"0xa0da8cda8e423792022ad58bb165268801c56112dedb1199d22b14c96fe16013", "value":"0xaa", "gasPrice": "0x2540be400", "beaconHash": "0x597d47b2513390109adb6d594daea3d81c8e20ab0f764529127fcd15b749481c" } ] }' localhost:8545 | jq .
{
  "result": "0xa883493b54126e51ac080c10bb42ce1ed1031d708b2ae77af14e8e5ea4ac3626",
  "id": "1",
  "jsonrpc": "2.0"
}
sergiu@aion-XPS-8930:~/repos/aion$ curl -X POST --data '{"jsonrpc":"2.0", "id":"1", "method": "eth_getTransactionByHash", "params":[ "0xa883493b54126e51ac080c10bb42ce1ed1031d708b2ae77af14e8e5ea4ac3626" ] }' localhost:8545 | jq . 
{
  "result": {
    "nrgPrice": "0x2540be400",
    "blockHash": "0xe8ffbd80be2dca9315082522cde09c8d37bd379d5e03a07060d4c7be7346d546",
    "nrg": 90000,
    "transactionIndex": 0,
    "nonce": 1,
    "input": "0x",
    "blockNumber": "0x29",
    "gas": 90000,
    "from": "0xa04577e56a63000b7e2a4c690cb0418cc3f203e709b4d78ffdd2f25ac24f5e67",
    "to": "0xa0da8cda8e423792022ad58bb165268801c56112dedb1199d22b14c96fe16013",
    "value": "0x00aa",
    "hash": "0xa883493b54126e51ac080c10bb42ce1ed1031d708b2ae77af14e8e5ea4ac3626",
    "gasPrice": "0x2540be400",
    "timestamp": 1568266900
  },
  "id": "1",
  "jsonrpc": "2.0"
}
```