### PR TITLE
AKI-509: Bugfix for block encoding/decoding inconsistency:

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/types/AbstractBlock.java
+++ b/modAionImpl/src/org/aion/zero/impl/types/AbstractBlock.java
@@ -35,8 +35,6 @@ public abstract class AbstractBlock implements Block {
 
     public abstract String getShortDescr();
 
-    abstract void parseRLP();
-
     /**
      * check if param block is son of this block
      *
@@ -59,7 +57,6 @@ public abstract class AbstractBlock implements Block {
     }
 
     List<byte[]> getBodyElements() {
-        parseRLP();
         byte[] transactions = getTransactionsEncoded();
         List<byte[]> body = new ArrayList<>();
         body.add(transactions);


### PR DESCRIPTION
 
<!--Notice: Please submit your PR to the `master` branch and rebase your code on `master` before opening the pull request.-->

## Description

<!--Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.-->

- The bug: the seal method in StakingBlock was not updating the encoding with the sealer signature. - The fix: removed the lazy initialization of the encoding to avoid similar issues caused by other updates. 
- Unit tests for both staking and mining blocks to verify that generated blocks decode correctly.

## Type of change

<!--Insert **x** into the following checkboxes to confirm (eg. [x]):-->
- [x] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

