### PR TITLE
AKI 317: TransactionStore enhancements

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionBlockchainImpl.java
@@ -1462,12 +1462,12 @@ public class AionBlockchainImpl implements IAionBlockchain {
             List<AionTxExecSummary> execSummaries = summary.getSummaries();
 
             for (int i = 0; i < receipts.size(); i++) {
-                AionTxInfo infoWithInternalTxs = AionTxInfo.newInstanceWithInternalTransactions(receipts.get(i), block.getHash(), i, execSummaries.get(i).getInternalTransactions());
+                AionTxInfo infoWithInternalTxs = AionTxInfo.newInstanceWithInternalTransactions(receipts.get(i), block.getHashWrapper(), i, execSummaries.get(i).getInternalTransactions());
 
                 if (storeInternalTransactions) {
                     transactionStore.putTxInfoToBatch(infoWithInternalTxs);
                 } else {
-                    AionTxInfo info = AionTxInfo.newInstance(receipts.get(i), block.getHash(), i);
+                    AionTxInfo info = AionTxInfo.newInstance(receipts.get(i), block.getHashWrapper(), i);
                     transactionStore.putTxInfoToBatch(info);
                 }
 
@@ -1843,12 +1843,12 @@ public class AionBlockchainImpl implements IAionBlockchain {
         getBlockStore().saveBlock(block, td, !fork);
 
         for (int i = 0; i < receipts.size(); i++) {
-            AionTxInfo infoWithInternalTxs = AionTxInfo.newInstanceWithInternalTransactions(receipts.get(i), block.getHash(), i, summaries.get(i).getInternalTransactions());
+            AionTxInfo infoWithInternalTxs = AionTxInfo.newInstanceWithInternalTransactions(receipts.get(i), block.getHashWrapper(), i, summaries.get(i).getInternalTransactions());
 
             if (storeInternalTransactions) {
                 transactionStore.putTxInfoToBatch(infoWithInternalTxs);
             } else {
-                AionTxInfo info = AionTxInfo.newInstance(receipts.get(i), block.getHash(), i);
+                AionTxInfo info = AionTxInfo.newInstance(receipts.get(i), block.getHashWrapper(), i);
                 transactionStore.putTxInfoToBatch(info);
             }
 

--- a/modAionImpl/src/org/aion/zero/impl/db/DBUtils.java
+++ b/modAionImpl/src/org/aion/zero/impl/db/DBUtils.java
@@ -14,6 +14,7 @@ import org.aion.log.LogLevel;
 import org.aion.mcf.blockchain.Block;
 import org.aion.zero.impl.config.CfgDb;
 import org.aion.base.AccountState;
+import org.aion.util.types.ByteArrayWrapper;
 import org.aion.zero.impl.core.ImportResult;
 import org.aion.mcf.db.Repository;
 import org.aion.mcf.db.RepositoryCache;
@@ -702,16 +703,16 @@ public class DBUtils {
         AionBlockchainImpl blockchain = new AionBlockchainImpl(cfg, false);
 
         try {
-            List<AionTxInfo> txInfoList = blockchain.getTransactionStore().getTxInfo(txHash);
+            Map<ByteArrayWrapper, AionTxInfo> txInfoList = blockchain.getTransactionStore().getTxInfo(txHash);
 
             if (txInfoList == null || txInfoList.isEmpty()) {
                 System.out.println("Can not find the transaction with given hash.");
                 return Status.FAILURE;
             }
 
-            for (AionTxInfo info : txInfoList) {
+            for (Map.Entry<ByteArrayWrapper, AionTxInfo> entry : txInfoList.entrySet()) {
 
-                Block block = blockchain.getBlockStore().getBlockByHash(info.getBlockHash());
+                Block block = blockchain.getBlockStore().getBlockByHash(entry.getKey().toBytes());
                 if (block == null) {
                     System.out.println(
                             "Can not find the block data with given block hash of the transaction info.");
@@ -720,7 +721,7 @@ public class DBUtils {
                     return Status.FAILURE;
                 }
 
-                AionTransaction tx = block.getTransactionsList().get(info.getIndex());
+                AionTransaction tx = block.getTransactionsList().get(entry.getValue().getIndex());
 
                 if (tx == null) {
                     System.out.println("Can not find the transaction data with given hash.");
@@ -730,7 +731,7 @@ public class DBUtils {
                 }
 
                 System.out.println(tx.toString());
-                System.out.println(info.toString());
+                System.out.println(entry.getValue());
                 System.out.println();
             }
 

--- a/modAionImpl/src/org/aion/zero/impl/types/AionTxInfo.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionTxInfo.java
@@ -25,7 +25,7 @@ public class AionTxInfo {
 
     // note that the receipt is modified to set the transaction
     private final AionTxReceipt receipt;
-    private final ByteArrayWrapper blockHash;
+    public final ByteArrayWrapper blockHash;
     private final int index;
     private final List<InternalTransaction> internalTransactions;
     private final boolean createdWithInternalTransactions;

--- a/modAionImpl/src/org/aion/zero/impl/types/AionTxInfo.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionTxInfo.java
@@ -15,6 +15,7 @@ import org.aion.types.InternalTransaction;
 import org.aion.types.InternalTransaction.RejectedStatus;
 import org.aion.util.conversions.Hex;
 import org.aion.base.AionTxReceipt;
+import org.aion.util.types.ByteArrayWrapper;
 import org.slf4j.Logger;
 
 public class AionTxInfo {
@@ -24,13 +25,13 @@ public class AionTxInfo {
 
     // note that the receipt is modified to set the transaction
     private final AionTxReceipt receipt;
-    private final byte[] blockHash;
+    private final ByteArrayWrapper blockHash;
     private final int index;
     private final List<InternalTransaction> internalTransactions;
     private final boolean createdWithInternalTransactions;
 
     /** @implNote Instance creation should be done through the static factory methods. */
-    private AionTxInfo(AionTxReceipt receipt, byte[] blockHash, int index, List<InternalTransaction> internalTransactions, boolean createdWithInternalTransactions) {
+    private AionTxInfo(AionTxReceipt receipt, ByteArrayWrapper blockHash, int index, List<InternalTransaction> internalTransactions, boolean createdWithInternalTransactions) {
         this.receipt = receipt;
         this.blockHash = blockHash;
         this.index = index;
@@ -42,12 +43,12 @@ public class AionTxInfo {
      * Creates an instance with the base data: receipt, block hash and index. Does not stored
      * information regarding internal transactions.
      */
-    public static AionTxInfo newInstance(AionTxReceipt receipt, byte[] blockHash, int index) {
+    public static AionTxInfo newInstance(AionTxReceipt receipt, ByteArrayWrapper blockHash, int index) {
         return new AionTxInfo(receipt, blockHash, index, null, false);
     }
 
     /** Creates an instance with receipt, block hash, index and internal transactions. */
-    public static AionTxInfo newInstanceWithInternalTransactions(AionTxReceipt receipt, byte[] blockHash, int index, List<InternalTransaction> internalTransactions) {
+    public static AionTxInfo newInstanceWithInternalTransactions(AionTxReceipt receipt, ByteArrayWrapper blockHash, int index, List<InternalTransaction> internalTransactions) {
         return new AionTxInfo(receipt, blockHash, index, internalTransactions, true);
     }
 
@@ -89,7 +90,7 @@ public class AionTxInfo {
         RLPList txInfo = (RLPList) params.get(0);
 
         AionTxReceipt receipt = new AionTxReceipt(txInfo.get(INDEX_RECEIPT).getRLPData());
-        byte[] blockHash = txInfo.get(INDEX_BLOCK_HASH).getRLPData();
+        ByteArrayWrapper blockHash = ByteArrayWrapper.wrap(txInfo.get(INDEX_BLOCK_HASH).getRLPData());
 
         int index;
         RLPItem indexRLP = (RLPItem) txInfo.get(INDEX_TX_INDEX);
@@ -139,7 +140,7 @@ public class AionTxInfo {
     public byte[] getEncoded() {
 
         byte[] receiptRLP = this.receipt.toBytes();
-        byte[] blockHashRLP = RLP.encodeElement(blockHash);
+        byte[] blockHashRLP = RLP.encodeElement(blockHash.toBytes());
         byte[] indexRLP = RLP.encodeInt(index);
         byte[] completeRLP = RLP.encodeByte(createdWithInternalTransactions ? (byte) 1 : (byte) 0);
 
@@ -163,7 +164,7 @@ public class AionTxInfo {
     }
 
     public byte[] getBlockHash() {
-        return blockHash;
+        return blockHash.toBytes();
     }
 
     public int getIndex() {

--- a/modApiServer/test/org/aion/api/server/types/TxTest.java
+++ b/modApiServer/test/org/aion/api/server/types/TxTest.java
@@ -81,7 +81,7 @@ public class TxTest {
                         nrgLimit);
         byte[] hash = block.getHash();
 
-        JSONObject object = Tx.aionTxInfoToDetailsJSON(AionTxInfo.newInstance(txReceipt,hash,0), block);
+        JSONObject object = Tx.aionTxInfoToDetailsJSON(AionTxInfo.newInstance(txReceipt,block.getHashWrapper(),0), block);
         assertNotNull(object);
         assertEquals(ByteUtil.byteArrayToLong(txNonce), object.get("nonce"));
         assertEquals(StringUtils.toJsonHex(data), object.get("input"));
@@ -134,9 +134,8 @@ public class TxTest {
                 solution,
                 nrgConsumed,
                 nrgLimit);
-        byte[] hashWithLog = block.getHash();
 
-        JSONObject jsonWithLogs = Tx.aionTxInfoToDetailsJSON(AionTxInfo.newInstance(txReceiptWithLog, hashWithLog, 0), blockWithLog);
+        JSONObject jsonWithLogs = Tx.aionTxInfoToDetailsJSON(AionTxInfo.newInstance(txReceiptWithLog, blockWithLog.getHashWrapper(), 0), blockWithLog);
 
         assertNotNull(jsonWithLogs);
         List<Object> jsonArray = jsonWithLogs.getJSONArray("logs").toList();


### PR DESCRIPTION
## Description

- Using the wrapped block hash inside AionTxInfo;
- Changing the serialization to use sets instead of lists;
- Switched transaction storage to an overwrite policy:
   - the ability to overwrite previously-stored transaction information is necessary to apply config updates to store internal transactions or not to store them;
   - removed caching optimization: not particularly useful;
   - removed unused return value for putTxInfoToBatch method.

Completes task AKI-317.

## Type of change

Insert **x** into the following checkboxes to confirm (eg. [x]):
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.
