### PR TITLE
Static factory methods for creating blocks

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/ChainConfiguration.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/ChainConfiguration.java
@@ -3,7 +3,7 @@ package org.aion.zero.impl.blockchain;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import org.aion.equihash.OptimizedEquiValidator;
@@ -127,9 +127,9 @@ public class ChainConfiguration {
                         new EnergyConsumedRule(),
                         new SignatureRule());
 
-        Map<Byte, List<BlockHeaderRule>> unityRules = new HashMap<>();
-        unityRules.put(BlockSealType.SEAL_POW_BLOCK.getSealId(), powRules);
-        unityRules.put(BlockSealType.SEAL_POS_BLOCK.getSealId(), posRules);
+        Map<BlockSealType, List<BlockHeaderRule>> unityRules = new EnumMap<>(BlockSealType.class);
+        unityRules.put(BlockSealType.SEAL_POW_BLOCK, powRules);
+        unityRules.put(BlockSealType.SEAL_POS_BLOCK, posRules);
 
         return new BlockHeaderValidator(unityRules);
     }
@@ -138,8 +138,8 @@ public class ChainConfiguration {
         List<DependentBlockHeaderRule> posRules =
                 Arrays.asList(new StakingSeedRule(), new StakingBlockTimeStampRule());
 
-        Map<Byte, List<DependentBlockHeaderRule>> unityRules = new HashMap<>();
-        unityRules.put(BlockSealType.SEAL_POS_BLOCK.getSealId(), posRules);
+        Map<BlockSealType, List<DependentBlockHeaderRule>> unityRules = new EnumMap<>(BlockSealType.class);
+        unityRules.put(BlockSealType.SEAL_POS_BLOCK, posRules);
 
         return new ParentBlockHeaderValidator(unityRules);
     }
@@ -149,8 +149,8 @@ public class ChainConfiguration {
         List<GrandParentDependantBlockHeaderRule> powRules =
                 Collections.singletonList(new AionDifficultyRule(this));
 
-        Map<Byte, List<GrandParentDependantBlockHeaderRule>> unityRules = new HashMap<>();
-        unityRules.put(BlockSealType.SEAL_POW_BLOCK.getSealId(), powRules);
+        Map<BlockSealType, List<GrandParentDependantBlockHeaderRule>> unityRules = new EnumMap<>(BlockSealType.class);
+        unityRules.put(BlockSealType.SEAL_POW_BLOCK, powRules);
 
         return new GrandParentBlockHeaderValidator(unityRules);
     }
@@ -165,9 +165,9 @@ public class ChainConfiguration {
         List<GrandParentDependantBlockHeaderRule> posRules =
                 Collections.singletonList(new UnityDifficultyRule(this));
 
-        Map<Byte, List<GrandParentDependantBlockHeaderRule>> unityRules = new HashMap<>();
-        unityRules.put(BlockSealType.SEAL_POW_BLOCK.getSealId(), powRules);
-        unityRules.put(BlockSealType.SEAL_POS_BLOCK.getSealId(), posRules);
+        Map<BlockSealType, List<GrandParentDependantBlockHeaderRule>> unityRules = new EnumMap<>(BlockSealType.class);
+        unityRules.put(BlockSealType.SEAL_POW_BLOCK, powRules);
+        unityRules.put(BlockSealType.SEAL_POS_BLOCK, posRules);
 
         return new GrandParentBlockHeaderValidator(unityRules);
     }
@@ -181,9 +181,9 @@ public class ChainConfiguration {
                                 getConstants().getEnergyDivisorLimitLong(),
                                 getConstants().getEnergyLowerBoundLong()));
 
-        Map<Byte, List<DependentBlockHeaderRule>> unityRules = new HashMap<>();
-        unityRules.put(BlockSealType.SEAL_POW_BLOCK.getSealId(), rules);
-        unityRules.put(BlockSealType.SEAL_POS_BLOCK.getSealId(), rules);
+        Map<BlockSealType, List<DependentBlockHeaderRule>> unityRules = new EnumMap<>(BlockSealType.class);
+        unityRules.put(BlockSealType.SEAL_POW_BLOCK, rules);
+        unityRules.put(BlockSealType.SEAL_POS_BLOCK, rules);
 
         return new ParentBlockHeaderValidator(unityRules);
     }

--- a/modAionImpl/src/org/aion/zero/impl/blockchain/StandaloneBlockchain.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/StandaloneBlockchain.java
@@ -6,6 +6,7 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -372,11 +373,9 @@ public class StandaloneBlockchain extends AionBlockchainImpl {
                                                                     .getMaximumExtraDataSize()),
                                                     new EnergyConsumedRule());
 
-                                    Map<Byte, List<BlockHeaderRule>> unityRules = new HashMap<>();
-                                    unityRules.put(
-                                            BlockSealType.SEAL_POW_BLOCK.getSealId(), powRules);
-                                    unityRules.put(
-                                            BlockSealType.SEAL_POS_BLOCK.getSealId(), posRules);
+                                    Map<BlockSealType, List<BlockHeaderRule>> unityRules = new EnumMap<>(BlockSealType.class);
+                                    unityRules.put(BlockSealType.SEAL_POW_BLOCK, powRules);
+                                    unityRules.put(BlockSealType.SEAL_POS_BLOCK, posRules);
 
                                     return new BlockHeaderValidator(unityRules);
                                 }

--- a/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/AionBlockStore.java
@@ -36,8 +36,7 @@ import org.aion.rlp.RLPList;
 import org.aion.util.bytes.ByteUtil;
 import org.aion.util.conversions.Hex;
 import org.aion.zero.impl.config.CfgAion;
-import org.aion.zero.impl.types.AionBlock;
-import org.aion.zero.impl.types.StakingBlock;
+import org.aion.zero.impl.types.BlockUtil;
 import org.aion.zero.impl.types.UnityDifficulty;
 import org.slf4j.Logger;
 
@@ -87,18 +86,11 @@ public class AionBlockStore implements IBlockStoreBase {
 
             @Override
             public Block deserialize(byte[] bytes) {
-                // TODO : [unity] better way to avoid rlp decode?
-                RLPList params = RLP.decode2(bytes);
-                RLPList block = (RLPList) params.get(0);
-                RLPList header = (RLPList) block.get(0);
-                byte[] sealType = header.get(0).getRLPData();
-                if (sealType[0] == BlockSealType.SEAL_POW_BLOCK.getSealId()) {
-                    return new AionBlock(bytes);
-                } else if (sealType[0] == BlockSealType.SEAL_POS_BLOCK.getSealId()) {
-                    return new StakingBlock(bytes);
+                Block block = BlockUtil.newBlockFromRlp(bytes);
+                if (block != null) {
+                    return block;
                 } else {
-                    throw new IllegalStateException(
-                            "Invalid rlp encode data: " + ByteUtil.toHexString(bytes));
+                    throw new NullPointerException("Invalid rlp encode data: " + ByteUtil.toHexString(bytes));
                 }
             }
         };

--- a/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/SyncMgr.java
@@ -11,13 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.aion.evtmgr.IEvent;
 import org.aion.evtmgr.IEventMgr;
 import org.aion.evtmgr.impl.evt.EventConsensus;
@@ -25,7 +20,6 @@ import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.aion.mcf.blockchain.Block;
 import org.aion.mcf.blockchain.BlockHeader;
-import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
 import org.aion.mcf.config.StatsType;
 import org.aion.p2p.IP2pMgr;
 import org.aion.util.bytes.ByteUtil;
@@ -33,10 +27,7 @@ import org.aion.util.conversions.Hex;
 import org.aion.util.types.ByteArrayWrapper;
 import org.aion.zero.impl.blockchain.AionBlockchainImpl;
 import org.aion.zero.impl.blockchain.ChainConfiguration;
-import org.aion.zero.impl.types.A0BlockHeader;
-import org.aion.zero.impl.types.AionBlock;
-import org.aion.zero.impl.types.StakingBlock;
-import org.aion.zero.impl.types.StakingBlockHeader;
+import org.aion.zero.impl.types.BlockUtil;
 import org.aion.zero.impl.valid.BlockHeaderValidator;
 import org.apache.commons.collections4.map.LRUMap;
 import org.slf4j.Logger;
@@ -327,14 +318,7 @@ public final class SyncMgr {
         Iterator<BlockHeader> headerIt = headers.iterator();
         Iterator<byte[]> bodyIt = _bodies.iterator();
         while (headerIt.hasNext() && bodyIt.hasNext()) {
-            BlockHeader header = headerIt.next();
-            Block block = null;
-            if (header.getSealType() == BlockSealType.SEAL_POW_BLOCK) {
-                block = AionBlock.createBlockFromNetwork((A0BlockHeader) header, bodyIt.next());
-            } else if (header.getSealType() == BlockSealType.SEAL_POS_BLOCK) {
-                block = StakingBlock.createBlockFromNetwork((StakingBlockHeader) header, bodyIt.next());
-            }
-
+            Block block = BlockUtil.newBlockWithHeader(headerIt.next(), bodyIt.next());
             if (block == null) {
                 log.error("<assemble-and-validate-blocks node={} size={}>", _displayId, _bodies.size());
                 assembleError = true;

--- a/modAionImpl/src/org/aion/zero/impl/sync/msg/ResBlocksHeaders.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/msg/ResBlocksHeaders.java
@@ -2,9 +2,7 @@ package org.aion.zero.impl.sync.msg;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.aion.mcf.blockchain.BlockHeader;
-import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Msg;
 import org.aion.p2p.Ver;
@@ -12,8 +10,7 @@ import org.aion.rlp.RLP;
 import org.aion.rlp.RLPElement;
 import org.aion.rlp.RLPList;
 import org.aion.zero.impl.sync.Act;
-import org.aion.zero.impl.types.A0BlockHeader;
-import org.aion.zero.impl.types.StakingBlockHeader;
+import org.aion.zero.impl.types.BlockUtil;
 import org.slf4j.Logger;
 
 /** @author chris */
@@ -33,19 +30,7 @@ public final class ResBlocksHeaders extends Msg {
                 RLPList list = (RLPList) RLP.decode2(_msgBytes).get(0);
                 List<BlockHeader> blockHeaders = new ArrayList<>();
                 for (RLPElement aList : list) {
-                    RLPList rlpData = ((RLPList) aList);
-                    byte[] type = rlpData.get(0).getRLPData();
-                    if (type[0] == BlockSealType.SEAL_POW_BLOCK.ordinal()) {
-                        blockHeaders.add(
-                                A0BlockHeader.Builder.newInstance(true)
-                                        .withRlpList(rlpData)
-                                        .build());
-                    } else if (type[0] == BlockSealType.SEAL_POS_BLOCK.ordinal()) {
-                        blockHeaders.add(
-                                StakingBlockHeader.Builder.newInstance(true)
-                                        .withRlpList(rlpData)
-                                        .build());
-                    }
+                    blockHeaders.add(BlockUtil.newHeaderFromRlpList((RLPList) aList));
                 }
                 return new ResBlocksHeaders(blockHeaders);
             } catch (Exception ex) {

--- a/modAionImpl/src/org/aion/zero/impl/sync/msg/ResponseBlocks.java
+++ b/modAionImpl/src/org/aion/zero/impl/sync/msg/ResponseBlocks.java
@@ -3,9 +3,7 @@ package org.aion.zero.impl.sync.msg;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
 import org.aion.mcf.blockchain.Block;
-import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
 import org.aion.p2p.Ctrl;
 import org.aion.p2p.Msg;
 import org.aion.p2p.Ver;
@@ -13,8 +11,7 @@ import org.aion.rlp.RLP;
 import org.aion.rlp.RLPElement;
 import org.aion.rlp.RLPList;
 import org.aion.zero.impl.sync.Act;
-import org.aion.zero.impl.types.AionBlock;
-import org.aion.zero.impl.types.StakingBlock;
+import org.aion.zero.impl.types.BlockUtil;
 
 /**
  * Response message to a request for a block range.
@@ -62,25 +59,9 @@ public final class ResponseBlocks extends Msg {
             }
 
             List<Block> blocks = new ArrayList<>();
-            Block current = null;
+            Block current;
             for (RLPElement encoded : list) {
-                try { // preventative try-catch: it's unlikely that exceptions can pass up to here
-                    RLPList params = RLP.decode2(encoded.getRLPData());
-                    RLPList blockRLP = (RLPList) params.get(0);
-                    if (blockRLP.get(0) instanceof RLPList && blockRLP.get(1) instanceof RLPList) {
-                        // Parse Header
-                        RLPList headerRLP = (RLPList) blockRLP.get(0);
-
-                        byte[] type = headerRLP.get(0).getRLPData();
-                        if (type[0] == BlockSealType.SEAL_POW_BLOCK.ordinal()) {
-                            current = AionBlock.fromRLPList(blockRLP);
-                        } else if (type[0] == BlockSealType.SEAL_POS_BLOCK.ordinal()) {
-                            current = StakingBlock.fromRLPList(blockRLP);
-                        }
-                    }
-                } catch (Exception e) {
-                    return null;
-                }
+                current = BlockUtil.newBlockFromRlp(encoded.getRLPData());
                 if (current == null) {
                     return null;
                 } else {

--- a/modAionImpl/src/org/aion/zero/impl/types/BlockUtil.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/BlockUtil.java
@@ -1,0 +1,147 @@
+package org.aion.zero.impl.types;
+
+import java.util.Arrays;
+import org.aion.log.AionLoggerFactory;
+import org.aion.log.LogEnum;
+import org.aion.mcf.blockchain.Block;
+import org.aion.mcf.blockchain.BlockHeader;
+import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
+import org.aion.rlp.RLP;
+import org.aion.rlp.RLPList;
+import org.slf4j.Logger;
+
+/**
+ * Utility for creating {@link Block} objects. The static methods in this class should be used
+ * instead of instantiating the different block types using their constructors directly.
+ *
+ * @author Alexandra Roatis
+ */
+public final class BlockUtil {
+    private static final Logger genLog = AionLoggerFactory.getLogger(LogEnum.GEN.name());
+
+    private BlockUtil() {
+        throw new IllegalStateException("This utility class is not meant to be instantiated.");
+    }
+
+    /**
+     * Decodes the given encoding into a new instance of a block or returns {@code null} if the RLP
+     * encoding does not describe a valid block.
+     *
+     * @param rlp RLP encoded block data
+     * @return a new instance of a block or {@code null} if the RLP encoding does not describe a
+     *     valid block
+     */
+    public static Block newBlockFromRlp(byte[] rlp) {
+        // return null when given empty bytes
+        if (rlp == null || rlp.length == 0) {
+            return null;
+        }
+
+        // attempt decoding, return null if it fails
+        try {
+            RLPList params = RLP.decode2(rlp);
+            RLPList block = (RLPList) params.get(0);
+            RLPList header = (RLPList) block.get(0);
+            byte[] sealType = header.get(0).getRLPData();
+            if (sealType[0] == BlockSealType.SEAL_POW_BLOCK.getSealId()) {
+                return new AionBlock(rlp);
+            } else if (sealType[0] == BlockSealType.SEAL_POS_BLOCK.getSealId()) {
+                return new StakingBlock(rlp);
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            genLog.warn("Unable to decode block bytes " + Arrays.toString(rlp), e);
+            return null;
+        }
+    }
+
+    /**
+     * Decodes the given encoding into a new instance of a block or returns {@code null} if the RLP
+     * encoding does not describe a valid block.
+     *
+     * @param rlpList an RLPList instance encoding block data
+     * @return a new instance of a block or {@code null} if the RLP encoding does not describe a
+     *     valid block
+     */
+    public static Block newBlockFromRlpList(RLPList rlpList) {
+        // return null when given empty bytes
+        if (rlpList == null || rlpList.size() != 2) {
+            return null;
+        }
+        try {
+            // parse header
+            RLPList headerRLP = (RLPList) rlpList.get(0);
+            byte[] type = headerRLP.get(0).getRLPData();
+            if (type[0] == BlockSealType.SEAL_POW_BLOCK.getSealId()) {
+                return AionBlock.fromRLPList(rlpList);
+
+            } else if (type[0] == BlockSealType.SEAL_POS_BLOCK.getSealId()) {
+                return StakingBlock.fromRLPList(rlpList);
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            genLog.warn("Unable to decode block bytes " + Arrays.toString(rlpList.getRLPData()), e);
+            return null;
+        }
+    }
+
+    /**
+     * Assembles a new block instance given its header and body. Returns {@code null} when given
+     * invalid data.
+     *
+     * @param header the block header
+     * @param bodyBytes the body of the block; can be an empty byte array when there are no
+     *     transactions in the block
+     * @return a new instance of a block or {@code null} when given invalid data
+     */
+    public static Block newBlockWithHeader(BlockHeader header, byte[] bodyBytes) {
+        // return null when given empty bytes
+        if (header == null || bodyBytes == null) {
+            return null;
+        }
+        try {
+            if (header.getSealType() == BlockSealType.SEAL_POW_BLOCK) {
+                return AionBlock.createBlockFromNetwork((A0BlockHeader) header, bodyBytes);
+            } else if (header.getSealType() == BlockSealType.SEAL_POS_BLOCK) {
+                return StakingBlock.createBlockFromNetwork((StakingBlockHeader) header, bodyBytes);
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            genLog.warn("Unable to decode block with header " + header, e);
+            return null;
+        }
+    }
+
+    /**
+     * Decodes the given encoding into a new instance of a block header or returns {@code null} if
+     * the RLP encoding does not describe a valid block header.
+     *
+     * @param rlpList an RLPList instance encoding block header data
+     * @return a new instance of a block header or {@code null} if the RLP encoding does not
+     *     describe a valid block header
+     */
+    public static BlockHeader newHeaderFromRlpList(RLPList rlpList) {
+        // return null when given empty bytes
+        if (rlpList == null) {
+            return null;
+        }
+
+        // attempt decoding, return null if it fails
+        try {
+            byte[] sealType = rlpList.get(0).getRLPData();
+            if (sealType[0] == BlockSealType.SEAL_POW_BLOCK.getSealId()) {
+                return A0BlockHeader.Builder.newInstance(true).withRlpList(rlpList).build();
+            } else if (sealType[0] == BlockSealType.SEAL_POS_BLOCK.getSealId()) {
+                return StakingBlockHeader.Builder.newInstance(true).withRlpList(rlpList).build();
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            genLog.warn("Unable to decode block bytes " + Arrays.toString(rlpList.getRLPData()), e);
+            return null;
+        }
+    }
+}

--- a/modAionImpl/src/org/aion/zero/impl/valid/BlockHeaderValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/BlockHeaderValidator.java
@@ -6,13 +6,14 @@ import java.util.List;
 
 import java.util.Map;
 import org.aion.mcf.blockchain.BlockHeader;
+import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
 import org.slf4j.Logger;
 
 public class BlockHeaderValidator {
 
-    private Map<Byte, List<BlockHeaderRule>> chainRules;
+    private Map<BlockSealType, List<BlockHeaderRule>> chainRules;
 
-    public BlockHeaderValidator(Map<Byte, List<BlockHeaderRule>> rules) {
+    public BlockHeaderValidator(Map<BlockSealType, List<BlockHeaderRule>> rules) {
         if (rules == null) {
             throw new NullPointerException("The blockHeaderRule can not be null");
         }
@@ -27,7 +28,7 @@ public class BlockHeaderValidator {
             return false;
         }
 
-        List<BlockHeaderRule> rules = chainRules.get(header.getSealType().getSealId());
+        List<BlockHeaderRule> rules = chainRules.get(header.getSealType());
         if (rules == null) {
             return false;
         } else {

--- a/modAionImpl/src/org/aion/zero/impl/valid/GrandParentBlockHeaderValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/GrandParentBlockHeaderValidator.java
@@ -5,14 +5,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.aion.mcf.blockchain.BlockHeader;
+import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
 import org.slf4j.Logger;
 
 public class GrandParentBlockHeaderValidator {
 
-    private Map<Byte, List<GrandParentDependantBlockHeaderRule>> chainRules;
+    private Map<BlockSealType, List<GrandParentDependantBlockHeaderRule>> chainRules;
 
     public GrandParentBlockHeaderValidator(
-        Map<Byte, List<GrandParentDependantBlockHeaderRule>> rules) {
+        Map<BlockSealType, List<GrandParentDependantBlockHeaderRule>> rules) {
         if (rules == null) {
             throw new NullPointerException();
         }
@@ -35,7 +36,7 @@ public class GrandParentBlockHeaderValidator {
             return false;
         }
 
-        List<GrandParentDependantBlockHeaderRule> rules = chainRules.get(current.getSealType().getSealId());
+        List<GrandParentDependantBlockHeaderRule> rules = chainRules.get(current.getSealType());
 
         if (rules == null) {
             return false;

--- a/modAionImpl/src/org/aion/zero/impl/valid/ParentBlockHeaderValidator.java
+++ b/modAionImpl/src/org/aion/zero/impl/valid/ParentBlockHeaderValidator.java
@@ -5,14 +5,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.aion.mcf.blockchain.BlockHeader;
+import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
 import org.slf4j.Logger;
 
 /** validation rules depending on parent's block header */
 public class ParentBlockHeaderValidator {
 
-    private Map<Byte, List<DependentBlockHeaderRule>> chainRules;
+    private Map<BlockSealType, List<DependentBlockHeaderRule>> chainRules;
 
-    public ParentBlockHeaderValidator(Map<Byte, List<DependentBlockHeaderRule>> rules) {
+    public ParentBlockHeaderValidator(Map<BlockSealType, List<DependentBlockHeaderRule>> rules) {
         if (rules == null) {
             throw new NullPointerException();
         }
@@ -39,7 +40,7 @@ public class ParentBlockHeaderValidator {
             return false;
         }
 
-        List<DependentBlockHeaderRule> rules = chainRules.get(header.getSealType().getSealId());
+        List<DependentBlockHeaderRule> rules = chainRules.get(header.getSealType());
 
         if (rules == null) {
             return false;


### PR DESCRIPTION
## Description

- Static factory methods for creating blocks.
- Bugfixes: BroadcastNewBlockHandler, ResponseBlocks and ResBlocksHeaders were incorrectly using enum ordinal instead of seal id.
- Using EnumMap in chain config for increased performance and code maintenance.

Fixes Issue AKI-369.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [x] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.
