### PR TITLE
AKI-449: BlockchainTestUtils functionality to generate random Unity chains

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionBlockchainImpl.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionBlockchainImpl.java
@@ -130,7 +130,7 @@ public class AionBlockchainImpl implements IAionBlockchain {
     private final GreatGrandParentBlockHeaderValidator unityGreatGrandParentBlockHeaderValidator;
     private final ParentBlockHeaderValidator preUnityParentBlockHeaderValidator;
     private final ParentBlockHeaderValidator unityParentBlockHeaderValidator;
-    private final StakingContractHelper stakingContractHelper;
+    private StakingContractHelper stakingContractHelper = null;
     public final ForkUtility forkUtility;
     public final BeaconHashValidator beaconHashValidator;
 
@@ -248,13 +248,6 @@ public class AionBlockchainImpl implements IAionBlockchain {
 
         // initialize beacon hash validator
         this.beaconHashValidator = new BeaconHashValidator(this, this.forkUtility);
-
-        stakingContractHelper =
-            new StakingContractHelper(
-                forTest
-                    ? AddressUtils.ZERO_ADDRESS
-                    : CfgAion.inst().getGenesis().getStakingContractAddress(),
-                this);
     }
 
     /**
@@ -2546,6 +2539,9 @@ public class AionBlockchainImpl implements IAionBlockchain {
     }
 
     public StakingContractHelper getStakingContractHelper() {
+        if (stakingContractHelper == null) {
+            stakingContractHelper = new StakingContractHelper(CfgAion.inst().getGenesis().getStakingContractAddress(), this);
+        }
         return stakingContractHelper;
     }
 

--- a/modAionImpl/src/org/aion/zero/impl/types/AionGenesis.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AionGenesis.java
@@ -1,5 +1,6 @@
 package org.aion.zero.impl.types;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -172,7 +173,8 @@ public class AionGenesis extends AionBlock {
         this.networkBalances = networkBalances;
     }
 
-    private void setStakingContractAddress(AionAddress address) {
+    @VisibleForTesting
+    public void setStakingContractAddress(AionAddress address) {
         stakingContractAddress = address;
     }
 

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainTestUtils.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainTestUtils.java
@@ -7,17 +7,24 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import org.aion.avm.stub.IAvmResourceFactory;
+import org.aion.avm.stub.IContractFactory.AvmContract;
 import org.aion.base.AionTransaction;
 import org.aion.base.TransactionTypes;
+import org.aion.base.TxUtil;
 import org.aion.crypto.ECKey;
 import org.aion.crypto.ECKeyFac;
 import org.aion.crypto.HashUtil;
 import org.aion.mcf.blockchain.Block;
-import org.aion.zero.impl.core.ImportResult;
+import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
 import org.aion.types.AionAddress;
+import org.aion.zero.impl.core.ImportResult;
 import org.aion.zero.impl.db.AionRepositoryImpl;
 import org.aion.zero.impl.types.A0BlockHeader;
 import org.aion.zero.impl.types.AionBlock;
+import org.aion.zero.impl.types.StakingBlock;
+import org.aion.zero.impl.types.StakingBlockHeader;
+import org.aion.zero.impl.vm.TestResourceProvider;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -29,7 +36,7 @@ public class BlockchainTestUtils {
     private static final Random rand = new Random();
     private static final byte[] ZERO_BYTE = new byte[0];
     private static final long NRG = 21000L;
-    private static final long NRG_PRICE = 1L;
+    private static final long NRG_PRICE = 10_123_456_789L;
 
     public static List<ECKey> generateAccounts(int size) {
         List<ECKey> accs = new ArrayList<>();
@@ -205,6 +212,194 @@ public class BlockchainTestUtils {
 
         A0BlockHeader newBlockHeader = A0BlockHeader.Builder.newInstance().withHeader(block.getHeader()).withExtraData(extraData).build();
         block.updateHeader(newBlockHeader);
+
+        ImportResult result = chain.tryToConnectInternal(block, (time + 10));
+
+        System.out.format(
+                "Created block with hash: %s, number: %6d, extra data: %6s, txs: %3d, import status: %20s %n",
+                block.getShortHash(),
+                block.getNumber(),
+                new String(block.getExtraData()),
+                block.getTransactionsList().size(),
+                result.toString());
+
+        return Pair.of(block, result);
+    }
+
+    /**
+     * Generates a random chain with alternating mining and staking blocks after the unity fork is reached.
+     * The staking registry contract is deployed in the block before the fork.
+     * Stakers are registered in the Unity fork block.
+     *
+     * @param chain blockchain implementation to be populated
+     * @param resourceProvider provides the implementations of the two AVMs; <b>must have both enabled</b>
+     * @param blocks number of blocks to be added to the chain
+     * @param frequency every multiple of frequency block will be on the main chain
+     * @param accounts existing accounts with balance on the chain used to generate random transactions; <b>will be used as stakers after the Unity fork</b>
+     * @param stakingRegistryOwner existing account with balance; <b>will be used to deploy the StakerRegistry contract</b>
+     * @param txCount maximum number of transactions per block
+     */
+    public static void generateRandomUnityChain(StandaloneBlockchain chain, TestResourceProvider resourceProvider, long blocks, int frequency, List<ECKey> accounts, ECKey stakingRegistryOwner, int txCount) {
+        long seed = rand.nextLong();
+        rand.setSeed(seed);
+        System.out.println("Random seed used: " + seed);
+
+        // ensure the stakingRegistryOwner is not among the stakers
+        List<ECKey> stakers = new ArrayList<>(accounts);
+        stakers.remove(stakingRegistryOwner);
+
+        if (stakingRegistryOwner == null || stakers == null || stakers.isEmpty()) {
+            throw new IllegalStateException("Please provide the accounts required to build a Unity chain.");
+        }
+
+        Block parent, block, mainChain;
+        mainChain = chain.getGenesis();
+
+        List<Block> knownBlocks = new ArrayList<>();
+        knownBlocks.add(mainChain);
+
+        List<AionTransaction> txs;
+        AionRepositoryImpl repo = chain.getRepository();
+
+        long time = System.currentTimeMillis();
+        for (int i = 0; i < blocks; i++) {
+            // ensuring that we add to the main chain at least every MAIN_CHAIN_FREQUENCY block
+            if (i % frequency == 0) {
+                // the parent will be the main chain
+                parent = mainChain;
+            } else {
+                // decide if to keep the node among potential parents
+                if (rand.nextBoolean()) {
+                    // the parent is a random already imported block
+                    parent = knownBlocks.get(rand.nextInt(knownBlocks.size()));
+                } else {
+                    // randomly remove some parent nodes
+                    parent = knownBlocks.remove(rand.nextInt(knownBlocks.size()));
+                }
+            }
+            long nextBlockNumber = parent.getNumber() + 1;
+
+            // generate transactions for correct root
+            byte[] originalRoot = repo.getRoot();
+            repo.syncToRoot(parent.getStateRoot());
+            // ensure that staking is possible after the fork block
+            if (chain.forkUtility.isUnityForkBlock(nextBlockNumber + 1)) {
+                // deploy staking contract
+                AionTransaction tx = deployStakingContract(resourceProvider.factoryForVersion1, stakingRegistryOwner, repo.getNonce(new AionAddress(stakingRegistryOwner.getAddress())));
+                txs = List.of(tx);
+
+                // set the staking contract address in the staking genesis
+                AionAddress contract = TxUtil.calculateContractAddress(tx.getSenderAddress().toByteArray(), tx.getNonceBI());
+                chain.getGenesis().setStakingContractAddress(contract);
+            } else if (chain.forkUtility.isUnityForkBlock(nextBlockNumber)) {
+                // set the staking contract address in the staking genesis
+                AionAddress contract = chain.getGenesis().getStakingContractAddress();
+                txs = new ArrayList<>();
+
+                for (ECKey key : stakers) {
+                    // register stakers
+                    txs.add(registerStaker(resourceProvider.factoryForVersion1, key, repo.getNonce(new AionAddress(key.getAddress())), contract));
+                }
+            } else {
+                txs = generateTransactions(txCount, accounts, repo);
+            }
+            // get back to current root
+            repo.syncToRoot(originalRoot);
+
+            if (chain.forkUtility.isUnityForkActive(nextBlockNumber)) {
+                // create and import post-unity block
+                Pair<Block, ImportResult> importPair;
+
+                if (parent.getHeader().getSealType() == BlockSealType.SEAL_POS_BLOCK) {
+                    importPair = addMiningBlock(chain, parent, txs, time, String.valueOf(i).getBytes());
+                } else {
+                    // get the parent seed
+                    byte[] parentSeed = chain.forkUtility.isUnityForkBlock(parent.getNumber())
+                            ? StakingBlockHeader.GENESIS_SEED
+                            : ((StakingBlock) chain.getBlockByHash(parent.getParentHash())).getSeed();
+                    importPair = addStakingBlock(chain, parentSeed, txs, time, stakers.get(rand.nextInt(stakers.size())));
+                }
+
+                if (importPair != null) {
+                    time += 10;
+                    block = importPair.getLeft();
+                    knownBlocks.add(block);
+                    if (importPair.getRight() == ImportResult.IMPORTED_BEST) {
+                        mainChain = block;
+                    }
+                }
+            } else {
+                // create and import pre-unity block
+                Pair<Block, ImportResult> importPair= addMiningBlock(chain, parent, txs, time, String.valueOf(i).getBytes());
+                time += 10;
+                block = importPair.getLeft();
+                knownBlocks.add(block);
+                if (importPair.getRight() == ImportResult.IMPORTED_BEST) {
+                    mainChain = block;
+                }
+            }
+        }
+    }
+
+    private static AionTransaction deployStakingContract(IAvmResourceFactory avmFactory, ECKey owner, BigInteger nonce) {
+        byte[] jar = avmFactory.newContractFactory().getDeploymentBytes(AvmContract.UNITY_STAKER_REGISTRY);
+        return AionTransaction.create(
+                owner,
+                nonce.toByteArray(),
+                null,
+                new byte[0],
+                jar,
+                5_000_000L,
+                NRG_PRICE,
+                TransactionTypes.AVM_CREATE_CODE,
+                null);
+    }
+
+    private static AionTransaction registerStaker(
+            IAvmResourceFactory avmFactory, ECKey caller, BigInteger nonce, AionAddress contract) {
+        AionAddress callerAddress = new AionAddress(caller.getAddress());
+        byte[] callBytes =
+                avmFactory
+                        .newStreamingEncoder()
+                        .encodeOneString("registerStaker")
+                        .encodeOneAddress(callerAddress) // staker address
+                        .encodeOneAddress(callerAddress) // signing address
+                        .encodeOneAddress(callerAddress) // coinbase address
+                        .getEncoding();
+        return AionTransaction.create(
+                caller,
+                nonce.toByteArray(),
+                contract,
+                MIN_SELF_STAKE.toByteArray(),
+                callBytes,
+                2_000_000L,
+                NRG_PRICE,
+                TransactionTypes.DEFAULT,
+                null);
+    }
+
+    private static final BigInteger MIN_SELF_STAKE = new BigInteger("1000000000000000000000");
+
+    private static Pair<Block, ImportResult> addStakingBlock(
+            StandaloneBlockchain chain,
+            byte[] parentSeed,
+            List<AionTransaction> txs,
+            long time,
+            ECKey key) {
+        byte[] newSeed = key.sign(parentSeed).getSignature();
+        StakingBlock block =
+                chain.createStakingBlockTemplate(
+                        txs,
+                        key.getPubKey(),
+                        newSeed,
+                        new AionAddress(key.getAddress()).toByteArray());
+
+        if (block == null) {
+            return null;
+        }
+
+        byte[] mineHashSig = key.sign(block.getHeader().getMineHash()).getSignature();
+        block.seal(mineHashSig, key.getPubKey());
 
         ImportResult result = chain.tryToConnectInternal(block, (time + 10));
 


### PR DESCRIPTION
<!--Notice: Please submit your PR to the `master` branch and rebase your code on `master` before opening the pull request.-->

## Description

<!--Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.-->

- Extracted common block creation and import into a separate method:
   - number of blocks given as long;
   - printing seed used at the start of the random chain generation;
   - creating chains with blocks without transactions is limited to pre-unity blocks since accounts are required for deploying the staking contract;
- Allowing the staking contract address and helper to be set for testing.
- AKI-449: BlockchainTestUtils can generate random Unity chains.

## Type of change

<!--Insert **x** into the following checkboxes to confirm (eg. [x]):-->
- [ ] Bug fix.
- [ ] New feature.
- [x] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

<!--Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.-->

- Verified that chain generation works correctly with different parameters.

