### PR TITLE
Unit tests for encode/decode staking & mining blocks

### DIFF
--- a/modAionImpl/test/org/aion/zero/impl/types/BlockEncodeTest.java
+++ b/modAionImpl/test/org/aion/zero/impl/types/BlockEncodeTest.java
@@ -1,0 +1,170 @@
+package org.aion.zero.impl.types;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.aion.zero.impl.blockchain.BlockchainTestUtils.generateAccounts;
+import static org.aion.zero.impl.types.A0BlockHeader.NONCE_LENGTH;
+import static org.aion.zero.impl.types.A0BlockHeader.SOLUTIONSIZE;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import org.aion.base.TransactionTypeRule;
+import org.aion.crypto.ECKey;
+import org.aion.mcf.blockchain.Block;
+import org.aion.mcf.blockchain.BlockHeader.BlockSealType;
+import org.aion.zero.impl.blockchain.BlockchainTestUtils;
+import org.aion.zero.impl.blockchain.StandaloneBlockchain;
+import org.aion.zero.impl.vm.AvmPathManager;
+import org.aion.zero.impl.vm.AvmTestConfig;
+import org.aion.zero.impl.vm.TestResourceProvider;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Ensures that the encoding for generate blocks matches the decoding.
+ *
+ * @author Alexandra Roatis
+ */
+public class BlockEncodeTest {
+
+    private static TestResourceProvider resourceProvider;
+    private StandaloneBlockchain blockchain;
+    private ECKey deployerKey;
+    private List<ECKey> accounts;
+
+    @BeforeClass
+    public static void setupAvm() throws Exception {
+        resourceProvider = TestResourceProvider.initializeAndCreateNewProvider(AvmPathManager.getPathOfProjectRootDirectory());
+        AvmTestConfig.supportBothAvmVersions(0, 2, 0);
+    }
+
+    @AfterClass
+    public static void tearDownAvm() throws Exception {
+        AvmTestConfig.clearConfigurations();
+        resourceProvider.close();
+    }
+
+    @Before
+    public void setup() {
+        accounts = generateAccounts(10);
+        StandaloneBlockchain.Bundle bundle =
+                new StandaloneBlockchain.Builder()
+                        .withDefaultAccounts(accounts)
+                        .withValidatorConfiguration("simple")
+                        .withAvmEnabled()
+                        .build();
+
+        this.blockchain = bundle.bc;
+        this.deployerKey = bundle.privateKeys.get(0);
+        TransactionTypeRule.allowAVMContractTransaction();
+    }
+
+    @After
+    public void tearDown() {
+        this.blockchain = null;
+        this.deployerKey = null;
+    }
+
+    @Test
+    public void generateFirstStakeBlockAndCheckEncoding() {
+        long unityForkNumber = 2L;
+        blockchain.forkUtility.enableUnityFork(unityForkNumber);
+        List<ECKey> txAccounts = new ArrayList<>(accounts);
+        txAccounts.remove(deployerKey);
+
+        // populating the chain to be above the Unity fork point
+        BlockchainTestUtils.generateRandomUnityChain(blockchain, resourceProvider, unityForkNumber + 1, 1, accounts, deployerKey, 60);
+
+        // get the top block from the generated chain
+        StakingBlock stakingBlock = (StakingBlock) blockchain.getBestBlock();
+        assertThat(stakingBlock.getHeader().getSealType()).isEqualTo(BlockSealType.SEAL_POS_BLOCK);
+
+        // used to check the encode/decode correctness
+        StakingBlock decodedBlock = (StakingBlock) BlockUtil.newBlockFromRlp(stakingBlock.getEncoded());
+        assertThat(decodedBlock).isNotNull();
+
+        // verify header equality
+        StakingBlockHeader expected = stakingBlock.getHeader();
+        StakingBlockHeader actual = decodedBlock.getHeader();
+        assertThat(actual.getHash()).isEqualTo(expected.getHash());
+        assertThat(actual.getParentHash()).isEqualTo(expected.getParentHash());
+        assertThat(actual.getNumber()).isEqualTo(expected.getNumber());
+        assertThat(actual.getSeed()).isEqualTo(expected.getSeed());
+        assertThat(actual.getSignature()).isEqualTo(expected.getSignature());
+        assertThat(actual.getSigningPublicKey()).isEqualTo(expected.getSigningPublicKey());
+        assertThat(actual.getExtraData()).isEqualTo(expected.getExtraData());
+        assertThat(actual.getDifficulty()).isEqualTo(expected.getDifficulty());
+        assertThat(actual.getDifficultyBI()).isEqualTo(expected.getDifficultyBI());
+        assertThat(actual.getTimestamp()).isEqualTo(expected.getTimestamp());
+        assertThat(actual.getEnergyConsumed()).isEqualTo(expected.getEnergyConsumed());
+        assertThat(actual.getEnergyLimit()).isEqualTo(expected.getEnergyLimit());
+        assertThat(actual.getMineHash()).isEqualTo(expected.getMineHash());
+        assertThat(actual.getCoinbase()).isEqualTo(expected.getCoinbase());
+        assertThat(actual.getStateRoot()).isEqualTo(expected.getStateRoot());
+        assertThat(actual.getTxTrieRoot()).isEqualTo(expected.getTxTrieRoot());
+        assertThat(actual.getReceiptsRoot()).isEqualTo(expected.getReceiptsRoot());
+        assertThat(actual.getSealType()).isEqualTo(expected.getSealType());
+        assertThat(actual.getLogsBloom()).isEqualTo(expected.getLogsBloom());
+        assertThat(actual.getEncoded()).isEqualTo(expected.getEncoded());
+
+        // verify body
+        assertThat(decodedBlock.getTransactionsList()).isEqualTo(stakingBlock.getTransactionsList());
+    }
+
+    @Test
+    public void generateFirstMiningBlockAfterUnityAndCheckEncoding() {
+        long unityForkNumber = 2L;
+        blockchain.forkUtility.enableUnityFork(unityForkNumber);
+        List<ECKey> txAccounts = new ArrayList<>(accounts);
+        txAccounts.remove(deployerKey);
+
+        // populating the chain to be above the Unity fork point
+        BlockchainTestUtils.generateRandomUnityChain(blockchain, resourceProvider, unityForkNumber + 2, 1, accounts, deployerKey, 60);
+
+        // get the top block from the generated chain
+        AionBlock miningBlock = (AionBlock) blockchain.getBestBlock();
+        assertThat(miningBlock.getHeader().getSealType()).isEqualTo(BlockSealType.SEAL_POW_BLOCK);
+
+        byte[] solution = new byte[SOLUTIONSIZE];
+        solution[0] = (byte) 6;
+        byte[] nonce = new byte[NONCE_LENGTH];
+        nonce[0] = (byte) 6;
+        // updating the block with a non-empty solution
+        // since the testing setup does not add the nonce and solution to the block
+        miningBlock.seal(nonce, solution);
+
+        // used to check the encode/decode correctness
+        AionBlock decodedBlock = (AionBlock) BlockUtil.newBlockFromRlp(miningBlock.getEncoded());
+        assertThat(decodedBlock).isNotNull();
+
+        // verify header equality
+        A0BlockHeader expected = miningBlock.getHeader();
+        A0BlockHeader actual = decodedBlock.getHeader();
+        assertThat(actual.getHash()).isEqualTo(expected.getHash());
+        assertThat(actual.getParentHash()).isEqualTo(expected.getParentHash());
+        assertThat(actual.getNumber()).isEqualTo(expected.getNumber());
+        assertThat(actual.getNonce()).isEqualTo(expected.getNonce());
+        assertThat(actual.getSolution()).isEqualTo(expected.getSolution());
+        assertThat(actual.getPowBoundaryBI()).isEqualTo(expected.getPowBoundaryBI());
+        assertThat(actual.getExtraData()).isEqualTo(expected.getExtraData());
+        assertThat(actual.getDifficulty()).isEqualTo(expected.getDifficulty());
+        assertThat(actual.getDifficultyBI()).isEqualTo(expected.getDifficultyBI());
+        assertThat(actual.getTimestamp()).isEqualTo(expected.getTimestamp());
+        assertThat(actual.getEnergyConsumed()).isEqualTo(expected.getEnergyConsumed());
+        assertThat(actual.getEnergyLimit()).isEqualTo(expected.getEnergyLimit());
+        assertThat(actual.getMineHash()).isEqualTo(expected.getMineHash());
+        assertThat(actual.getCoinbase()).isEqualTo(expected.getCoinbase());
+        assertThat(actual.getStateRoot()).isEqualTo(expected.getStateRoot());
+        assertThat(actual.getTxTrieRoot()).isEqualTo(expected.getTxTrieRoot());
+        assertThat(actual.getReceiptsRoot()).isEqualTo(expected.getReceiptsRoot());
+        assertThat(actual.getSealType()).isEqualTo(expected.getSealType());
+        assertThat(actual.getLogsBloom()).isEqualTo(expected.getLogsBloom());
+        assertThat(actual.getEncoded()).isEqualTo(expected.getEncoded());
+
+        // verify body
+        assertThat(decodedBlock.getTransactionsList()).isEqualTo(miningBlock.getTransactionsList());
+    }
+}


### PR DESCRIPTION


<!--Notice: Please submit your PR to the `master` branch and rebase your code on `master` before opening the pull request.-->

## Description

<!--Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.-->

 - verifies that generated blocks encode/decode correctly by checking every
 meaningful getter after creating a block from an encoding;
 - note: checking the block equality using the current equals implementation
 would miss the errors in encoding.

## Type of change

<!--Insert **x** into the following checkboxes to confirm (eg. [x]):-->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [x] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.
