### PR TITLE
Avm is initialized in a single place

### DIFF
--- a/modBoot/src/org/aion/Aion.java
+++ b/modBoot/src/org/aion/Aion.java
@@ -408,7 +408,9 @@ public class Aion {
         } catch (IOException e) {
             // Nothing to handle here, we are shutting down...
         } finally{
-            AvmProvider.releaseLock();
+            if (AvmProvider.holdsLock()) {
+                AvmProvider.releaseLock();
+            }
         }
     }
 


### PR DESCRIPTION
- We had a problem where the avm was being initialized in multiple places
  for different CLI arguments, and was even not being initialized at times
  it should be. This change fixes these issues by initializing the avm in
  a single place that all CLI variations have to pass through.
- This change also fixes AKI-457 by checking that the thread owns the avm
  lock before calling release on it first.

<!--Notice: Please submit your PR to the `master` branch and rebase your code on `master` before opening the pull request.-->

## Description

<!--Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.-->

-

Fixes Issue # .

## Type of change

<!--Insert **x** into the following checkboxes to confirm (eg. [x]):-->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

<!--Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.-->

-

