### PR TITLE
Beacon hash validator not comparing byte arrays correctly

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/valid/BeaconHashValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/BeaconHashValidator.java
@@ -62,7 +62,7 @@ public class BeaconHashValidator {
         long t0 = System.nanoTime();
         try {
             Preconditions.checkNotNull(tx, "AionTransaction must not be null");
-            Preconditions.checkNotNull(tx, "Block must not be null");
+            Preconditions.checkNotNull(block, "Block must not be null");
 
             byte[] beaconHash = tx.getBeaconHash();
             if (beaconHash == null) {

--- a/modAionImpl/src/org/aion/zero/impl/valid/BeaconHashValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/BeaconHashValidator.java
@@ -10,6 +10,8 @@ import org.aion.zero.impl.blockchain.IAionBlockchain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+
 /** Validates beacon hash of transaction */
 public class BeaconHashValidator {
     private final IAionBlockchain blockchain;
@@ -153,7 +155,7 @@ public class BeaconHashValidator {
         long beaconNumber = beaconBlock.getNumber();
 
         while(null != cur) {
-            if(beaconHash.equals(cur.getHash())) {
+            if(Arrays.equals(beaconHash, cur.getHash())) {
                 return true;
             } else if(beaconNumber >= cur.getNumber()) {
                 TX_LOG.debug("BeaconHashValidator#checkSideChain: reached level of beacon hash block {}",

--- a/modAionImpl/test/org/aion/zero/impl/valid/BeaconHashValidatorTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/valid/BeaconHashValidatorTest.java
@@ -155,6 +155,8 @@ public class BeaconHashValidatorTest {
 
         LinkedList<Block> sideChain = mockChain(fork050Number, 4, blockchain);
 
+        byte[] beaconHash = new byte[32];
+        System.arraycopy(sideChain.get(3).getHash(), 0, beaconHash, 0, 32);
         AionTransaction tx = AionTransaction.createWithoutKey(
                 new byte[] { 1 },                           // nonce - any val
                 new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
@@ -166,7 +168,7 @@ public class BeaconHashValidatorTest {
                 1l,                                         // energyLimit - any val
                 1l,                                         // energyPrice - any val
                 (byte) 1,                                   // type - any val
-                sideChain.get(3).getHash()                  // beacon hash
+                beaconHash                                  // beacon hash
         );
 
         BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
@@ -194,6 +196,9 @@ public class BeaconHashValidatorTest {
         when(blockchain.isMainChain(sideChain.get(2).getHash(), sideChain.get(2).getNumber())).thenReturn(true);
         when(blockchain.isMainChain(sideChain.get(4).getHash())).thenReturn(true);
 
+        byte[] beaconHash = new byte[32];
+        System.arraycopy(sideChain.get(4).getHash(), 0, beaconHash, 0, 32);
+
         AionTransaction tx = AionTransaction.createWithoutKey(
                 new byte[] { 1 },                           // nonce - any val
                 new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
@@ -205,7 +210,7 @@ public class BeaconHashValidatorTest {
                 1l,                                         // energyLimit - any val
                 1l,                                         // energyPrice - any val
                 (byte) 1,                                   // type - any val
-                sideChain.get(4).getHash()                  // beacon hash
+                beaconHash                                  // beacon hash
         );
 
         BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);
@@ -241,6 +246,8 @@ public class BeaconHashValidatorTest {
         // need to set up the side chain so that its head block number is > mainchainOnlyBlockNum
         LinkedList<Block> sideChain = mockChain(0, 4, blockchain);
 
+        byte[] beaconHash = new byte[32];
+        System.arraycopy(mainchainOnlyBlockHash, 0, beaconHash, 0, 32);
         AionTransaction tx = AionTransaction.createWithoutKey(
                 new byte[] { 1 },                           // nonce - any val
                 new AionAddress(ByteUtil.hexStringToBytes(  // sender - any val
@@ -252,7 +259,7 @@ public class BeaconHashValidatorTest {
                 1l,                                         // energyLimit - any val
                 1l,                                         // energyPrice - any val
                 (byte) 1,                                   // type - any val
-                mainchainOnlyBlockHash                      // beacon hash
+                beaconHash                                  // beacon hash
         );
 
         BeaconHashValidator unit = new BeaconHashValidator(blockchain, fork050Number);


### PR DESCRIPTION
## Notice

Please submit your PR to the `master` branch and rebase your code on `master` before opening the pull request.

## Description

Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.

- One of the checks in the sidechain case used byte[].equals(other) which checks reference-equality.  Changed it to Arrays.equals(byte[],byte[]) which checks value-equality -- the equality we care about
- Updated unit test so that this case would be caught in case it arises again
- Also fixed a small typo in a null check

Fixes Issue # .

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.

- I noticed this problem while creating a node harness test for the beacon hash side chain case.  The test was failing.  Now it passes.

