### PR TITLE
Ignore some benchmark tests or the concreted class tests

### DIFF
--- a/modAionImpl/test/org/aion/equihash/EquihashSolutionsGenerationTest210_9.java
+++ b/modAionImpl/test/org/aion/equihash/EquihashSolutionsGenerationTest210_9.java
@@ -385,6 +385,6 @@ public class EquihashSolutionsGenerationTest210_9 {
     }
 
     public static Object blocks() {
-        return TestResources.blocks(10);
+        return TestResources.blocks(3);
     }
 }

--- a/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainAccountStateBenchmark.java
+++ b/modAionImpl/test/org/aion/zero/impl/blockchain/BlockchainAccountStateBenchmark.java
@@ -37,6 +37,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
+@Ignore
+// TODO: AKI-480 Ignore the test because time consuming, should move to benchmark test
 public class BlockchainAccountStateBenchmark {
 
     private Random random = new SecureRandom();

--- a/modAionImpl/test/org/aion/zero/impl/core/energy/TargettedEnergyLimitStrategyTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/core/energy/TargettedEnergyLimitStrategyTest.java
@@ -12,6 +12,7 @@ import org.aion.zero.impl.valid.EnergyLimitRule;
 import org.aion.zero.impl.types.A0BlockHeader;
 import org.aion.zero.impl.valid.RuleError;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -147,6 +148,8 @@ public class TargettedEnergyLimitStrategyTest {
     // given the targetted energy limit strategy, should always converge to our
     // desired limit
     @Test
+    // TODO: AKI-480 Ignore the test because time consuming, should move to benchmark test
+    @Ignore
     public void testConvergence() {
         AbstractEnergyStrategyLimit strategy =
                 new TargetStrategy(

--- a/modApiServer/test/org/aion/api/server/account/AccountManagerTest.java
+++ b/modApiServer/test/org/aion/api/server/account/AccountManagerTest.java
@@ -23,8 +23,11 @@ import org.aion.util.types.AddressUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
+// TODO: AKI-480 Ignore the test because time consuming, also it is pretty concrete class. Will move to the other test task
 public class AccountManagerTest {
     private static AccountManager accountManager = AccountManager.inst();
     private AionAddress notRegistered =

--- a/modTxPool/build.gradle
+++ b/modTxPool/build.gradle
@@ -6,6 +6,7 @@ clean.dependsOn deleteNativeLibs
 dependencies {
     compile project(':modBase')
     compile files("${rootProject.projectDir}/lib/aion-types-22a3be9.jar")
+    compile 'com.google.guava:guava:25.1-jre'
     
     testCompile 'junit:junit:4.12'
 }

--- a/modTxPool/src/module-info.java
+++ b/modTxPool/src/module-info.java
@@ -4,6 +4,7 @@ module aion.txpool {
     requires aion.util;
     requires aion.log;
     requires slf4j.api;
+    requires com.google.common;
 
     exports org.aion.txpool;
 }

--- a/modTxPool/test/org/aion/txpool/TxnPoolTest.java
+++ b/modTxPool/test/org/aion/txpool/TxnPoolTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import org.aion.base.AionTransaction;
 import org.aion.base.PooledTransaction;
 import org.aion.base.TransactionTypes;
@@ -279,32 +280,28 @@ public class TxnPoolTest {
     }
 
     @Test
-    public void timeout1() throws Exception {
+    public void timeout1() {
         Properties config = new Properties();
         config.put("tx-timeout", "10"); // 10 sec
 
-        ITxPool tp = new TxPoolA0(config);
+        TxPoolA0 tp = new TxPoolA0(config);
         List<PooledTransaction> txnl = getMockTransaction(30000L);
         tp.add(txnl);
 
-        Thread.sleep(10999);
-
-        tp.snapshot();
+        tp.snapshot( TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 10);
         Assert.assertEquals(0, tp.size());
     }
 
     @Test
-    public void timeout2() throws Exception {
+    public void timeout2() {
         Properties config = new Properties();
-        config.put("tx-timeout", "1"); // 10 sec
+        config.put("tx-timeout", "1"); // still 10 sec
 
-        ITxPool tp = new TxPoolA0(config);
+        TxPoolA0 tp = new TxPoolA0(config);
         List<PooledTransaction> txnl = getMockTransaction(30000L);
         tp.add(txnl);
 
-        Thread.sleep(8999);
-
-        tp.snapshot();
+        tp.snapshot(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 9);
         Assert.assertEquals(1, tp.size());
     }
 
@@ -988,7 +985,8 @@ public class TxnPoolTest {
     }
 
     @Test
-    // @Ignore
+    @Ignore
+    // TODO: AKI-480 move it to the benchmark test
     /* 100K new transactions in pool around 1200ms (cold-call)
      */ public void benchmarkSnapshot() {
         Properties config = new Properties();
@@ -1033,6 +1031,8 @@ public class TxnPoolTest {
     }
 
     @Test
+    @Ignore
+    // TODO: AKI-480 move it to the benchmark test
     /* 100K new transactions in pool around 650ms (cold-call)
 
       1K new transactions insert to the pool later around 150ms to snap (including sort)
@@ -1107,6 +1107,7 @@ public class TxnPoolTest {
 
     @Test
     @Ignore
+    // TODO: AKI-480 move it to the benchmark test
     /* 1M new transactions with 10000 accounts (100 txs per account)in pool snapshot around 10s (cold-call)
       gen new txns 55s (spent a lot of time to sign tx)
       put txns into pool 2.5s
@@ -1162,6 +1163,8 @@ public class TxnPoolTest {
     }
 
     @Test
+    @Ignore
+    // TODO: AKI-480 move it to the benchmark test
     /* 100K new transactions in pool around 350ms (cold-call)
      */ public void benchmarkSnapshot4() {
         Properties config = new Properties();
@@ -1227,6 +1230,8 @@ public class TxnPoolTest {
     }
 
     @Test
+    @Ignore
+    // TODO: AKI-480 move it to the benchmark test
     /* 100K new transactions in pool around 350ms (cold-call)
 
       the second time snapshot is around 35ms


### PR DESCRIPTION
Ignore some benchmark tests, refactoring test cases and the concreted class tests. Reduced 4.5 mins in the CI unit testing. 