### PR TITLE
AKI-516: Quickly return null when asked to create impossible block te…

### DIFF
--- a/modAionImpl/src/org/aion/zero/impl/blockchain/AionHub.java
+++ b/modAionImpl/src/org/aion/zero/impl/blockchain/AionHub.java
@@ -20,6 +20,7 @@ import org.aion.log.AionLoggerFactory;
 import org.aion.log.LogEnum;
 import org.aion.log.LogUtil;
 import org.aion.mcf.blockchain.Block;
+import org.aion.mcf.blockchain.BlockHeader;
 import org.aion.zero.impl.SystemExitCodes;
 import org.aion.zero.impl.Version;
 import org.aion.zero.impl.config.CfgNetP2p;
@@ -590,47 +591,57 @@ public class AionHub {
 
     // Returns a new template if a better parent block to mine on is found, or if the system time
     // is ahead of the oldBlockTemplate
+    // Returns null if we're waiting on a Staking block, or if creating a new block template failed for some reason
     public BlockContext getNewMiningBlockTemplate(BlockContext oldBlockTemplate, long systemTime) {
+        if (blockchain.isUnityForkEnabledAtNextBlock() &&
+                blockchain.getBestBlock().getHeader().getSealType() == BlockHeader.BlockSealType.SEAL_POW_BLOCK) {
+            return null;
+        } else {
+            BlockContext context = null;
+            
+            blockTemplateLock.lock();
+            try {
+                Block bestBlock = mempool.getBestBlock();
+                byte[] bestBlockHash = bestBlock.getHash();
 
-        BlockContext context = null;
+                if (oldBlockTemplate == null
+                        || !Arrays.equals(bestBlockHash, oldBlockTemplate.block.getParentHash())) {
 
-        blockTemplateLock.lock();
-        try {
-            Block bestBlock = mempool.getBestBlock();
-            byte[] bestBlockHash = bestBlock.getHash();
+                    // Generate new block template
+                    AionPendingStateImpl.TransactionSortedSet ret =
+                            new AionPendingStateImpl.TransactionSortedSet();
+                    ret.addAll(mempool.getPendingTransactions());
 
-            if (oldBlockTemplate == null
-                    || !Arrays.equals(bestBlockHash, oldBlockTemplate.block.getParentHash())) {
-
-                // Generate new block template
-                AionPendingStateImpl.TransactionSortedSet ret =
-                        new AionPendingStateImpl.TransactionSortedSet();
-                ret.addAll(mempool.getPendingTransactions());
-
-                context =
-                        blockchain.createNewMiningBlockContext(
-                                bestBlock, new ArrayList<>(ret), false);
-            } else if (systemTime > oldBlockTemplate.block.getTimestamp() && blockchain.isUnityForkEnabledAtNextBlock()) {
-                context = blockchain.updateMiningBlockContext(oldBlockTemplate, systemTime);
+                    context =
+                            blockchain.createNewMiningBlockContext(
+                                    bestBlock, new ArrayList<>(ret), false);
+                } else if (systemTime > oldBlockTemplate.block.getTimestamp() && blockchain.isUnityForkEnabledAtNextBlock()) {
+                    context = blockchain.updateMiningBlockContext(oldBlockTemplate, systemTime);
+                }
+            } finally {
+                blockTemplateLock.unlock();
             }
-        } finally {
-            blockTemplateLock.unlock();
-        }
 
-        return null == context ? oldBlockTemplate : context;
+            return context;
+        }
     }
-
+    
+    // Returns null if we're waiting on a Mining block, or if creating a new block template failed for some reason
     public StakingBlock getStakingBlockTemplate(byte[] newSeed, byte[] signingPublicKey, byte[] coinbase) {
-        StakingBlock blockTemplate;
-        blockTemplateLock.lock();
-        try {
-            blockTemplate = (StakingBlock) blockchain.createStakingBlockTemplate(
-                    mempool.getPendingTransactions(), signingPublicKey, newSeed, coinbase);
-        } finally {
-            blockTemplateLock.unlock();
-        }
+        if (blockchain.getBestBlock().getHeader().getSealType() == BlockHeader.BlockSealType.SEAL_POS_BLOCK) {
+            return null;
+        } else {
+            StakingBlock blockTemplate;
+            blockTemplateLock.lock();
+            try {
+                blockTemplate = blockchain.createStakingBlockTemplate(
+                        mempool.getPendingTransactions(), signingPublicKey, newSeed, coinbase);
+            } finally {
+                blockTemplateLock.unlock();
+            }
 
-        return blockTemplate;
+            return blockTemplate;
+        }
     }
 
     public void enableUnityFork(long unityForkNumber) {

--- a/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
+++ b/modApiServer/src/org/aion/api/server/rpc/ApiWeb3Aion.java
@@ -2511,8 +2511,16 @@ public class ApiWeb3Aion extends ApiAion {
         BlockContext bestBlock;
         try {
             bestBlock = getBlockTemplate();
+            if (bestBlock == null) {
+                LOG.debug("Couldn't create a mining block template");
+                
+                JSONObject obj = new JSONObject();
+                obj.put("message", "no mining block template ");
+                obj.put("code", -1);
+                return new RpcMsg(obj);
+            }
         } catch (Exception e) {
-            LOG.error("get block template failed!", e);
+            LOG.error("get mining block template failed!", e);
 
             JSONObject obj = new JSONObject();
             obj.put("message", "failed: " + e.toString());


### PR DESCRIPTION
…mplates

- This prevents users from seeing many messages like "Tried to create 2 PoS blocks in a row!"
- It also reduces unnecessary work

<!--Notice: Please submit your PR to the `master` branch and rebase your code on `master` before opening the pull request.-->

## Description

<!--Please include a brief summary of the change that this pull request proposes. Include any relevant motivation and context. List any dependencies required for this change.-->

-

Fixes Issue # .

## Type of change

<!--Insert **x** into the following checkboxes to confirm (eg. [x]):-->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Enhancement.
- [ ] Unit test.
- [ ] Breaking change (a fix or feature that causes existing functionality to not work as expected).
- [ ] Requires documentation update.

## Testing

<!--Please describe the tests you used to validate this pull request. Provide any relevant details for test configurations as well as any instructions to reproduce these results.-->

-

