### PR TITLE
Fix when we configure the avm

### DIFF
--- a/modVM/src/org/aion/vm/avm/schedule/AvmVersionSchedule.java
+++ b/modVM/src/org/aion/vm/avm/schedule/AvmVersionSchedule.java
@@ -63,7 +63,7 @@ public final class AvmVersionSchedule {
             throw new IllegalArgumentException("Cannot create schedule with negative version 2 active block!");
         }
         if (blockNumberToActivateVersion1 >= blockNumberToActivateVersion2) {
-            throw new IllegalArgumentException("Cannot create schedule with version 1 active later than version 2!");
+            throw new IllegalArgumentException("Cannot create schedule with version 1 active later than, or at the same time as, version 2!");
         }
 
         return new AvmVersionSchedule(true, blockNumberToActivateVersion1, true, blockNumberToActivateVersion2, activeVersionTolerance);


### PR DESCRIPTION
- The issue is that we were configuring this too early and the properties
  we read from our config file were not yet set up (and were defaulting to
  mainnet settings).
- We now configure the avm in the proper places so that we read the correct
  fork values and we handle configuration failures as well.